### PR TITLE
fleet: propagate config to instances + catch GIL/runner mismatch

### DIFF
--- a/fleet/fleet
+++ b/fleet/fleet
@@ -13,8 +13,9 @@
 # All paths/flags come from fleet.conf next to this script.
 set -euo pipefail
 HERE="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+CONF_FILE="${FLEET_CONF:-$HERE/fleet.conf}"
 # shellcheck source=/dev/null
-. "${FLEET_CONF:-$HERE/fleet.conf}"
+. "$CONF_FILE"
 : "${INSTANCES:=$(( $(nproc) - 1 ))}"
 UNIT_NAME="fusil@.service"
 UNIT_PATH="/etc/systemd/system/$UNIT_NAME"
@@ -28,7 +29,8 @@ units(){  # active/loaded fusil@N units, one per line
     systemctl list-units --all --no-legend --plain 'fusil@*.service' 2>/dev/null | awk '{print $1}'
 }
 list_crashes(){  # every kept crash dir under an instance (layout-agnostic: has source.py)
-    find "$1" -maxdepth 3 -name source.py -printf '%h\n' 2>/dev/null | sort -u
+    [ -d "$1" ] || return 0                     # dir may not exist yet -> don't trip set -e
+    find "$1" -maxdepth 3 -name source.py -printf '%h\n' 2>/dev/null | sort -u || true
 }
 
 cmd_check(){  # validate fleet.conf before we start anything (catches the #1 footgun:
@@ -47,6 +49,13 @@ cmd_check(){  # validate fleet.conf before we start anything (catches the #1 foo
         PYTHONPATH="$repo${PYTHONPATH:+:$PYTHONPATH}" "$RUNNER_PY" -c 'import fusil, ptrace' 2>/dev/null \
             || { echo "  RUNNER_PY cannot 'import fusil, ptrace': '$RUNNER_PY'"
                  echo "    -> wrong python (not the venv), or python-ptrace not installed"; ok=0; }
+        # PYTHON_GIL is inherited by the runner too -- a non-free-threaded runner fatals
+        # on PYTHON_GIL=0. Check every GIL mode we'd actually use.
+        for g in ${GIL_MODES:-1}; do
+            PYTHON_GIL="$g" "$RUNNER_PY" -c 'pass' >/dev/null 2>&1 \
+                || { echo "  RUNNER_PY can't run with PYTHON_GIL=$g (runner is not free-threaded): '$RUNNER_PY'"
+                     echo "    -> use a free-threaded runner python, or remove $g from GIL_MODES"; ok=0; }
+        done
     fi
     [ "$ok" = 1 ] || die "preflight failed -- fix fleet.conf (see above), then retry"
     echo "preflight OK: runner imports fusil+ptrace; paths exist"
@@ -56,6 +65,7 @@ cmd_install(){
     need_root install
     [ -x "$HERE/fleet-run" ] || chmod +x "$HERE/fleet-run"
     sed -e "s#@@FLEET_RUN@@#$HERE/fleet-run#g" \
+        -e "s#@@FLEET_CONF@@#$CONF_FILE#g" \
         -e "s#@@MEM_MAX@@#${MEM_MAX:-infinity}#g" \
         -e "s#@@NICE@@#${NICE:-10}#g" \
         "$HERE/$UNIT_NAME.in" > "$UNIT_PATH"

--- a/fleet/fleet-run
+++ b/fleet/fleet-run
@@ -5,8 +5,10 @@
 set -euo pipefail
 i="${1:?usage: fleet-run <instance-number>}"
 HERE="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# Use the same config `fleet up` validated: it bakes FLEET_CONF into the unit's
+# Environment, so the instances read it rather than the in-repo example.
 # shellcheck source=/dev/null
-. "$HERE/fleet.conf"
+. "${FLEET_CONF:-$HERE/fleet.conf}"
 
 inst_dir="$FLEET_DIR/inst-$(printf '%02d' "$i")"
 mkdir -p "$inst_dir"

--- a/fleet/fusil@.service.in
+++ b/fleet/fusil@.service.in
@@ -9,6 +9,8 @@ After=network.target
 
 [Service]
 Type=simple
+# The config `fleet up` validated (so instances read the same one, not the in-repo example).
+Environment=FLEET_CONF=@@FLEET_CONF@@
 ExecStart=@@FLEET_RUN@@ %i
 Restart=always
 RestartSec=10


### PR DESCRIPTION
Closes #74. Follow-up to #73.

Fixes three issues from first real use:
- **Instances ran the wrong config** (exit 127): `fleet up` now bakes `Environment=FLEET_CONF=<validated config>` into the unit and `fleet-run` honors `$FLEET_CONF`. Preflight and instances now use the same config.
- **`status` showed only a header**: `list_crashes` returns early on a missing dir so `set -euo pipefail` doesn't abort the loop.
- **Non-free-threaded runner + PYTHON_GIL=0** fatals silently → restart-loop. Preflight now checks `PYTHON_GIL=$g RUNNER_PY -c pass` per GIL mode and fails clearly.

Validated: config propagation (unit carries Environment=FLEET_CONF), end-to-end `fleet-run` with PYTHON_GIL=1 runs fusil (exit 0), status survives missing dirs, and the GIL preflight rejects a non-FT runner with GIL_MODES containing 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)