### PR TITLE
OOM mode: per-call markers to pinpoint which invocation crashed

### DIFF
--- a/doc/oom-fuzzing.md
+++ b/doc/oom-fuzzing.md
@@ -50,6 +50,7 @@ A new `OOM Fuzzing` option group:
 | `--oom-fuzz` | bool | `False` | Enable OOM mode. |
 | `--oom-max-start` | int | `1000` | Dense sweep upper bound (exclusive): each call sweeps `range(0, N)`. |
 | `--oom-calls` | int | `10` | Number of OOM-wrapped function calls per script (replaces `--functions-number` in OOM mode, bounding `oom_calls × oom_max_start` total iterations). |
+| `--oom-verbose` | bool | `False` | Also print the sweep `start` index before each injection, so the exact failing allocation can be pinpointed on replay (verbose; ~`oom_max_start` lines per call). |
 
 Options thread automatically via `self.options` → `PythonSource` →
 `WritePythonCode.options`.
@@ -73,14 +74,22 @@ except ImportError:
 
 ```python
 _OOM_MAX_START = <oom_max_start>
+_OOM_VERBOSE = <oom_verbose>
 
-def oom_call(func, *args, **kwargs):
-    # Dense OOM sweep. MemoryError is the expected outcome; a segfault/abort
-    # terminates the process (the signal fusil scores as success). remove_mem_hooks
-    # runs in the inner finally so the except clause allocates safely.
+def oom_call(label, func, *args, **kwargs):
+    # Dense OOM sweep. The per-call marker (printed once, before the sweep)
+    # identifies which invocation was running if a crash follows -- more reliable
+    # than the faulthandler frame, which is often an incidental allocation rather
+    # than the fuzzed target. MemoryError is swallowed silently; SystemError is
+    # surfaced (PyCFunction contract violations); a segfault/abort terminates the
+    # process (the signal fusil scores). remove_mem_hooks runs in the inner finally
+    # so the except clauses allocate safely.
     if not _OOM_AVAILABLE:
         return
+    print("[OOM] " + label, file=stderr)
     for _start in range(_OOM_MAX_START):
+        if _OOM_VERBOSE:
+            print("[OOM]   start=" + str(_start), file=stderr)
         _set_nomemory(_start, 0)
         try:
             try:
@@ -89,8 +98,10 @@ def oom_call(func, *args, **kwargs):
                 _remove_mem_hooks()
         except MemoryError:
             pass
-        except BaseException as _err:
-            print(type(_err).__name__, file=stderr)
+        except SystemError:
+            print("[OOM] SystemError in " + label, file=stderr)
+        except BaseException:
+            pass
 ```
 
 **Call sites** (new `_generate_oom_function_call`, reusing
@@ -98,13 +109,23 @@ def oom_call(func, *args, **kwargs):
 
 ```python
 # OOM sweep: <func_name>
-oom_call(getattr(fuzz_target_module, "<func_name>"),
+oom_call("<prefix>:<module>.<func_name>", getattr(fuzz_target_module, "<func_name>"),
     <arg lines>,
 )
 ```
 
 Arguments are built **once** at the `oom_call(...)` expression (outside the sweep
 loop); arming happens inside `oom_call` after the args exist.
+
+### Pinpointing which call crashed
+
+faulthandler's top Python frame is frequently an *incidental* allocation (GC /
+finalization / warnings firing as the budget runs out), not the fuzzed target —
+so it is unreliable for attribution. The **last `[OOM] <prefix>:<module>.<func>`
+marker** printed before the crash dump identifies the culprit invocation. With
+`--oom-verbose`, the immediately preceding `[OOM]   start=N` line gives the exact
+allocation offset, which is enough to write a minimal reproducer. Marker prefixes
+(`[OOM]`) are chosen to avoid the stdout scorer's words.
 
 ### 3. Wiring (`_write_main_fuzzing_logic`)
 

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -352,6 +352,14 @@ class Fuzzer(Application):
             type="int",
             default=10,
         )
