### PR TITLE
In-loop OOM crash dedupe engine + integration plan (Phase A core)

### DIFF
--- a/doc/oom-dedup-plan.md
+++ b/doc/oom-dedup-plan.md
@@ -1,0 +1,137 @@
+# In-loop OOM crash dedupe — integration plan
+
+Goal: let the OOM Python fuzzer dedupe crashes **as they happen**, against the
+`cpython-oom-findings` catalog, so it (a) self-labels each crash directory with its bug
+id and (b) optionally prunes known duplicates instead of writing thousands of them to
+disk. This complements — does not replace — the catalog's batch `ingest.py`: same
+snapshot, applied at the highest-leverage point (crash time, same binary).
+
+## Why in-loop (vs. only batch ingest)
+
+- **Same-binary site.** The crash is classified on the exact interpreter that produced
+  it — no re-run, no host↔local nondeterminism (the thing that cost us ~26 NOREPROs).
+- **No dup flood on disk.** Known-and-over-cap crashes never get persisted.
+- **Real-time signal.** "NEW site!" surfaces immediately, not in a later batch.
+
+The single-writer/read-only-snapshot design carries over: fuzzer instances only *read*
+`known_sites.tsv`; the catalog stays the lone writer. (See the catalog repo's
+`docs/DEDUP_PIPELINE.md`.)
+
+## What is landed now (Phase A core — tested)
+
+- **`fusil/python/oom_dedup.py`** — pure-Python, no python-ptrace dependency. Loads the
+  snapshot, classifies a crash from its stdout (tier-1: aborts + fatals carry an exact
+  `file:line: func(): Assertion …` / `Fatal Python error: <msg>`), matches the snapshot
+  (assert ▸ msg ▸ func ▸ line/near-12), and a `Deduper.decide(stdout) -> (keep, label)`
+  with per-bug seen/kept counters.
+- **`tests/python/test_oom_dedup.py`** — 14 unit tests (classification, every match
+  path, prune-over-cap, new/segv never pruned, prune-off keeps all). Runs in the dev
+  venv (no ptrace): `python -m unittest tests.python.test_oom_dedup`.
+
+Safety contract enforced by the engine: `keep=False` is returned **only** for a
+*confidently-known* bug already at its sample cap, and **only** when `prune=True`.
+New-site, segv (tier-1-unresolved), import, and clean outcomes are always kept.
+
+## Wiring to apply on a python-ptrace host (Phase A glue — needs a live run)
+
+These three edits are inert unless `--oom-dedup-catalog` is passed (off-path behaviour
+is byte-for-byte unchanged), so they can't regress existing runs; the *enabled* path
+should be smoke-tested on the fuzzing host before merge.
+
+### 1. CLI options — `fusil/python/__init__.py`, in `createFuzzerOptions` OOM group
+
+```python
+oom_options.add_option("--oom-dedup-catalog", type="str", default=None,
+    help="Path to known_sites.tsv; enables in-loop crash dedupe + dir labeling")
+oom_options.add_option("--oom-dedup-keep", type="int", default=5,
+    help="Keep at most N sample dirs per known bug (default: 5)")
+oom_options.add_option("--oom-dedup-prune", action="store_true", default=False,
+    help="Remove known-duplicate crash dirs beyond the keep cap (default: keep all)")
+```
+
+### 2. Install the keep-policy — `fusil/python/__init__.py`, end of `setupProject`
+
+```python
+if self.options.oom_dedup_catalog:
+    from fusil.python.oom_dedup import Deduper
+    self._deduper = Deduper(self.options.oom_dedup_catalog,
+                            keep=self.options.oom_dedup_keep,
+                            prune=self.options.oom_dedup_prune)
+    self.session_keep_policy = self._oom_keep_policy   # consulted by SessionDirectory
+```
+
+and on the `Fuzzer` class:
+
+```python
+def _oom_keep_policy(self, session):
+    """Synchronous (keep, label) decision for a crashed session, from its stdout."""
+    import os
+    try:
+        text = open(os.path.join(session.directory.directory, "stdout"),
+                    errors="replace").read()
+    except OSError:
+        return True, None
+    return self._deduper.decide(text)
+```
+
+Report the tally at shutdown (in `Fuzzer.exit`):
+
+```python
+if getattr(self, "_deduper", None):
+    self.error(self._deduper.report())
+```
+
+### 3. Consult the policy — `fusil/session_directory.py`, in `checkKeepDirectory`
+
+Replace the success branch:
+
+```python
+        if session.isSuccess():
+            policy = getattr(self.application(), "session_keep_policy", None)
+            if policy is not None:
+                keep, label = policy(session)
+                if label:
+                    self.on_session_rename(label)       # synchronous: labels the dir
+                if not keep:
+                    self.warning("Dedup: prune duplicate crash %s" % self.directory)
+                    return False
+            self.warning("Success: keep the directory %s" % self.directory)
+            return True
+```
+
+Why synchronous (a `keep_policy` callback) rather than reacting to `session_success`:
+the keep/rename decision happens in `SessionDirectory.deinit` → `checkKeepDirectory` →
+`keepDirectory` (which consumes `rename_parts`). Deciding here — where the stdout file
+is already complete — avoids racing the async `session_success`/`session_done` delivery
+against session teardown. `on_session_rename` is called synchronously so the label lands
+in `rename_parts` before `keepDirectory` renames the dir. The hook is generic (any
+`Application` may set `session_keep_policy`); the OOM fuzzer is just its first user.
+
+### Smoke test on the host
+
+```bash
+PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe --oom-fuzz \
+  --oom-dedup-catalog /path/to/cpython-oom-findings/catalog/known_sites.tsv \
+  --modules json,sqlite3 --sessions 200
+# expect: crash dirs named <module>-OOM-00NN / -oomNEW / -oomSEGV; the shutdown tally
+# prints seen/kept per bug. Add --oom-dedup-prune to drop known dups past the keep cap.
+```
+
+## Phase B (later)
+
+- **Segv resolution at crash time.** Tier-1 leaves segvs `unresolved` (always kept).
+  Resolve them on the same binary via the existing debugger/ptrace path (`replay.py`
+  already wires `ptrace_program='gdb.py'`, `allow_core_dump=True`; `process/debugger.py`
+  already emits rename parts), so segvs dedupe/prune too. This is the bigger fidelity win.
+- **Cross-instance merge.** N local instances each prune against their snapshot; a
+  periodic single-writer merge (catalog `ingest.py`) reconciles new-site collisions and
+  regenerates `known_sites.tsv`. Snapshot refresh: instances reload on SIGHUP or restart.
+- **Snapshot staleness.** Ship a `--oom-dedup-catalog` mtime check / periodic reload so
+  long-running instances pick up newly-cataloged bugs.
+
+## Contract
+
+`known_sites.tsv` is the interface between the catalog and the fuzzer:
+`<oom_id>\t<kind>\t<keytype>\t<key>` with keytype ∈ {func, line, assert, msg}. The
+classify/match logic here mirrors the catalog's `ingest.py`; if that format changes,
+update both. (Deliberate small duplication — the two live in separate repos.)

