### PR TITLE
Add OOM fuzzing mode (phase 1): set_nomemory sweeps over functions

### DIFF
--- a/doc/oom-fuzzing.md
+++ b/doc/oom-fuzzing.md
@@ -1,0 +1,168 @@
+# OOM (Out-Of-Memory) Fuzzing in Fusil
+
+This document describes the design and phased plan for fusil's OOM-injection
+fuzzing mode, which fails memory allocations to drive code down its rarely-tested
+allocation-failure error paths and surface crashes (segfaults / aborts) caused by
+unchecked allocations.
+
+The technique is adapted from the `cext-review-toolkit` reproducer catalog
+(Techniques 18, 23, 27, 31). The key adaptation for fusil: the toolkit runs each
+sweep iteration in its own subprocess because it wants to *classify every
+allocation offset*; fusil only wants to *find a crash*, and the generated
+`source.py` is already a disposable child process whose crash is exactly the
+signal fusil watches for. So **no per-iteration subprocess isolation is needed**.
+
+## How it fits fusil's model
+
+- **Crash detection is signal-based.** `WatchProcess.computeScore`
+  (`fusil/process/watch.py`) returns `signal_score = 1.0` for any process killed
+  by a signal (SIGSEGV/SIGABRT). The OOM-injected `source.py` crashing *is* the
+  success signal.
+- **Calls are centralized.** All calls route through the generated
+  `callMethod` / `callFunc` helpers, and `jit_harness` already establishes the
+  "run target in a loop" idiom. An OOM sweep is the same shape:
+  `for start in range(N): set_nomemory(start, 0); target()`.
+
+## Phases
+
+- **Phase 1 (this doc, implemented first):** `_testcapi.set_nomemory` injection,
+  **module-level functions only**, no refactor.
+- **Phase 2:** extract a single call-emission seam
+  (`_emit_call(target, name, args, harness=...)`) so the OOM/plain/JIT paths
+  share one primitive, then extend OOM coverage to methods, constructors, and
+  returned objects (where the high-value unchecked-allocation bugs live).
+- **Phase 3:** libfiu / `LD_PRELOAD` system-malloc injection (reaches foreign C
+  libraries that `set_nomemory` cannot), driven via the child process env.
+
+---
+
+## Phase 1 specification
+
+Every change is gated behind `options.oom_fuzz` so non-OOM generation is
+byte-for-byte unchanged.
+
+### 1. CLI options (`fusil/python/__init__.py`, `createFuzzerOptions`)
+
+A new `OOM Fuzzing` option group:
+
+| Option | Type | Default | Meaning |
+|--------|------|---------|---------|
+| `--oom-fuzz` | bool | `False` | Enable OOM mode. |
+| `--oom-max-start` | int | `1000` | Dense sweep upper bound (exclusive): each call sweeps `range(0, N)`. |
+| `--oom-calls` | int | `10` | Number of OOM-wrapped function calls per script (replaces `--functions-number` in OOM mode, bounding `oom_calls × oom_max_start` total iterations). |
+
+Options thread automatically via `self.options` → `PythonSource` →
+`WritePythonCode.options`.
+
+### 2. Generated-script changes (`write_python_code.py`)
+
+**Boilerplate** (in `_write_script_header_and_imports`, gated):
+
+```python
+import faulthandler
+faulthandler.enable()          # C traceback on SIGSEGV, before any arming
+try:
+    from _testcapi import set_nomemory as _set_nomemory, remove_mem_hooks as _remove_mem_hooks
+    _OOM_AVAILABLE = True
+except ImportError:
+    _OOM_AVAILABLE = False
+    print("OOM mode requested but _testcapi.set_nomemory unavailable; running without injection", file=stderr)
+```
+
+**Harness** (in `_write_helper_call_functions`, gated):
+
+```python
+_OOM_MAX_START = <oom_max_start>
+
+def oom_call(func, *args, **kwargs):
+    # Dense OOM sweep. MemoryError is the expected outcome; a segfault/abort
+    # terminates the process (the signal fusil scores as success). remove_mem_hooks
+    # runs in the inner finally so the except clause allocates safely.
+    if not _OOM_AVAILABLE:
+        return
+    for _start in range(_OOM_MAX_START):
+        _set_nomemory(_start, 0)
+        try:
+            try:
+                func(*args, **kwargs)
+            finally:
+                _remove_mem_hooks()
+        except MemoryError:
+            pass
+        except BaseException as _err:
+            print(type(_err).__name__, file=stderr)
+```
+
+**Call sites** (new `_generate_oom_function_call`, reusing
+`_write_arguments_for_call_lines` and `get_arg_number`):
+
+```python
+# OOM sweep: <func_name>
+oom_call(getattr(fuzz_target_module, "<func_name>"),
+    <arg lines>,
+)
+```
+
+Arguments are built **once** at the `oom_call(...)` expression (outside the sweep
+loop); arming happens inside `oom_call` after the args exist.
+
+### 3. Wiring (`_write_main_fuzzing_logic`)
+
+Branch the function loop and bound it by `--oom-calls`; gate the class and object
+fuzzing blocks with `if not self.options.oom_fuzz:` so Phase 1 emits only function
+sweeps.
+
+### 4. Detection config (`fusil/python/__init__.py`, `setupProject`)
+
+```python
+stdout.kill_words = {"mimalloc"} if self.options.oom_fuzz else {"MemoryError", "mimalloc"}
+```
+
+With `MemoryError` out of `kill_words` it matches none of the scoring words, so it
+neither kills nor scores. The harness's `print(type(_err).__name__)` surfaces other
+exceptions; of single-token exception names only `SystemError` collides with a
+scoring word (intended — catches PyCFunction contract violations). Real crashes
+score via `WatchProcess` signal handling, independent of stdout.
+
+## Behavioral decisions
+
+- **Silent harness** (no per-iteration prints) — avoids log floods,
+  `FileWatch.max_process_time` stalls, and accidental word matches.
+- **Surface non-MemoryError exceptions** so `SystemError` etc. are still caught.
+- **`remove_mem_hooks` in the inner `finally`** so the `except` clause runs with
+  the allocator restored.
+- **Dense, from 0** — sparse sweeps miss one-allocation-wide crash windows;
+  deeper-budget coverage accumulates across sessions.
+- **`_testcapi` self-guarded** — mode no-ops with a notice if the target
+  interpreter lacks it.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Session timeout from long sweeps | `oom_calls × oom_max_start` bounded; timeouts non-scoring unless `--record-timeouts`. |
+| `_testcapi` missing | Self-guarded import → no-op with notice. |
+| Output volume / log stalls | Silent harness except surfaced exception types. |
+| False-positive scoring | Exception-name prints don't match scoring words except intended `SystemError`. |
+| First crash ends that script's sweep | By design — crash = the find; coverage accumulates across sessions. |
+
+## Acceptance criteria
+
+1. `--oom-fuzz` produces a script with guarded `_testcapi` import,
+   `faulthandler.enable()`, an `oom_call` dense-sweep harness, and `oom_calls`
+   function-call sweep sites.
+2. Non-OOM generation is unchanged.
+3. Benign module: runs to completion, MemoryError neither kills nor scores.
+4. A segfault/abort in any swept call is scored 1.0 by existing `WatchProcess`.
+
+## Usage
+
+```bash
+# Inspect generated output only:
+PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe --oom-fuzz \
+    --modules json --sessions 1 --oom-calls 5 --oom-max-start 200 --only-generate
+
+# Run for real on a benign module:
+PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe --oom-fuzz \
+    --modules json --sessions 3 --oom-calls 5 --oom-max-start 200
+```

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -329,6 +329,30 @@ class Fuzzer(Application):
             default=True,
         )
 
