### PR TITLE
fleet: document FT-runner requirement for GIL_MODES=0

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -60,7 +60,12 @@ Because systemd `enable`s them, they also come back **after a reboot**.
   `MEM_MAX`. Each instance also runs child interpreters, so it uses more than one core's
   worth at peak.
 - **Diversity.** `GIL_MODES="0 1"` alternates instances between free-threaded and
-  GIL-on. To also throw JIT or different module sets into the mix, run a second fleet
+  GIL-on (they find disjoint crashes). Caveat: `PYTHON_GIL=0` is inherited by the
+  *runner* python too, so including `0` requires `RUNNER_PY` to be a **free-threaded**
+  venv (build one from a free-threaded CPython + `pip install python-ptrace`); a non-FT
+  runner fatals with "Disabling the GIL is not supported by this build" (`fleet check`
+  catches it). Use `GIL_MODES="1"` if your runner isn't free-threaded.
+  To also throw JIT or different module sets into the mix, run a second fleet
   dir with different `FUSIL_FLAGS` (the unit is shared, so use a separate checkout/config
   if you want two profiles at once — or just edit `FUSIL_FLAGS` and `fleet restart`).
 - **Logs filling disk.** `fusil.out` is truncated each run start. With `--oom-verbose`

--- a/fleet/fleet.conf
+++ b/fleet/fleet.conf
@@ -17,7 +17,10 @@ INGEST=/home/ubuntu/projects/cpython-oom-findings/scripts/ingest.py
 # --- fleet size & diversity ---
 INSTANCES=                       # how many instances; empty = (nproc - 1)
 GIL_MODES="0 1"                  # PYTHON_GIL values cycled across instances (0=off,1=on);
-                                 # the two modes find DISJOINT crashes, so run both.
+                                 # the two modes find DISJOINT crashes, so run both. NOTE:
+                                 # PYTHON_GIL=0 is inherited by RUNNER_PY too, so including 0
+                                 # REQUIRES a free-threaded RUNNER_PY (else fusil fatals;
+                                 # `fleet check` enforces it). Use "1" for a non-FT runner.
 MEM_MAX=6G                       # per-instance memory cap (systemd MemoryMax); "infinity" to disable
 NICE=10                          # CPU niceness so the box stays responsive
 LOG=file                         # "file" -> $inst/fusil.out (truncated each run) | "none" -> /dev/null


### PR DESCRIPTION
Closes #78. Doc-only follow-up: `fleet.conf` + `README` now note that `GIL_MODES` containing `0` requires a free-threaded `RUNNER_PY` (PYTHON_GIL=0 is inherited by the runner), with the FT-venv fix and the `GIL_MODES="1"` fallback. Preflight already enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)