### PR TITLE
oom_dedup: match only the resolved site frame

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -236,7 +236,13 @@ class Deduper:
         chain = []
         if self.resolve_segv and (has_segv or generic_fatal or not asserts):
             chain = self._resolve(source_path)
-            candidates += [c for c in (_site_to_candidate(s) for s in chain) if c]
+            # Match only the resolved SITE (chain[0], the innermost real frame after the
+            # plumbing skip). Deeper frames are shared deallocator/eval plumbing
+            # (_Py_Dealloc, subtype_dealloc, ...) that would over-match many bugs.
+            if chain:
+                cand = _site_to_candidate(chain[0])
+                if cand:
+                    candidates.append(cand)
 
         matched = set()
         for c in candidates:

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -159,12 +159,18 @@ class TestHardening(unittest.TestCase):
         self.assertTrue(keep)
         self.assertEqual(label, "OOM-0099")
 
-    def test_secondary_chain_frame_matches_known(self):
-        # gdb chain: frame 0 is new, a deeper frame is a known bug -> known, not oomNEW.
+    def test_resolved_site_frame_matches_known(self):
+        # the resolved SITE (chain[0], after the plumbing skip) is what we match.
+        d = self._deduper(resolver=lambda sp: ["dictiter_dealloc@Objects/dictobject.c:5532",
+                                               "subtype_dealloc@Objects/typeobject.c:2876"])
+        self.assertEqual(d.decide(SEGV, source_path="s"), (True, "OOM-0006"))
+
+    def test_deeper_chain_frame_not_matched(self):
+        # a NEW site frame stays oomNEW even if a deeper (generic) frame would match --
+        # avoids over-matching shared deallocator plumbing.
         d = self._deduper(resolver=lambda sp: ["brand_new@Objects/zzz.c:9",
                                                "dictiter_dealloc@Objects/dictobject.c:5532"])
-        keep, label = d.decide(SEGV, source_path="s")
-        self.assertEqual((keep, label), (True, "OOM-0006"))
+        self.assertEqual(d.decide(SEGV, source_path="s")[1], "oomNEW")
 
 
 class TestExtractSite(unittest.TestCase):


### PR DESCRIPTION
Closes #82. Follow-up to #81. Matching all chain frames over-matched shared deallocator/eval plumbing (a negative-refcount crash hit ~10 bugs). Now matches only chain[0] + all stdout assertions; 28 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)