### PR TITLE
fleet-run: set HOME under systemd (fix restart loop)

### DIFF
--- a/fleet/fleet-run
+++ b/fleet/fleet-run
@@ -19,6 +19,12 @@ cd "$inst_dir"
 read -r -a _modes <<< "$GIL_MODES"
 gil="${_modes[$(( (i - 1) % ${#_modes[@]} ))]}"
 
+# systemd starts services with a clean environment and no HOME; fusil needs it (config
+# lookup / ~ expansion), so derive it from the running user (root -> /root).
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)"
+    export HOME="${HOME:-/root}"
+fi
 export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
 export PYTHON_GIL="$gil"
 # systemd runs with a clean environment (no venv activation); add the fusil repo root so


### PR DESCRIPTION
Closes #76. Follow-up to #75.

systemd's clean service env has no `HOME`, so fusil exits at startup ("Unable to retrieve user home directory: empty HOME environment variable") and `Restart=always` loops. Manual runs worked because `sudo su` set HOME. `fleet-run` now derives HOME from the running user when unset. Verified under `env -i` (no HOME): fusil runs sessions with OOM dedup active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)