### PR TITLE
Add fleet/: systemd-based multi-instance fusil runner

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -1,0 +1,80 @@
+# fusil fleet — run many fusil instances and keep them alive
+
+Replaces the manual loop of "cd into a dir, start fusil, check it's still up, eyeball
+the results" with three commands. It uses **systemd** (the service manager already on
+your Linux box) to start N instances, restart any that die or finish, cap their memory,
+and capture their logs — no VMs or containers needed.
+
+## What it gives you
+
+- **One command to start N instances**, each in its own directory, spread across both
+  `PYTHON_GIL` modes (they find *different* crashes).
+- **Auto-restart**: if an instance crashes or hits `--success` and exits, systemd brings
+  it back. This is the "is it still running?" check, done by the OS.
+- **A memory cap per instance** (`MemoryMax`) so a runaway OOM-injection child can't take
+  down the whole machine.
+- **`fleet finds`**: surfaces the `oomNEW` crash dirs — the new-bug candidates — across
+  all instances, using the labels the in-loop dedup already writes. That's your
+  "anything interesting?" answer.
+
+## One-time setup
+
+1. Copy this `fleet/` directory onto the fuzzing host (anywhere, e.g. `/home/ubuntu/fleet`).
+2. Edit **`fleet.conf`** — set `FUSIL_PY`, `TARGET_PYTHON`, `CATALOG`, `FLEET_DIR`, and the
+   `FUSIL_FLAGS` (the defaults match your current command). Make sure `RUNNER_PY` is the
+   `python3` from the venv that has fusil installed.
+3. `chmod +x fleet fleet-run`
+
+> The `CATALOG` (`known_sites.tsv`) is the dedup snapshot. Generate/refresh it from the
+> `cpython-oom-findings` catalog with `gen_known_sites.py`; all instances read it
+> read-only, so there's no write contention.
+
+## Daily use
+
+```bash
+sudo ./fleet up            # start (nproc-1) instances; or: sudo ./fleet up 8
+./fleet status             # per-instance state + crashes kept + NEW candidates
+./fleet finds              # list the oomNEW dirs across the whole fleet
+./fleet tail 3             # follow instance 3's output live
+sudo ./fleet down          # stop everything
+sudo ./fleet restart       # restart all (e.g. after refreshing the catalog)
+./fleet triage             # dedupe all instances' crashes (needs INGEST set in fleet.conf)
+```
+
+`fleet up` installs `/etc/systemd/system/fusil@.service` and runs `fusil@1 … fusil@N`.
+Because systemd `enable`s them, they also come back **after a reboot**.
+
+## How it maps to your old steps
+
+| Old manual step | Now |
+|---|---|
+| `sudo su`, activate venv, `cd` into a dir, `nohup … &` per instance | `sudo ./fleet up N` |
+| check each is still running, restart by hand | systemd `Restart=always` (automatic) |
+| eyeball every result dir for something interesting | `./fleet finds` / `./fleet status` |
+| `> /dev/null` (logs lost) | per-instance `fusil.out` (or journald); `./fleet tail N` |
+
+## Tuning
+
+- **How many instances?** `up` defaults to `nproc-1`. Memory is usually the limit, not
+  CPU — watch `free -h`; if instances get OOM-killed often, lower the count or raise
+  `MEM_MAX`. Each instance also runs child interpreters, so it uses more than one core's
+  worth at peak.
+- **Diversity.** `GIL_MODES="0 1"` alternates instances between free-threaded and
+  GIL-on. To also throw JIT or different module sets into the mix, run a second fleet
+  dir with different `FUSIL_FLAGS` (the unit is shared, so use a separate checkout/config
+  if you want two profiles at once — or just edit `FUSIL_FLAGS` and `fleet restart`).
+- **Logs filling disk.** `fusil.out` is truncated each run start. With `--oom-verbose`
+  it can still grow within a run; set `LOG=none` in `fleet.conf` to discard fusil's
+  stdout (you still get crash dirs + `session.log` + systemd's start/stop in journald).
+
+## Under the hood (so it's not a black box)
+
+- **`fusil@.service.in`** — a systemd *template* unit. `%i` is the instance number;
+  `fleet up` fills in the paths/limits and installs it. `systemctl start fusil@3` ⇒ runs
+  instance 3.
+- **`fleet-run N`** — what each unit actually runs: makes `inst-NN/`, picks the GIL mode
+  for instance N, `exec`s fusil there so systemd supervises fusil directly.
+- **`fleet`** — a thin wrapper over `systemctl` + reads the result dirs for `status`/`finds`.
+
+To see raw systemd state at any time: `systemctl status 'fusil@*'`,
+`journalctl -u fusil@3 -e`.

--- a/fleet/fleet
+++ b/fleet/fleet
@@ -1,0 +1,134 @@
+#!/bin/bash
+# fleet -- run and supervise a fleet of fusil instances via systemd.
+#
+#   sudo ./fleet up [N]     install the unit + start N instances (default: nproc-1)
+#   sudo ./fleet down       stop + disable all instances
+#   ./fleet status          per-instance state + crash/NEW-find counts
+#   ./fleet finds           list this fleet's oomNEW (new-bug candidate) dirs
+#   ./fleet triage          dedupe all instances' crashes (needs INGEST in fleet.conf)
+#   ./fleet tail [N]        follow instance N's log (default: 1)
+#   sudo ./fleet restart    restart all instances (e.g. to pick up a new catalog)
+#
+# All paths/flags come from fleet.conf next to this script.
+set -euo pipefail
+HERE="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/fleet.conf"
+: "${INSTANCES:=$(( $(nproc) - 1 ))}"
+UNIT_NAME="fusil@.service"
+UNIT_PATH="/etc/systemd/system/$UNIT_NAME"
+STATE="$FLEET_DIR/.fleet_instances"
+
+die(){ echo "fleet: $*" >&2; exit 1; }
+need_root(){ [ "$(id -u)" = 0 ] || die "run this as root (sudo ./fleet $1)"; }
+inst_dir(){ printf '%s/inst-%02d' "$FLEET_DIR" "$1"; }
+
+units(){  # active/loaded fusil@N units, one per line
+    systemctl list-units --all --no-legend --plain 'fusil@*.service' 2>/dev/null | awk '{print $1}'
+}
+list_crashes(){  # every kept crash dir under an instance (layout-agnostic: has source.py)
+    find "$1" -maxdepth 3 -name source.py -printf '%h\n' 2>/dev/null | sort -u
+}
+
+cmd_install(){
+    need_root install
+    [ -x "$HERE/fleet-run" ] || chmod +x "$HERE/fleet-run"
+    sed -e "s#@@FLEET_RUN@@#$HERE/fleet-run#g" \
+        -e "s#@@MEM_MAX@@#${MEM_MAX:-infinity}#g" \
+        -e "s#@@NICE@@#${NICE:-10}#g" \
+        "$HERE/$UNIT_NAME.in" > "$UNIT_PATH"
+    systemctl daemon-reload
+    echo "installed $UNIT_PATH (MemoryMax=${MEM_MAX:-infinity}, nice=${NICE:-10})"
+}
+
+cmd_up(){
+    need_root up
+    local n="${1:-$INSTANCES}"
+    mkdir -p "$FLEET_DIR"
+    cmd_install
+    echo "$n" > "$STATE"
+    for i in $(seq 1 "$n"); do systemctl enable --now "fusil@$i" >/dev/null; done
+    echo "started $n instances (GIL modes cycled: $GIL_MODES)"
+    cmd_status
+}
+
+cmd_down(){
+    need_root down
+    local u list; list="$(units)"
+    [ -n "$list" ] || { echo "no instances running"; return; }
+    # shellcheck disable=SC2086
+    systemctl disable --now $list >/dev/null 2>&1 || true
+    echo "stopped: $(echo "$list" | wc -l) instances"
+}
+
+cmd_restart(){
+    need_root restart
+    local list; list="$(units)"
+    [ -n "$list" ] || die "no instances running"
+    # shellcheck disable=SC2086
+    systemctl restart $list
+    echo "restarted $(echo "$list" | wc -l) instances"
+}
+
+cmd_status(){
+    local list; list="$(units)"
+    [ -n "$list" ] || { echo "no instances (run: sudo ./fleet up)"; return; }
+    printf '%-4s %-9s %-20s %8s %6s\n' '#' STATE SINCE CRASHES NEW
+    local tot=0 totnew=0
+    for u in $list; do
+        local i state since dir n new
+        i="${u#fusil@}"; i="${i%.service}"
+        state="$(systemctl is-active "$u" 2>/dev/null || true)"
+        since="$(systemctl show -p ActiveEnterTimestamp --value "$u" 2>/dev/null | cut -d' ' -f2-3)"
+        dir="$(inst_dir "$i")"
+        n="$(list_crashes "$dir" | wc -l)"
+        new="$(list_crashes "$dir" | grep -c oomNEW || true)"
+        tot=$((tot + n)); totnew=$((totnew + new))
+        printf '%-4s %-9s %-20s %8s %6s\n' "$i" "$state" "${since:-?}" "$n" "$new"
+    done
+    echo "---- totals: $tot crashes kept, $totnew oomNEW candidates ----"
+    [ "$totnew" -gt 0 ] && echo "see them with: ./fleet finds"
+}
+
+cmd_finds(){
+    echo "== oomNEW (new-bug candidates) across the fleet =="
+    local any=
+    for d in "$FLEET_DIR"/inst-*; do
+        [ -d "$d" ] || continue
+        list_crashes "$d" | grep oomNEW | sed "s#$FLEET_DIR/##" && any=1 || true
+    done
+    [ -n "$any" ] || echo "(none yet)"
+}
+
+cmd_triage(){
+    local dirs=("$FLEET_DIR"/inst-*/)
+    if [ -n "${INGEST:-}" ] && [ -f "$INGEST" ]; then
+        echo "ingesting all instances' crashes via $INGEST ..."
+        "$RUNNER_PY" "$INGEST" "${dirs[@]}" --snapshot "$CATALOG" "$@"
+    else
+        echo "(no INGEST configured in fleet.conf -- listing candidates only)"
+        cmd_finds
+    fi
+}
+
+cmd_tail(){
+    local i="${1:-1}" dir; dir="$(inst_dir "$i")"
+    if [ "${LOG:-file}" = "none" ]; then
+        journalctl -u "fusil@$i" -f
+    else
+        echo "== tailing $dir/fusil.out (Ctrl-C to stop) =="
+        tail -n 40 -f "$dir/fusil.out"
+    fi
+}
+
+case "${1:-status}" in
+    up)       shift; cmd_up "$@" ;;
+    down)     cmd_down ;;
+    install)  cmd_install ;;
+    restart)  cmd_restart ;;
+    status)   cmd_status ;;
+    finds)    cmd_finds ;;
+    triage)   shift; cmd_triage "$@" ;;
+    tail)     shift; cmd_tail "$@" ;;
+    *)        sed -n '2,12p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
+esac