--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -1,0 +1,154 @@
+"""In-loop crash dedupe for the OOM Python fuzzer.
+
+Pure-Python and free of any runtime (python-ptrace) dependency, so it unit-tests in
+isolation. It loads the known-sites snapshot produced by the cpython-oom-findings
+catalog (``gen_known_sites.py`` -> ``known_sites.tsv``) and, given a crash's captured
+stdout, decides whether the crash is a *known* bug (and how many we've already kept) so
+the fuzzer can prune duplicates in-loop and self-label each crash directory.
+
+Tier-1 resolution only: aborts and fatals carry an exact ``file:line: func(): Assertion``
+/ ``Fatal Python error: <msg>`` in stdout and dedupe build-stably for free. Segvs have
+no reliable C site in stdout and are returned ``unresolved`` -- never pruned here; a
+later phase resolves them via the debugger. The snapshot file format is the contract
+shared with the catalog's ``ingest.py``.
+"""
+import re
+import collections
+
+# ---- stdout classification (mirrors catalog ingest.py tier-1) ----
+ASSERT = re.compile(r"([\w./+-]+\.(?:c|h)):(\d+):[^\n]*?\b(\w+)\s*\([^)]*\)\s*:\s*Assertion `([^']*)' failed")
+ASSERT2 = re.compile(r"([\w./+-]+\.(?:c|h)):(\d+):[^\n]*?Assertion `([^']*)' failed")
+FATAL = re.compile(r'Fatal Python error:\s*([^\n]+)')
+SEGV = re.compile(r'AddressSanitizer: SEGV|Fatal Python error: Segmentation fault|Segmentation fault')
+GENERIC_FATAL = ("_PyObject_AssertFailed", "_Py_NegativeRefcount")
+
+
+def _nf(f):
+    return f.lstrip("./")
+
+
+def classify(text):
+    """Classify a crash from its stdout. Returns a dict with ``kind`` in
+    {abort, fatal, segv, import, clean} plus any resolved file/line/func/assert/msg."""
+    m = ASSERT.search(text) or ASSERT2.search(text)
+    if m:
+        g = m.groups()
+        f, ln, func, expr = g if len(g) == 4 else (g[0], g[1], None, g[2])
+        return dict(kind="abort", file=_nf(f), line=int(ln), func=func,
+                    assert_expr=expr.strip(), fatal_msg=None)
+    fa = FATAL.search(text)
+    if fa and not SEGV.search(text):
+        msg = fa.group(1).strip()
+        if msg.startswith(GENERIC_FATAL):       # carries no site -> treat like segv
+            return dict(kind="segv", file=None, line=None, func=None,
+                        assert_expr=None, fatal_msg=None)
+        return dict(kind="fatal", file=None, line=None, func=None,
+                    assert_expr=None, fatal_msg=msg[:60])
+    if SEGV.search(text):
+        return dict(kind="segv", file=None, line=None, func=None,
+                    assert_expr=None, fatal_msg=None)
+    if re.search(r'(ModuleNotFoundError|ImportError):', text):
+        return dict(kind="import")
+    return dict(kind="clean")
+
+
+# ---- snapshot loading + matching (mirrors catalog ingest.py) ----
+def load_snapshot(lines):
+    """Load ``known_sites.tsv`` rows (an iterable of lines) into matcher tables."""
+    by_func, by_assert, by_line = {}, {}, {}
+    per_file_lines = collections.defaultdict(list)
+    by_msg, kind_of = [], {}
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            continue
+        oid, kind, kt, key = parts
+        kind_of[oid] = kind
+        if kt == "func":
+            by_func.setdefault(key, set()).add(oid)
+        elif kt == "assert":
+            by_assert.setdefault(key, set()).add(oid)
+        elif kt == "msg":
+            by_msg.append((key, oid))
+        elif kt == "line":
+            f, ln = key.rsplit(":", 1)
+            by_line.setdefault((f, int(ln)), set()).add(oid)
+            per_file_lines[f].append((int(ln), oid))
+    return dict(func=by_func, assert_=by_assert, line=by_line,
+                fl=per_file_lines, msg=by_msg, kind=kind_of)
+
+
+def load_snapshot_file(path):
+    with open(path) as fh:
+        return load_snapshot(fh)
+
+
+def match(c, snap):
+    """Return (oom_ids:set, how:str). Empty set + 'NEW' if unmatched."""
+    if c.get("assert_expr") and c.get("file"):
+        hit = snap["assert_"].get("%s:%s" % (c["file"], c["assert_expr"]))
+        if hit:
+            return hit, "assert"
+    if c.get("fatal_msg"):
+        hit = set(o for k, o in snap["msg"]
+                  if c["fatal_msg"].startswith(k) or k.startswith(c["fatal_msg"][:30]))
+        if hit:
+            return hit, "msg"
+    if c.get("file") and c.get("func"):
+        hit = snap["func"].get("%s:%s" % (c["file"], c["func"]))
+        if hit:
+            return hit, "func"
+    if c.get("file") and c.get("line"):
+        hit = snap["line"].get((c["file"], c["line"]))
+        if hit:
+            return hit, "line"
+        for ln, oid in snap["fl"].get(c["file"], ()):
+            if abs(ln - c["line"]) <= 12:
+                return {oid}, "near"
+    return set(), "NEW"
+
+
+class Deduper:
+    """Stateful in-loop deduper: feed each crash's stdout, get a (keep, label) decision.
+
+    keep=False is only ever returned for a *confidently-known* bug already at its sample
+    cap, and only when ``prune`` is enabled -- new/unresolved/segv crashes are always kept.
+    """
+    def __init__(self, snapshot_path, keep=5, prune=False):
+        self.snap = load_snapshot_file(snapshot_path)
+        self.keep_cap = keep
+        self.prune = prune
+        self.seen = collections.Counter()   # bug/new-key -> total crashes seen
+        self.kept = collections.Counter()   # bug -> directories kept
+
+    def decide(self, stdout_text):
+        """Return (keep: bool, label: str) for one crash."""
+        c = classify(stdout_text)
+        kind = c.get("kind")
+        if kind in ("clean", "import"):
+            return True, "oom" + (kind or "")
+        if kind == "segv":
+            self.seen["segv:unresolved"] += 1
+            return True, "oomSEGV"           # tier-1 can't resolve -> always keep
+        ids, how = match(c, self.snap)
+        if not ids:
+            key = (c.get("assert_expr") and "%s:%s" % (c["file"], c["assert_expr"])) \
+                  or (c.get("func") and "%s:%s" % (c["file"], c["func"])) \
+                  or c.get("fatal_msg") or "?"
+            self.seen["NEW:" + key] += 1
+            return True, "oomNEW"            # never prune a candidate-new site
+        oid = sorted(ids)[0]
+        self.seen[oid] += 1
+        if self.prune and self.kept[oid] >= self.keep_cap:
+            return False, oid                # known + over cap -> prune duplicate
+        self.kept[oid] += 1
+        return True, oid
+
+    def report(self):
+        lines = ["OOM dedupe summary (seen / kept):"]
+        for key, n in self.seen.most_common():
+            lines.append("  %-22s seen=%-5d kept=%d" % (key, n, self.kept.get(key, n)))
+        return "\n".join(lines)

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -1,0 +1,127 @@
+"""Unit tests for the in-loop OOM crash deduper (fusil.python.oom_dedup).
+
+Pure-Python: exercises classification, snapshot matching, and the keep/prune decision
+without the python-ptrace runtime stack, so it runs in the dev venv.
+"""
+import os
+import tempfile
+import unittest
+
+from fusil.python import oom_dedup
+
+SNAPSHOT = "\n".join([
+    "# oom_id\tkind\tkeytype\tkey",
+    "OOM-0003\tabort\tfunc\tObjects/codeobject.c:code_dealloc",
+    "OOM-0003\tabort\tline\tObjects/codeobject.c:2440",
+    "OOM-0027\tabort\tassert\tPython/generated_cases.c.h:PyStackRef_BoolCheck(cond)",
+    "OOM-0027\tabort\tfunc\tPython/generated_cases.c.h:_PyEval_EvalFrameDefault",
+    "OOM-0022\tfatal\tmsg\t_Py_CheckSlotResult: Slot __delitem__ of type dict succeeded",
+    "OOM-0004\tabort\tline\tObjects/object.c:909",
+])
+
+ABORT_0003 = "python: Objects/codeobject.c:2440: void code_dealloc(PyObject *): Assertion `co != NULL' failed."
+ABORT_0027 = ("python: Python/generated_cases.c.h:11120: PyObject *_PyEval_EvalFrameDefault"
+              "(PyThreadState *, _PyInterpreterFrame *, int): Assertion `PyStackRef_BoolCheck(cond)' failed.")
+ABORT_NEAR = "python: Objects/object.c:915: void clear_freelist(void): Assertion `x' failed."  # within 12 of 909
+FATAL_0022 = "Fatal Python error: _Py_CheckSlotResult: Slot __delitem__ of type dict succeeded with an exception"
+GENERIC_FATAL = "Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed"
+SEGV = "Fatal Python error: Segmentation fault\nCurrent thread's C stack trace ..."
+ABORT_NEW = "python: Objects/brandnew.c:5: void totally_new(void): Assertion `nope' failed."
+
+
+class TestClassify(unittest.TestCase):
+    def test_abort_extracts_file_line_func_expr(self):
+        c = oom_dedup.classify(ABORT_0003)
+        self.assertEqual(c["kind"], "abort")
+        self.assertEqual(c["file"], "Objects/codeobject.c")
+        self.assertEqual(c["line"], 2440)
+        self.assertEqual(c["func"], "code_dealloc")
+        self.assertEqual(c["assert_expr"], "co != NULL")
+
+    def test_specific_fatal(self):
+        c = oom_dedup.classify(FATAL_0022)
+        self.assertEqual(c["kind"], "fatal")
+        self.assertTrue(c["fatal_msg"].startswith("_Py_CheckSlotResult"))
+
+    def test_generic_assert_fatal_routes_to_segv(self):
+        # carries no real site -> must not be trusted as a known fatal
+        self.assertEqual(oom_dedup.classify(GENERIC_FATAL)["kind"], "segv")
+
+    def test_segv_and_import_and_clean(self):
+        self.assertEqual(oom_dedup.classify(SEGV)["kind"], "segv")
+        self.assertEqual(oom_dedup.classify("ModuleNotFoundError: no mod")["kind"], "import")
+        self.assertEqual(oom_dedup.classify("hello world, no crash")["kind"], "clean")
+
+
+class TestMatch(unittest.TestCase):
+    def setUp(self):
+        self.snap = oom_dedup.load_snapshot(SNAPSHOT.splitlines())
+
+    def _match(self, text):
+        return oom_dedup.match(oom_dedup.classify(text), self.snap)
+
+    def test_match_by_func(self):
+        ids, how = self._match(ABORT_0003)
+        self.assertEqual(ids, {"OOM-0003"})
+
+    def test_assert_beats_func(self):
+        ids, how = self._match(ABORT_0027)
+        self.assertEqual(ids, {"OOM-0027"})
+        self.assertEqual(how, "assert")
+
+    def test_match_by_msg(self):
+        ids, _ = self._match(FATAL_0022)
+        self.assertEqual(ids, {"OOM-0022"})
+
+    def test_near_line(self):
+        ids, how = self._match(ABORT_NEAR)
+        self.assertEqual(ids, {"OOM-0004"})
+        self.assertEqual(how, "near")
+
+    def test_unknown_is_new(self):
+        ids, how = self._match(ABORT_NEW)
+        self.assertEqual(ids, set())
+        self.assertEqual(how, "NEW")
+
+
+class TestDeduper(unittest.TestCase):
+    def _deduper(self, keep=5, prune=False):
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(SNAPSHOT)
+        self.addCleanup(os.unlink, path)
+        return oom_dedup.Deduper(path, keep=keep, prune=prune)
+
+    def test_known_kept_and_labeled(self):
+        d = self._deduper()
+        keep, label = d.decide(ABORT_0003)
+        self.assertTrue(keep)
+        self.assertEqual(label, "OOM-0003")
+
+    def test_prune_over_cap(self):
+        d = self._deduper(keep=2, prune=True)
+        self.assertEqual([d.decide(ABORT_0003)[0] for _ in range(4)], [True, True, False, False])
+        self.assertEqual(d.kept["OOM-0003"], 2)
+        self.assertEqual(d.seen["OOM-0003"], 4)
+
+    def test_new_never_pruned(self):
+        d = self._deduper(keep=1, prune=True)
+        for _ in range(3):
+            keep, label = d.decide(ABORT_NEW)
+            self.assertTrue(keep)
+            self.assertEqual(label, "oomNEW")
+
+    def test_segv_never_pruned(self):
+        d = self._deduper(keep=1, prune=True)
+        for _ in range(3):
+            keep, label = d.decide(SEGV)
+            self.assertTrue(keep)
+            self.assertEqual(label, "oomSEGV")
+
+    def test_prune_disabled_keeps_all(self):
+        d = self._deduper(keep=1, prune=False)
+        self.assertTrue(all(d.decide(ABORT_0003)[0] for _ in range(5)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #64.

Adds the **tested engine** for in-loop OOM crash dedupe plus the integration plan. The OOM fuzzer produces ~96% duplicate crash dirs; this lets it dedupe against the `cpython-oom-findings` catalog snapshot (`known_sites.tsv`) at crash time to self-label dirs and prune known duplicates.

### What's in this PR (all tested / docs)
- `fusil/python/oom_dedup.py` — pure-Python (no python-ptrace dep). Snapshot load, stdout classification (tier-1: aborts/fatals), matching (assert ▸ msg ▸ func ▸ line/near-12), and `Deduper.decide(stdout) -> (keep, label)`. `keep=False` only for a confidently-known bug over its sample cap **and** when prune is enabled; new/segv/import/clean are always kept.
- `tests/python/test_oom_dedup.py` — 14 unit tests; run with `python -m unittest tests.python.test_oom_dedup` (works in the dev venv, no ptrace).
- `doc/oom-dedup-plan.md` — design + the exact **default-off** wiring diffs (CLI options, `setupProject` keep-policy install, `SessionDirectory.checkKeepDirectory` hook) + Phase B.

### Not in this PR (needs a python-ptrace host)
The runtime wiring is **documented, not applied** — it can't be executed in the dev venv (no python-ptrace), so the glue is specified in the plan for smoke-testing on the fuzzing host. Off-path behaviour is unchanged (everything gates on `--oom-dedup-catalog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)