### PR TITLE
Wire in-loop OOM dedupe into the fuzzer (Phase A glue)

### DIFF
--- a/doc/oom-dedup-plan.md
+++ b/doc/oom-dedup-plan.md
@@ -32,11 +32,16 @@ Safety contract enforced by the engine: `keep=False` is returned **only** for a
 *confidently-known* bug already at its sample cap, and **only** when `prune=True`.
 New-site, segv (tier-1-unresolved), import, and clean outcomes are always kept.
 
-## Wiring to apply on a python-ptrace host (Phase A glue — needs a live run)
+## Wiring (Phase A glue — APPLIED)
 
-These three edits are inert unless `--oom-dedup-catalog` is passed (off-path behaviour
-is byte-for-byte unchanged), so they can't regress existing runs; the *enabled* path
-should be smoke-tested on the fuzzing host before merge.
+These three edits are now in place. They are inert unless `--oom-dedup-catalog` is
+passed (off-path behaviour is byte-for-byte unchanged), so they cannot regress existing
+runs. **Validated locally** (python-ptrace present): options parse, the deduper installs
+and loads the snapshot ("OOM dedupe enabled …"), and the tally prints at exit; plus
+`tests/python/test_oom_dedup_wiring.py` covers `_oom_keep_policy`. **Still to validate on
+a real fuzzing run / the host**: the live crash → `checkKeepDirectory` → prune/label path
+(needs an actual crashing session, which the dev box can't fully drive without the
+`fusil` user / a reliable crash).
 
 ### 1. CLI options — `fusil/python/__init__.py`, in `createFuzzerOptions` OOM group
 

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -360,6 +360,27 @@ class Fuzzer(Application):
             action="store_true",
             default=False,
         )