--- a/fleet/fleet-run
+++ b/fleet/fleet-run
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Launch ONE fusil instance. Called by systemd (ExecStart=fleet-run %i); not meant to
+# be run by hand. Sets up the instance's working directory + per-instance environment,
+# then exec's fusil so systemd supervises the fusil process directly.
+set -euo pipefail
+i="${1:?usage: fleet-run <instance-number>}"
+HERE="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/fleet.conf"
+
+inst_dir="$FLEET_DIR/inst-$(printf '%02d' "$i")"
+mkdir -p "$inst_dir"
+cd "$inst_dir"
+
+# Per-instance GIL mode: cycle through GIL_MODES (0=GIL off, 1=on) -- the two modes
+# surface disjoint OOM crashes, so spreading instances across both widens coverage.
+read -r -a _modes <<< "$GIL_MODES"
+gil="${_modes[$(( (i - 1) % ${#_modes[@]} ))]}"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
+export PYTHON_GIL="$gil"
+
+# Output sink: a per-run logfile (truncated each start) or discard.
+if [ "${LOG:-file}" = "none" ]; then
+    exec >/dev/null 2>&1
+else
+    exec >"$inst_dir/fusil.out" 2>&1
+fi
+
+echo "# fleet-run instance $i  gil=$gil  $(date -u +%FT%TZ)  dir=$inst_dir"
+# shellcheck disable=SC2086  -- FUSIL_FLAGS is intentionally word-split
+exec "$RUNNER_PY" "$FUSIL_PY" --python="$TARGET_PYTHON" $FUSIL_FLAGS