+        oom_options = OptionGroupWithSections(parser, "OOM Fuzzing")
+        oom_options.add_option(
+            "--oom-fuzz",
+            help="Enable OOM (out-of-memory) injection: wrap calls in dense "
+                 "_testcapi.set_nomemory sweeps to drive allocation-failure error "
+                 "paths and find crashes (default: False)",
+            action="store_true",
+            default=False,
+        )
+        oom_options.add_option(
+            "--oom-max-start",
+            help="Dense OOM sweep upper bound (exclusive): each call sweeps "
+                 "range(0, N) (default: 1000)",
+            type="int",
+            default=1000,
+        )
+        oom_options.add_option(
+            "--oom-calls",
+            help="Number of OOM-wrapped function calls to generate per script "
+                 "(replaces --functions-number in OOM mode, default: 10)",
+            type="int",
+            default=10,
+        )
+
         config_options = OptionGroupWithSections(parser, "Configuration")
         config_options.add_option(
             "--write-config",
@@ -350,7 +374,7 @@ class Fuzzer(Application):
             default=False,
         )
 
-        options = input_options, running_options, fuzzing_options, jit_options, config_options
+        options = input_options, running_options, fuzzing_options, jit_options, oom_options, config_options
         for option in options:
             parser.add_option_group(option)
 