+        oom_options.add_option(
+            "--oom-dedup-catalog",
+            help="Path to known_sites.tsv (cpython-oom-findings). Enables in-loop "
+                 "crash dedupe: label each crash dir with its matched bug id and, "
+                 "with --oom-dedup-prune, drop known duplicates (default: disabled)",
+            type="str",
+            default=None,
+        )
+        oom_options.add_option(
+            "--oom-dedup-keep",
+            help="Keep at most N sample directories per known bug (default: 5)",
+            type="int",
+            default=5,
+        )
+        oom_options.add_option(
+            "--oom-dedup-prune",
+            help="Remove known-duplicate crash dirs beyond the keep cap "
+                 "(default: keep all, label only)",
+            action="store_true",
+            default=False,
+        )
 
         config_options = OptionGroupWithSections(parser, "Configuration")
         config_options.add_option(
@@ -469,9 +490,44 @@ class Fuzzer(Application):
 
         # import_all()
 
+        # In-loop OOM crash dedupe: install a keep-policy that SessionDirectory
+        # consults for each crashing session (label dirs, optionally prune known dups).
+        self._deduper = None
+        if self.options.oom_dedup_catalog:
+            from fusil.python.oom_dedup import Deduper
+            self._deduper = Deduper(
+                self.options.oom_dedup_catalog,
+                keep=self.options.oom_dedup_keep,
+                prune=self.options.oom_dedup_prune,
+            )
+            self.session_keep_policy = self._oom_keep_policy
+            project.error(
+                "OOM dedupe enabled: %s (keep=%d, prune=%s)"
+                % (self.options.oom_dedup_catalog, self.options.oom_dedup_keep,
+                   self.options.oom_dedup_prune)
+            )
+
+    def _oom_keep_policy(self, session):
+        """Return (keep, label) for a crashed session from its captured stdout.
+
+        Consulted synchronously by SessionDirectory.checkKeepDirectory, where the
+        stdout file is already complete. Returns (True, None) on any error so a crash
+        is never lost to a dedupe failure.
+        """
+        import os
+        try:
+            stdout_path = os.path.join(session.directory.directory, "stdout")
+            with open(stdout_path, errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            return True, None
+        return self._deduper.decide(text)
+
     def exit(self, keep_log: bool = True) -> None:
         """Clean up and exit the fuzzer, printing runtime statistics."""
         super().exit(keep_log=keep_log)
+        if getattr(self, "_deduper", None):
+            self.error(self._deduper.report())
         self.error(print_running_time(time_start))
 
 

--- a/fusil/session_directory.py
+++ b/fusil/session_directory.py
@@ -63,6 +63,16 @@ class SessionDirectory(SessionAgent, Directory):
         application = self.application()
         if not self.isEmpty(False):
             if session.isSuccess():
+                # Optional keep-policy (e.g. OOM in-loop dedupe): may relabel the
+                # crash dir and/or prune a known duplicate. Absent policy -> unchanged.
+                policy = getattr(application, "session_keep_policy", None)
+                if policy is not None:
+                    keep, label = policy(session)
+                    if label:
+                        self.on_session_rename(label)
+                    if not keep:
+                        self.warning("Dedup: prune duplicate crash %s" % self.directory)
+                        return False
                 # Session sucess and non-empty directory: keep directory
                 self.warning("Success: keep the directory %s" % self.directory)
                 return True

--- a/tests/python/test_oom_dedup_wiring.py
+++ b/tests/python/test_oom_dedup_wiring.py
@@ -1,0 +1,64 @@
+"""Wiring tests for the OOM keep-policy glue (Fuzzer._oom_keep_policy).
+
+Unlike test_oom_dedup (pure engine), this exercises the method that SessionDirectory
+calls, so it imports the runtime stack and SKIPS where python-ptrace is unavailable.
+It locks the contract the core hook depends on: reading <session.directory.directory>/
+stdout, calling the deduper, and never losing a crash on a read error.
+"""
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+try:
+    from fusil.python import Fuzzer
+    from fusil.python.oom_dedup import Deduper
+    HAVE_FUSIL = True
+except Exception:                       # pragma: no cover - env without python-ptrace
+    HAVE_FUSIL = False
+
+SNAPSHOT = "\n".join([
+    "OOM-0003\tabort\tfunc\tObjects/codeobject.c:code_dealloc",
+    "OOM-0003\tabort\tline\tObjects/codeobject.c:2440",
+])
+ABORT = "python: Objects/codeobject.c:2440: void code_dealloc(PyObject *): Assertion `co != NULL' failed."
+
+
+@unittest.skipUnless(HAVE_FUSIL, "fusil runtime stack (python-ptrace) not importable")
+class TestKeepPolicy(unittest.TestCase):
+    def _fake_self(self, prune=False, keep=5):
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(SNAPSHOT)
+        self.addCleanup(os.unlink, path)
+        return SimpleNamespace(_deduper=Deduper(path, keep=keep, prune=prune))
+
+    def _session(self, text):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d)
+        with open(os.path.join(d, "stdout"), "w") as fh:
+            fh.write(text)
+        return SimpleNamespace(directory=SimpleNamespace(directory=d))
+
+    def test_known_crash_kept_and_labeled(self):
+        keep, label = Fuzzer._oom_keep_policy(self._fake_self(), self._session(ABORT))
+        self.assertTrue(keep)
+        self.assertEqual(label, "OOM-0003")
+
+    def test_prune_over_cap(self):
+        fs = self._fake_self(prune=True, keep=1)
+        sess = self._session(ABORT)
+        self.assertTrue(Fuzzer._oom_keep_policy(fs, sess)[0])
+        self.assertFalse(Fuzzer._oom_keep_policy(fs, sess)[0])
+
+    def test_missing_stdout_is_kept_unlabeled(self):
+        fs = self._fake_self()
+        sess = SimpleNamespace(directory=SimpleNamespace(directory="/no/such/dir/xyz"))
+        keep, label = Fuzzer._oom_keep_policy(fs, sess)
+        self.assertTrue(keep)
+        self.assertIsNone(label)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #66. Follow-up to #65 (engine).

Applies the **default-off** wiring from `doc/oom-dedup-plan.md`:
- `--oom-dedup-catalog` / `--oom-dedup-keep` / `--oom-dedup-prune` options.
- `setupProject` installs a `Deduper` + `session_keep_policy`; `Fuzzer._oom_keep_policy` decides (keep, label) from the crashed session's stdout; `exit()` prints the seen/kept tally.
- `SessionDirectory.checkKeepDirectory` consults an optional `application.session_keep_policy` for successful sessions — relabels the crash dir and prunes a known duplicate when told to. **Absent policy ⇒ byte-for-byte unchanged behaviour.**
- `tests/python/test_oom_dedup_wiring.py`: covers `_oom_keep_policy` (label / prune-over-cap / missing-stdout-kept); skips without python-ptrace.

### Validated locally
Options parse; deduper installs and loads the 28-bug snapshot (`OOM dedupe enabled …`); tally prints at exit; 17 dedupe tests pass; new code is ruff-clean.

### Still needs a real run (host)
The live crash → `checkKeepDirectory` → prune/label path needs an actual crashing fuzzing session (the dev box lacks the `fusil` user / a reliable crash). Smoke test in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)