--- a/fleet/fleet.conf
+++ b/fleet/fleet.conf
@@ -1,0 +1,29 @@
+# fusil fleet configuration -- edit for your host, then run `sudo ./fleet up`.
+# Everything the fleet needs lives here; the scripts read this file.
+
+# --- paths (absolute) ---
+RUNNER_PY=python3                                              # the venv python that runs fusil
+FUSIL_PY=/home/ubuntu/projects/fusil/fuzzers/fusil-python-threaded
+TARGET_PYTHON=/home/ubuntu/projects/upstream_cpython/python   # the CPython build under test
+CATALOG=/home/ubuntu/known_sites.tsv                          # read-only dedup snapshot
+FLEET_DIR=/home/ubuntu/fusil-fleet                            # per-instance working dirs go here
+
+# Optional: path to the catalog repo's ingest.py, for `fleet triage` (cross-instance
+# dedup). Leave empty to disable; `fleet triage` then just lists oomNEW dirs.
+INGEST=/home/ubuntu/projects/cpython-oom-findings/scripts/ingest.py
+
+# --- fleet size & diversity ---
+INSTANCES=                       # how many instances; empty = (nproc - 1)
+GIL_MODES="0 1"                  # PYTHON_GIL values cycled across instances (0=off,1=on);
+                                 # the two modes find DISJOINT crashes, so run both.
+MEM_MAX=6G                       # per-instance memory cap (systemd MemoryMax); "infinity" to disable
+NICE=10                          # CPU niceness so the box stays responsive
+LOG=file                         # "file" -> $inst/fusil.out (truncated each run) | "none" -> /dev/null
+
+# --- fusil flags shared by every instance ---
+# (--python and the per-instance working dir are added automatically; PYTHON_GIL and
+# ASAN_OPTIONS are set per-instance by fleet-run.)
+FUSIL_FLAGS="-v --timeout 180 --success=12000 --fast --test-private \
+--oom-fuzz --oom-verbose --oom-dedup-prune --oom-dedup-catalog=$CATALOG --oom-dedup-resolve-segv \
+--functions-number 50 --classes-number 15 --methods-number 8 --objects-number 20 \
+--exitcode-score=1"