+        oom_options.add_option(
+            "--oom-verbose",
+            help="In OOM mode, also print the sweep start index before each "
+                 "injection so the exact failing allocation can be pinpointed on "
+                 "replay (verbose output; default: False)",
+            action="store_true",
+            default=False,
+        )
 
         config_options = OptionGroupWithSections(parser, "Configuration")
         config_options.add_option(

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -518,16 +518,25 @@ class WritePythonCode(WriteCode):
         if self.options.oom_fuzz:
             self.write_block(0, f'''
                 _OOM_MAX_START = {self.options.oom_max_start}
+                _OOM_VERBOSE = {bool(self.options.oom_verbose)}
 
-                def oom_call(func, *args, **kwargs):
+                def oom_call(label, func, *args, **kwargs):
                     # Dense OOM sweep: fail every allocation from #_start onward, one
-                    # _start per iteration. MemoryError is the expected outcome; a real
-                    # crash (segfault/abort) terminates the process, which is exactly the
-                    # signal fusil watches for. remove_mem_hooks runs in the inner finally
-                    # so the except clause allocates with the allocator restored.
+                    # _start per iteration. The per-call marker (printed once, before the
+                    # sweep) identifies which invocation was running if a crash follows --
+                    # more reliable than the faulthandler frame, which is often an
+                    # incidental allocation rather than the fuzzed target. MemoryError is
+                    # the expected outcome and is swallowed silently; SystemError is
+                    # surfaced (PyCFunction contract violations); a real crash
+                    # (segfault/abort) terminates the process, the signal fusil scores.
+                    # remove_mem_hooks runs in the inner finally so the except clauses
+                    # allocate with the allocator restored.
                     if not _OOM_AVAILABLE:
                         return
+                    print("[OOM] " + label, file=stderr)
                     for _start in range(_OOM_MAX_START):
+                        if _OOM_VERBOSE:
+                            print("[OOM]   start=" + str(_start), file=stderr)
                         _set_nomemory(_start, 0)
                         try:
                             try:
@@ -536,8 +545,10 @@ class WritePythonCode(WriteCode):
                                 _remove_mem_hooks()
                         except MemoryError:
                             pass
-                        except BaseException as _err:
-                            print(type(_err).__name__, file=stderr)
+                        except SystemError:
+                            print("[OOM] SystemError in " + label, file=stderr)
+                        except BaseException:
+                            pass
             ''')
             self.emptyLine()
 
@@ -1016,8 +1027,10 @@ class WritePythonCode(WriteCode):
         """Emits a module-level function call wrapped in a dense OOM sweep."""
         min_arg, max_arg = get_arg_number(func_obj, func_name, 1)
         num_args = randint(min_arg, max_arg)
+        # Per-call marker: the last one printed before a crash is the culprit call.
+        label = f"{prefix}:{self.module_name}.{func_name}"
         self.write(0, f"# OOM sweep: {func_name}")
-        self.write(0, f'oom_call(getattr(fuzz_target_module, "{func_name}"),')
+        self.write(0, f'oom_call("{label}", getattr(fuzz_target_module, "{func_name}"),')
         self._write_arguments_for_call_lines(num_args, 1)
         self.write(0, ")")
         self.emptyLine()

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -27,13 +27,14 @@ OOM_MAX_START = 50
 OOM_CALLS = 3
 
 
-def _make_options(oom_fuzz):
+def _make_options(oom_fuzz, oom_verbose=False):
     """Build an options stand-in with the attributes generation reads."""
     o = MagicMock()
     # OOM mode
     o.oom_fuzz = oom_fuzz
     o.oom_max_start = OOM_MAX_START
     o.oom_calls = OOM_CALLS
+    o.oom_verbose = oom_verbose
     # General generation knobs
     o.fuzz_exceptions = False
     o.test_private = False
@@ -58,10 +59,10 @@ def _make_options(oom_fuzz):
     return o
 
 
-def _generate(oom_fuzz):
+def _generate(oom_fuzz, oom_verbose=False):
     """Generate a fuzzing script against the ``math`` module and return its source."""
     parent = MagicMock()
-    parent.options = _make_options(oom_fuzz)
+    parent.options = _make_options(oom_fuzz, oom_verbose)
     parent.filenames = ["/bin/sh"]
     fd, path = tempfile.mkstemp(suffix="_oom_test.py")
     os.close(fd)
@@ -89,16 +90,31 @@ class TestOOMFuzzGeneration(unittest.TestCase):
         self.assertIn("from _testcapi import set_nomemory", src)
         self.assertIn("_OOM_AVAILABLE", src)
 
-        # The dense-sweep harness, parameterised by --oom-max-start.
-        self.assertIn("def oom_call(", src)
+        # The dense-sweep harness, parameterised by --oom-max-start, now takes a label.
+        self.assertIn("def oom_call(label, func", src)
         self.assertIn(f"_OOM_MAX_START = {OOM_MAX_START}", src)
         self.assertIn("range(_OOM_MAX_START)", src)
         self.assertIn("_remove_mem_hooks()", src)
-        # MemoryError swallowed silently; other exceptions surfaced.
-        self.assertIn("except MemoryError:", src)
 
-        # One sweep site per --oom-calls.
-        self.assertEqual(src.count("oom_call(getattr(fuzz_target_module,"), OOM_CALLS)
+        # Per-call marker (the pinpointing signal) and exception policy:
+        # MemoryError swallowed silently, SystemError surfaced.
+        self.assertIn('print("[OOM] " + label', src)
+        self.assertIn("except MemoryError:", src)
+        self.assertIn("except SystemError:", src)
+        # The old noisy "print every exception type" surfacing is gone.
+        self.assertNotIn("print(type(_err).__name__)", src)
+
+        # Verbose off by default.
+        self.assertIn("_OOM_VERBOSE = False", src)
+
+        # One labelled sweep site per --oom-calls.
+        self.assertEqual(src.count('oom_call("'), OOM_CALLS)
+
+    def test_verbose_emits_per_iteration_start(self):
+        src = _generate(oom_fuzz=True, oom_verbose=True)
+        ast.parse(src)
+        self.assertIn("_OOM_VERBOSE = True", src)
+        self.assertIn('print("[OOM]   start=" + str(_start)', src)
 
     def test_non_oom_mode_has_no_oom_artifacts(self):
         src = _generate(oom_fuzz=False)
@@ -109,6 +125,7 @@ class TestOOMFuzzGeneration(unittest.TestCase):
             "set_nomemory",
             "_OOM_AVAILABLE",
             "_OOM_MAX_START",
+            "_OOM_VERBOSE",
             "remove_mem_hooks",
         ):
             self.assertNotIn(marker, src, f"unexpected OOM artifact {marker!r} in non-OOM script")


