### PR TITLE
fleet: preflight + PYTHONPATH so misconfig fails fast

### DIFF
--- a/fleet/fleet
+++ b/fleet/fleet
@@ -1,8 +1,9 @@
 #!/bin/bash
 # fleet -- run and supervise a fleet of fusil instances via systemd.
 #
-#   sudo ./fleet up [N]     install the unit + start N instances (default: nproc-1)
-#   sudo ./fleet down       stop + disable all instances
+#   ./fleet check           validate fleet.conf (paths exist, runner imports fusil)
+#   sudo ./fleet up [N]      install the unit + start N instances (default: nproc-1)
+#   sudo ./fleet down        stop + disable all instances
 #   ./fleet status          per-instance state + crash/NEW-find counts
 #   ./fleet finds           list this fleet's oomNEW (new-bug candidate) dirs
 #   ./fleet triage          dedupe all instances' crashes (needs INGEST in fleet.conf)
@@ -13,7 +14,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck source=/dev/null
-. "$HERE/fleet.conf"
+. "${FLEET_CONF:-$HERE/fleet.conf}"
 : "${INSTANCES:=$(( $(nproc) - 1 ))}"
 UNIT_NAME="fusil@.service"
 UNIT_PATH="/etc/systemd/system/$UNIT_NAME"
@@ -30,6 +31,27 @@ list_crashes(){  # every kept crash dir under an instance (layout-agnostic: has 
     find "$1" -maxdepth 3 -name source.py -printf '%h\n' 2>/dev/null | sort -u
 }
 
+cmd_check(){  # validate fleet.conf before we start anything (catches the #1 footgun:
+              # wrong paths / a non-venv python that can't import fusil under systemd)
+    local ok=1 repo
+    repo="$(dirname "$(dirname "$FUSIL_PY")")"
+    [ -x "$RUNNER_PY" ] || { echo "  RUNNER_PY is not an executable file: '$RUNNER_PY'"
+                             echo "    -> use the ABSOLUTE venv python, e.g. /path/to/venv/bin/python"; ok=0; }
+    [ -f "$FUSIL_PY" ]  || { echo "  FUSIL_PY not found: '$FUSIL_PY'"; ok=0; }
+    [ -x "$TARGET_PYTHON" ] || { echo "  TARGET_PYTHON is not executable: '$TARGET_PYTHON'"; ok=0; }
+    case "$FUSIL_FLAGS" in
+        *--oom-dedup-catalog*) [ -f "$CATALOG" ] || {
+            echo "  CATALOG not found but --oom-dedup-catalog is set: '$CATALOG'"; ok=0; } ;;
+    esac
+    if [ -x "$RUNNER_PY" ] && [ -f "$FUSIL_PY" ]; then
+        PYTHONPATH="$repo${PYTHONPATH:+:$PYTHONPATH}" "$RUNNER_PY" -c 'import fusil, ptrace' 2>/dev/null \
+            || { echo "  RUNNER_PY cannot 'import fusil, ptrace': '$RUNNER_PY'"
+                 echo "    -> wrong python (not the venv), or python-ptrace not installed"; ok=0; }
+    fi
+    [ "$ok" = 1 ] || die "preflight failed -- fix fleet.conf (see above), then retry"
+    echo "preflight OK: runner imports fusil+ptrace; paths exist"
+}
+
 cmd_install(){
     need_root install
     [ -x "$HERE/fleet-run" ] || chmod +x "$HERE/fleet-run"
@@ -43,6 +65,7 @@ cmd_install(){
 
 cmd_up(){
     need_root up
+    cmd_check
     local n="${1:-$INSTANCES}"
     mkdir -p "$FLEET_DIR"
     cmd_install
@@ -124,11 +147,12 @@ cmd_tail(){
 case "${1:-status}" in
     up)       shift; cmd_up "$@" ;;
     down)     cmd_down ;;
+    check)    cmd_check ;;
     install)  cmd_install ;;
     restart)  cmd_restart ;;
     status)   cmd_status ;;
     finds)    cmd_finds ;;
     triage)   shift; cmd_triage "$@" ;;
     tail)     shift; cmd_tail "$@" ;;
-    *)        sed -n '2,12p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
+    *)        sed -n '2,13p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
 esac

--- a/fleet/fleet-run
+++ b/fleet/fleet-run
@@ -19,6 +19,9 @@ gil="${_modes[$(( (i - 1) % ${#_modes[@]} ))]}"
 
 export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
 export PYTHON_GIL="$gil"
+# systemd runs with a clean environment (no venv activation); add the fusil repo root so
+# `import fusil` works whether or not fusil is pip-installed in RUNNER_PY's environment.
+export PYTHONPATH="$(dirname "$(dirname "$FUSIL_PY")")${PYTHONPATH:+:$PYTHONPATH}"
 
 # Output sink: a per-run logfile (truncated each start) or discard.
 if [ "${LOG:-file}" = "none" ]; then

--- a/fleet/fleet.conf
+++ b/fleet/fleet.conf
@@ -1,8 +1,10 @@
 # fusil fleet configuration -- edit for your host, then run `sudo ./fleet up`.
 # Everything the fleet needs lives here; the scripts read this file.
 
-# --- paths (absolute) ---
-RUNNER_PY=python3                                              # the venv python that runs fusil
+# --- paths: use ABSOLUTE paths everywhere. systemd runs with a clean environment (no
+#     venv activation, no PYTHONPATH), so a bare `python3` will NOT find fusil. `fleet up`
+#     runs a preflight (`fleet check`) and refuses to start if any path is wrong. ---
+RUNNER_PY=/home/ubuntu/venvs/fusil_venv/bin/python            # ABSOLUTE venv python (has fusil + python-ptrace)
 FUSIL_PY=/home/ubuntu/projects/fusil/fuzzers/fusil-python-threaded
 TARGET_PYTHON=/home/ubuntu/projects/upstream_cpython/python   # the CPython build under test
 CATALOG=/home/ubuntu/known_sites.tsv                          # read-only dedup snapshot


### PR DESCRIPTION
Closes #72. Follow-up to #71.

A wrong `fleet.conf` made instances exit 1 and systemd restart-loop silently (real report: unedited `/home/ubuntu` paths + `RUNNER_PY=python3` = system python, no fusil). 

- **fleet-run** exports `PYTHONPATH=<repo root>` so `import fusil` works under systemd.
- **fleet** gains a `check` preflight (also run by `up`) that validates the paths exist and `RUNNER_PY` can `import fusil, ptrace`, aborting with per-path messages; plus a `$FLEET_CONF` override.
- **fleet.conf** example now uses an absolute venv python + a banner about systemd's clean env.

Tested: preflight fails clearly on the bad example and passes on a correct config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)