### PR TITLE
OOM dedup: resolve segv sites from the live ASan backtrace, not a gdb re-run

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -131,26 +131,57 @@ def match(c, snap):
     return set(), "NEW"
 
 
-# ---- segv site resolution by re-running source.py under gdb ----
+# ---- segv site resolution from the crash's own native backtrace ----
 # gdb frame:  "#5  0x.. in func (args) at Objects/foo.c:123"  or  "#0 func (..) at ..."
 _BT_FRAME = re.compile(
     r'^#\d+\s+(?:0x[0-9a-fA-F]+ in )?(\w+)\b.*?\bat '
     r'((?:Objects|Python|Modules|Include|Parser)/[\w./+-]+):(\d+)')
+# ASan/sanitizer frame already printed to stderr at crash time (merged into stdout):
+#   "    #5 0x.. in _excinfo_clear_type /abs/path/Python/crossinterp.c:1319:15"
+# The CPython source dir is matched anywhere in the absolute path; leading libc/pthread
+# frames carry no such path and are skipped, as is fatal/dump plumbing (via _BT_SKIP).
+_ASAN_FRAME = re.compile(
+    r'#\d+\s+0x[0-9a-fA-F]+\s+in\s+(\w+)\s+\S*?'
+    r'/((?:Objects|Python|Modules|Include|Parser)/[\w./+-]+\.(?:c|h)):(\d+)')
 # fatal/assert/dump plumbing -- skip so a recorded frame is the real crash/assert site
 _BT_SKIP = re.compile(r'^(fatal_error(_exit)?|_Py_FatalError\w*|_PyObject_AssertFailed'
                       r'|_Py_NegativeRefcount|_Py_DumpStack|faulthandler\w*'
                       r'|_Py_DumpExtensionModules)$')
+# Inlined refcount/atomic helpers live in these headers and show up as the innermost frame
+# of a "DECREF a freed object" segv -- skip them so the site is the real .c caller (e.g.
+# do_warn / PyContextVar_Set), not the shared Py_DECREF/_Py_atomic_load that masks dozens
+# of distinct bugs behind one line.
+_BT_SKIP_FILE = re.compile(r'(?:^|/)(?:refcount|pyatomic\w*|object)\.h$')
 _SITE = re.compile(r'^(\w+)@([\w./+-]+):(\d+)$')