### PR DESCRIPTION
Closes #62

## Summary

Makes OOM crashes attributable to a specific call. Phase 1's `oom_call` was silent; faulthandler's top Python frame is often an incidental allocation (GC/finalization/warnings firing as the budget runs out), not the fuzzed target — so there was no reliable locator. This adds a per-call marker and an opt-in exact-offset trace.

## Changes

- **Per-call marker**: `oom_call` now takes a label and prints `[OOM] <prefix>:<module>.<func>` once before the sweep. The last marker before a crash dump is the culprit invocation. ~`--oom-calls` lines per script; `[OOM]` prefix avoids the stdout scorer's words.
- **`--oom-verbose`**: also prints `[OOM]   start=N` before each injection (before arming → allocation-safe), giving the exact failing allocation offset for minimal repros.
- **Exception policy**: surface only `SystemError` (PyCFunction contract violations, which the stdout matcher scores); drop the per-exception type printing that flooded stdout with `TypeError`. `MemoryError` stays silent; real crashes still terminate the process.

## Verification

- Unit tests (`tests/python/test_oom_fuzz.py`, 3/3): labelled harness, marker print, `SystemError`-only surfacing, no stale `print(type(_err))`, one labelled site per `--oom-calls`, and verbose `start=` emission. No new full-suite failures (still 23 pre-existing, unrelated).
- End-to-end on `math`: default mode prints `[OOM] f1:math.degrees …` markers with **zero** `TypeError` noise; `--oom-verbose` interleaves `start=0..N` per call (precise pinpointing).

## Notes

- Marker text includes the target function name; in the unlikely event a module exposes a function whose name is itself a scorer word (e.g. `fatal`), the `[OOM]` line could contribute a small score. Low risk; can sanitise later if it ever bites.

Docs: `doc/oom-fuzzing.md` updated (options table + harness + a "Pinpointing which call crashed" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)