--- a/fleet/fusil@.service.in
+++ b/fleet/fusil@.service.in
@@ -1,0 +1,24 @@
+# systemd template unit for one fusil fleet instance.
+# `fleet up` fills @@..@@ from fleet.conf and installs this as
+# /etc/systemd/system/fusil@.service. "%i" is the instance number, so
+# `systemctl start fusil@3` runs instance 3. This file is a template -- do not
+# edit the installed copy by hand; edit fleet.conf and re-run `fleet up`.
+[Unit]
+Description=fusil fuzzing instance %i
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=@@FLEET_RUN@@ %i
+Restart=always
+RestartSec=10
+# Cap memory so a runaway OOM-injection child can't take down the host. The OOM
+# killer reaps the instance; Restart=always brings it back.
+MemoryMax=@@MEM_MAX@@
+OOMPolicy=continue
+Nice=@@NICE@@
+# Generous but bounded; fuzz children can spawn threads/processes.
+TasksMax=4096
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #70.

A `fleet/` toolkit to run and supervise many fusil instances, replacing the manual start/check/eyeball loop. Uses **systemd** (no VMs/containers).

- **`fleet up [N]`** installs a template unit and starts N instances (each in `inst-NN/`, spread across `PYTHON_GIL=0/1`); systemd `Restart=always` keeps them alive, `MemoryMax` caps each.
- **`fleet status` / `fleet finds`** read the `-oomNEW`/`-OOM-####` dir labels from the in-loop dedup to surface new-bug candidates fleet-wide.
- **`fleet triage`** runs the catalog `ingest.py` across all instances; **`fleet tail N`**, **`fleet down`**, **`fleet restart`** round it out.
- Config-driven (`fleet.conf`); plain-language `README.md` with an "old manual steps → fleet" map. Runs as root so fusil drops to the `fusil` user for children.

### Validated
bash syntax, systemd-unit generation, and crash-dir parsing (`finds`/`status`) against a fixture. The `systemctl` up/down/restart paths need a host with systemd + the `fusil` user (the dev box has neither) — first-run steps are in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)