+
+
+def _skip_frame(func, filename):
+    return bool(_BT_SKIP.match(func) or _BT_SKIP_FILE.search(filename))
 
 
 def extract_sites_from_bt(bt_text):
     """All real CPython frames in a gdb backtrace, innermost first, as 'func@file:line'
-    (fatal/assert/dump plumbing skipped)."""
+    (fatal/assert/dump plumbing + inlined refcount/atomic header helpers skipped)."""
     out = []
     for line in bt_text.splitlines():
         m = _BT_FRAME.match(line.strip())
-        if m and not _BT_SKIP.match(m.group(1)):
+        if m and not _skip_frame(m.group(1), m.group(2)):
             out.append("%s@%s:%s" % (m.group(1), m.group(2), m.group(3)))
+    return out
+
+
+def extract_native_sites(text):
+    """Real CPython frames from a *live* sanitizer backtrace already present in the crash's
+    captured stdout (innermost first), as 'func@file:line'. This is the actual crash -- no
+    re-run -- so it is deterministic and immune to the hash-seed/threading nondeterminism
+    that can stop a gdb re-run reproducing the same fault. ASan debug builds print this on
+    SEGV/abort; plumbing + inlined refcount/atomic header frames are skipped so the site is
+    the real .c caller."""
+    out = []
+    for m in _ASAN_FRAME.finditer(text):
+        f = _nf(m.group(2))
+        if not _skip_frame(m.group(1), f):
+            out.append("%s@%s:%s" % (m.group(1), f, m.group(3)))
     return out
 
 
@@ -231,11 +262,18 @@ class Deduper:
         if fmsg and not generic_fatal and not fmsg.lower().startswith(("segmentation", "aborted")):
             candidates.append(dict(file=None, line=None, func=None, assert_expr=None,
                                    fatal_msg=fmsg[:60]))
-        # Resolve via gdb when the stdout site is unreliable (pure segv / generic-assert
-        # fatal) or nothing matched yet -- and add every chain frame as a candidate.
+        # Resolve a crash site when the stdout assertion text is unreliable (pure segv /
+        # generic-assert fatal) or nothing matched yet. PREFER the native backtrace the
+        # crash already printed (ASan/debug build, captured in stdout): it is the actual
+        # fault, so it is deterministic -- unlike a gdb re-run, which can fail to reproduce
+        # under a different hash seed or thread timing and leave the crash mislabelled
+        # oomSEGV. Fall back to a gdb re-run of source.py only when stdout has no parseable
+        # native frames and --oom-dedup-resolve-segv is set.
         chain = []
-        if self.resolve_segv and (has_segv or generic_fatal or not asserts):
-            chain = self._resolve(source_path)
+        if has_segv or generic_fatal or not asserts:
+            chain = extract_native_sites(stdout_text)
+            if not chain and self.resolve_segv:
+                chain = self._resolve(source_path)
             # Match only the resolved SITE (chain[0], the innermost real frame after the
             # plumbing skip). Deeper frames are shared deallocator/eval plumbing
             # (_Py_Dealloc, subtype_dealloc, ...) that would over-match many bugs.

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -173,6 +173,82 @@ class TestHardening(unittest.TestCase):
         self.assertEqual(d.decide(SEGV, source_path="s")[1], "oomNEW")
 
 
+# A real ASan SEGV backtrace as captured in a session's stdout (stderr is merged in).
+# The leading nptl/libc frames carry no CPython path; the real site is frame #5.
+ASAN_SEGV = "\n".join([
+    "Fatal Python error: Segmentation fault",
+    "==910653==ERROR: AddressSanitizer: SEGV on unknown address 0x03e8000de53d",
+    "    #0 0x75087fea648c in __pthread_kill_implementation nptl/pthread_kill.c:44:76",
+    "    #3 0x75087fe45b7d in raise signal/../sysdeps/posix/raise.c:26:13",
+    "    #4 0x75087fe45caf  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x45caf)",
+    "    #5 0x579b5f3bf58c in dictiter_dealloc "
+    "/home/danzin/projects/3.16_ft_debug_asan_cpython/Objects/dictobject.c:5532:12",
+    "    #6 0x579b5f3bf58c in _PyXI_excinfo_clear "
+    "/home/danzin/projects/3.16_ft_debug_asan_cpython/Python/crossinterp.c:1374:5",
+    "    #7 0x579b5f038dba in cfunction_vectorcall_FASTCALL_KEYWORDS "
+    "/home/danzin/projects/3.16_ft_debug_asan_cpython/Objects/methodobject.c:465:24",
+    "SUMMARY: AddressSanitizer: SEGV nptl/pthread_kill.c:44:76",
+])
+
+
+class TestNativeBacktrace(unittest.TestCase):
+    """The fix: resolve a SEGV from the native backtrace ALREADY in stdout (ASan debug
+    build), with no gdb re-run -- so a crash whose source.py would not reproduce under a
+    fresh hash seed / thread timing is still labelled, not dumped as oomSEGV."""
+
+    def _deduper(self, resolver=None):
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(SNAPSHOT)
+        self.addCleanup(os.unlink, path)
+        # resolve_segv stays False: prove dedup works from stdout WITHOUT gdb.
+        return oom_dedup.Deduper(path, resolve_segv=resolver is not None, segv_resolver=resolver)
+
+    def test_extract_native_skips_libc_returns_real_site(self):
+        sites = oom_dedup.extract_native_sites(ASAN_SEGV)
+        self.assertEqual(sites[0], "dictiter_dealloc@Objects/dictobject.c:5532")
+
+    def test_asan_segv_matches_known_without_gdb(self):
+        # OOM-0006 is keyed on dictiter_dealloc in the snapshot; no resolver provided.
+        keep, label = self._deduper().decide(ASAN_SEGV, source_path=None)
+        self.assertTrue(keep)
+        self.assertEqual(label, "OOM-0006")
+
+    def test_asan_segv_unknown_site_is_new_not_segv(self):
+        stdout = ASAN_SEGV.replace("dictiter_dealloc", "brand_new_func").replace(
+            "Objects/dictobject.c:5532", "Objects/zzz.c:9")
+        keep, label = self._deduper().decide(stdout, source_path=None)
+        self.assertTrue(keep)
+        self.assertEqual(label, "oomNEW")
+
+    def test_native_backtrace_preferred_over_gdb_rerun(self):
+        # stdout has a usable native frame -> the (would-be-wrong) resolver is never called.
+        called = []
+        d = self._deduper(resolver=lambda sp: called.append(sp) or ["x@Objects/other.c:1"])
+        self.assertEqual(d.decide(ASAN_SEGV, source_path="s")[1], "OOM-0006")
+        self.assertEqual(called, [])
+
+    def test_bare_segv_no_native_no_resolver_stays_segv(self):
+        # non-ASan / no captured backtrace and resolution disabled -> oomSEGV (fallback kept).
+        self.assertEqual(self._deduper().decide(SEGV, source_path="s"), (True, "oomSEGV"))
+
+    def test_inlined_decref_atomic_header_frames_skipped(self):
+        # A "DECREF a freed object" segv: innermost frames are the inlined atomic/Py_DECREF
+        # helpers in headers -> the site must be the real .c caller (code_dealloc), not the
+        # shared header line that would mask dozens of distinct bugs as one.
+        bt = "\n".join([
+            "==1==ERROR: AddressSanitizer: SEGV on unknown address",
+            "    #4 0x0 in _Py_atomic_load_uint32_relaxed "
+            "/p/./Include/cpython/pyatomic_gcc.h:367:10",
+            "    #5 0x0 in Py_DECREF /p/./Include/refcount.h:345:22",
+            "    #6 0x0 in code_dealloc /p/Objects/codeobject.c:2440:9",
+        ])
+        sites = oom_dedup.extract_native_sites(bt)
+        self.assertEqual(sites[0], "code_dealloc@Objects/codeobject.c:2440")
+        # and it matches the catalog bug keyed on that .c line, not labelled oomNEW.
+        self.assertEqual(self._deduper().decide(bt, source_path=None), (True, "OOM-0003"))
+
+
 class TestExtractSite(unittest.TestCase):
     def test_skips_plumbing_returns_real_site(self):
         self.assertEqual(oom_dedup.extract_site_from_bt(BT),


### PR DESCRIPTION
Closes #84.

### What

In-loop segv resolution re-ran `source.py` under gdb to recover the crash site. That re-run is nondeterministic (fresh `PYTHONHASHSEED`, gdb thread-timing, 120s cap), so resolvable crashes were parked as `oomSEGV` and never deduped.

On an ASan/debug build the crash already prints its C backtrace to stderr at fault time, which fusil merges into the session `stdout`. This parses that backtrace directly (`extract_native_sites`) and prefers it over the gdb re-run (now a fallback only) — deterministic, no subprocess, works even without `--oom-dedup-resolve-segv`.

Also skips inlined refcount/atomic header frames (`refcount.h`, `pyatomic*.h`, `object.h`) so the resolved site is the real `.c` caller rather than the shared `Py_DECREF` / `_Py_atomic_load` line that masks many distinct bugs.

### Validation

- New tests: `TestNativeBacktrace` (real ASan sample) + an inlined-DECREF regression test; **31 dedup tests pass**, ruff clean.
- Swept a real 759-dir fleet run: `needs-gdb: 0` (every segv resolved from stdout), 757/759 dedupe to the existing catalog, 2 genuinely-new sites surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)