@@ -409,7 +433,12 @@ class Fuzzer(Application):
             "AddressSanitizer": 1.0,
         }
 
-        stdout.kill_words = {"MemoryError", "mimalloc"}
+        # In OOM mode, MemoryError is the expected (boring) outcome of injection,
+        # so it must not abort the session; real crashes still score via signal.
+        if self.options.oom_fuzz:
+            stdout.kill_words = {"mimalloc"}
+        else:
+            stdout.kill_words = {"MemoryError", "mimalloc"}
 
         # CPython critical messages
         stdout.addRegex("^XXX undetected error", 1.0)

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -319,6 +319,19 @@ class WritePythonCode(WriteCode):
         )
         self.emptyLine()
 
+        if self.options.oom_fuzz:
+            self.write_block(0, '''
+                import faulthandler
+                faulthandler.enable()
+                try:
+                    from _testcapi import set_nomemory as _set_nomemory, remove_mem_hooks as _remove_mem_hooks
+                    _OOM_AVAILABLE = True
+                except ImportError:
+                    _OOM_AVAILABLE = False
+                    print("OOM mode requested but _testcapi.set_nomemory unavailable; running without injection", file=stderr)
+            ''')
+            self.emptyLine()
+
     def _write_tricky_definitions(self) -> None:
         """Writes definitions for 'tricky' classes and objects."""
         self.write(0, fusil.python.tricky_weird.weird_classes)
@@ -502,6 +515,32 @@ class WritePythonCode(WriteCode):
         )
         self.emptyLine()
 
+        if self.options.oom_fuzz:
+            self.write_block(0, f'''
+                _OOM_MAX_START = {self.options.oom_max_start}
+
+                def oom_call(func, *args, **kwargs):
+                    # Dense OOM sweep: fail every allocation from #_start onward, one
+                    # _start per iteration. MemoryError is the expected outcome; a real
+                    # crash (segfault/abort) terminates the process, which is exactly the
+                    # signal fusil watches for. remove_mem_hooks runs in the inner finally
+                    # so the except clause allocates with the allocator restored.
+                    if not _OOM_AVAILABLE:
+                        return
+                    for _start in range(_OOM_MAX_START):
+                        _set_nomemory(_start, 0)
+                        try:
+                            try:
+                                func(*args, **kwargs)
+                            finally:
+                                _remove_mem_hooks()
+                        except MemoryError:
+                            pass
+                        except BaseException as _err:
+                            print(type(_err).__name__, file=stderr)
+            ''')
+            self.emptyLine()
+
     def _write_main_fuzzing_logic(self) -> None:
         """Writes the core fuzzing loops for functions, classes, and objects."""
         self.write(0, f"fuzz_target_module = {self.module_name}")
@@ -530,11 +569,24 @@ class WritePythonCode(WriteCode):
                 0,
                 f'"--- Fuzzing {len(self.module_functions)} functions in {self.module_name} ---"',
             )
-            for i in range(self.options.functions_number):
+            n_calls = (
+                self.options.oom_calls
+                if self.options.oom_fuzz
+                else self.options.functions_number
+            )
+            for i in range(n_calls):
                 prefix = f"f{i + 1}"
 
                 # --- SIMPLIFIED LOGIC ---
-                if self.options.jit_fuzz:
+                if self.options.oom_fuzz:
+                    # OOM injection: wrap a function call in a dense set_nomemory sweep
+                    func_name = choice(self.module_functions)
+                    try:
+                        func_obj = getattr(self.module, func_name)
+                    except AttributeError:
+                        continue
+                    self._generate_oom_function_call(prefix, func_name, func_obj)
+                elif self.options.jit_fuzz:
                     self.jit_writer.generate_scenario(prefix)
                 else:
                     # Standard (non-JIT) function call fuzzing
@@ -554,6 +606,10 @@ class WritePythonCode(WriteCode):
                     )
 
         self.emptyLine()
+
+        # Phase 1 OOM mode targets module-level functions only.
+        if self.options.oom_fuzz:
+            return
 
         # Fuzz classes (instantiate and call methods)
         if self.module_classes:
@@ -953,6 +1009,18 @@ class WritePythonCode(WriteCode):
                     arg_line_part + (last_char if arg_line_part == arg_lines[-1] else ""),
                 )
 
+
+    def _generate_oom_function_call(
+        self, prefix: str, func_name: str, func_obj: Callable[..., Any]
+    ) -> None:
+        """Emits a module-level function call wrapped in a dense OOM sweep."""
+        min_arg, max_arg = get_arg_number(func_obj, func_name, 1)
+        num_args = randint(min_arg, max_arg)
+        self.write(0, f"# OOM sweep: {func_name}")
+        self.write(0, f'oom_call(getattr(fuzz_target_module, "{func_name}"),')
+        self._write_arguments_for_call_lines(num_args, 1)
+        self.write(0, ")")
+        self.emptyLine()
 
     def _generate_and_write_call(
         self,

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -1,0 +1,118 @@
+"""Tests for OOM (out-of-memory) fuzzing mode code generation (Phase 1).
+
+These verify that ``--oom-fuzz`` makes ``WritePythonCode`` emit the set_nomemory
+boilerplate, the ``oom_call`` dense-sweep harness, and per-function sweep sites,
+and that none of that appears when the mode is off (gating / regression).
+
+The fixture builds a ``MagicMock`` options object with the few real-typed
+attributes the generator needs; it does not depend on the (currently stale)
+``test_write_python_code`` fixture.
+"""
+
+import ast
+import math
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.join(SCRIPT_DIR, "..", "..")
+sys.path.insert(0, PROJECT_ROOT)
+
+from fusil.python.write_python_code import WritePythonCode
+
+OOM_MAX_START = 50
+OOM_CALLS = 3
+
+
+def _make_options(oom_fuzz):
+    """Build an options stand-in with the attributes generation reads."""
+    o = MagicMock()
+    # OOM mode
+    o.oom_fuzz = oom_fuzz
+    o.oom_max_start = OOM_MAX_START
+    o.oom_calls = OOM_CALLS
+    # General generation knobs
+    o.fuzz_exceptions = False
+    o.test_private = False
+    o.no_numpy = True
+    o.no_tstrings = True
+    o.functions_number = 5
+    o.classes_number = 0
+    o.objects_number = 0
+    o.methods_number = 2
+    # JIT options (WriteJITCode is constructed unconditionally); OOM mode never
+    # dispatches to it, so legacy defaults are fine.
+    o.jit_fuzz = False
+    o.jit_external_references = True
+    o.jit_mode = "legacy"
+    o.jit_correctness_testing = False
+    o.jit_loop_iterations = 100
+    o.jit_hostile_prob = 0.1
+    o.jit_fuzz_classes = False
+    o.jit_fuzz_ast_mutation = False
+    o.jit_wrap_statements = False
+    o.jit_pattern_name = "ALL"
+    return o
+
+
+def _generate(oom_fuzz):
+    """Generate a fuzzing script against the ``math`` module and return its source."""
+    parent = MagicMock()
+    parent.options = _make_options(oom_fuzz)
+    parent.filenames = ["/bin/sh"]
+    fd, path = tempfile.mkstemp(suffix="_oom_test.py")
+    os.close(fd)
+    try:
+        writer = WritePythonCode(
+            parent, path, math, "math",
+            threads=False, _async=False, plugin_manager=None,
+        )
+        writer.generate_fuzzing_script()
+        with open(path) as fp:
+            return fp.read()
+    finally:
+        os.unlink(path)
+
+
+class TestOOMFuzzGeneration(unittest.TestCase):
+    def test_oom_mode_emits_harness_and_sweeps(self):
+        src = _generate(oom_fuzz=True)
+
+        # Generated script must be valid Python.
+        ast.parse(src)
+
+        # Guarded _testcapi boilerplate + faulthandler.
+        self.assertIn("faulthandler.enable()", src)
+        self.assertIn("from _testcapi import set_nomemory", src)
+        self.assertIn("_OOM_AVAILABLE", src)
+
+        # The dense-sweep harness, parameterised by --oom-max-start.
+        self.assertIn("def oom_call(", src)
+        self.assertIn(f"_OOM_MAX_START = {OOM_MAX_START}", src)
+        self.assertIn("range(_OOM_MAX_START)", src)
+        self.assertIn("_remove_mem_hooks()", src)
+        # MemoryError swallowed silently; other exceptions surfaced.
+        self.assertIn("except MemoryError:", src)
+
+        # One sweep site per --oom-calls.
+        self.assertEqual(src.count("oom_call(getattr(fuzz_target_module,"), OOM_CALLS)
+
+    def test_non_oom_mode_has_no_oom_artifacts(self):
+        src = _generate(oom_fuzz=False)
+
+        ast.parse(src)
+        for marker in (
+            "oom_call",
+            "set_nomemory",
+            "_OOM_AVAILABLE",
+            "_OOM_MAX_START",
+            "remove_mem_hooks",
+        ):
+            self.assertNotIn(marker, src, f"unexpected OOM artifact {marker!r} in non-OOM script")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #60

## Summary

Adds an `--oom-fuzz` mode that wraps generated calls in dense `_testcapi.set_nomemory` sweeps to drive allocation-failure error paths and surface crashes from unchecked allocations. Phase 1 covers **module-level functions only**. All generated OOM code is gated behind `options.oom_fuzz`, so non-OOM output is byte-for-byte unchanged.

## How it works

- **Boilerplate** (gated): guarded `from _testcapi import set_nomemory, remove_mem_hooks` + `faulthandler.enable()`.
- **Harness** (`oom_call`): for each call, densely sweeps `set_nomemory(start, 0)` over `range(0, --oom-max-start)`. `remove_mem_hooks` runs in an inner `finally` so the `except` clause allocates with the allocator restored. `MemoryError` is swallowed silently; other exception types are printed so the stdout matcher still catches e.g. `SystemError`. A real crash (segfault/abort) terminates the process — exactly the signal `WatchProcess` scores as success.
- **Call sites**: `--oom-calls` function sweeps, with arguments built once outside the sweep loop.
- **No subprocess isolation**: the generated `source.py` is already a disposable child, so the first crash ending it is the find; coverage accumulates across sessions.
- **Detection**: in OOM mode `MemoryError` is dropped from stdout `kill_words` so injection doesn't abort the session; crashes still score via signal.

## Options

`--oom-fuzz`, `--oom-max-start` (default 1000), `--oom-calls` (default 10).

## Verification

- **Generated script** (`--only-generate` on `math`): correct boilerplate, harness sweeping `range(50)`, 3 sweep sites, valid AST.
- **Executed** on benign `math`: clean exit, `MemoryError` swallowed, other exceptions surfaced, no crash.
- **Real fusil session** (no `--only-generate`): sessions complete, `Total: 0 success` — no false-positive scoring, no MemoryError-kill.
- **Regression**: non-OOM generation has zero OOM artifacts and parses.
- **Tests**: `tests/python/test_oom_fuzz.py` (2/2 pass — artifacts + valid AST + one site per `--oom-calls`; gating when off). No new full-suite failures (pre-existing errors are unrelated: stale `jit_external_references` fixture, missing numpy, `ast_mutator`→lafleur).

## Docs

`doc/oom-fuzzing.md` — design rationale and the phase 1/2/3 roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)