### PR TITLE
OOM fuzzing Phase 2: sweep class constructors and methods

### DIFF
--- a/doc/oom-fuzzing.md
+++ b/doc/oom-fuzzing.md
@@ -25,14 +25,45 @@ signal fusil watches for. So **no per-iteration subprocess isolation is needed**
 
 ## Phases
 
-- **Phase 1 (this doc, implemented first):** `_testcapi.set_nomemory` injection,
+- **Phase 1 (implemented):** `_testcapi.set_nomemory` injection,
   **module-level functions only**, no refactor.
-- **Phase 2:** extract a single call-emission seam
-  (`_emit_call(target, name, args, harness=...)`) so the OOM/plain/JIT paths
-  share one primitive, then extend OOM coverage to methods, constructors, and
-  returned objects (where the high-value unchecked-allocation bugs live).
+- **Phase 2 (implemented — constructors + methods):** extend OOM coverage to
+  class **constructors** and **methods**, where the high-value unchecked-allocation
+  bugs live (e.g. OOM-0030 is a str-subclass constructor bug). Done with a targeted
+  `_generate_oom_class_fuzzing(prefix, class_name, class_obj)` that reuses the existing
+  `oom_call` harness rather than the originally-sketched `_emit_call` seam refactor —
+  the seam (unifying the plain/JIT/OOM call-emission paths) is deferred as separate
+  cleanup since it touches the working plain and JIT paths for no extra coverage.
+  Returned-object methods (depth > 1) remain a future Phase 2c.
 - **Phase 3:** libfiu / `LD_PRELOAD` system-malloc injection (reaches foreign C
   libraries that `set_nomemory` cannot), driven via the child process env.
+
+## Phase 2 specification (classes)
+
+Gated behind `options.oom_fuzz`, after the Phase 1 function sweeps and bounded by two
+new options (so OOM-mode cost is controlled separately from the non-OOM
+`--classes-number`/`--methods-number`):
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--oom-classes` | `5` | Classes to OOM-fuzz per script (constructor sweep + method sweeps); `0` disables class fuzzing in OOM mode. |
+| `--oom-methods` | `5` | Method sweeps per instantiated class. |
+
+`_generate_oom_class_fuzzing` emits, per chosen class:
+
+1. **Constructor sweep** — the class object is itself the callable:
+   `oom_call("oc<i>:<mod>.<Class>", getattr(fuzz_target_module, "<Class>", None), <ctor args>)`.
+2. **One live instance**, built once *outside* any sweep via the existing `callFunc`
+   helper in a `try/except`, so methods run against a real object (not re-created 1000×).
+3. **Method sweeps** on that instance (discovered at generation time via
+   `_get_object_methods`, blacklist-respecting), guarded by
+   `if inst is not None and inst is not SENTINEL_VALUE:` — each is
+   `oom_call("oc<i>m<j>:<mod>.<Class>.<method>", getattr(inst, "<method>", None), <args>)`.
+   The safe `getattr(..., None)` plus the harness guard `if ... or func is None: return`
+   make a missing bound method a no-op sweep, never a raise.
+
+The non-OOM class/object blocks stay gated off in OOM mode (the function loop falls
+through to the class loop, then returns).
 
 ---
 

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -353,6 +353,21 @@ class Fuzzer(Application):
             default=10,
         )
         oom_options.add_option(
+            "--oom-classes",
+            help="Number of classes to OOM-fuzz per script: each gets a constructor "
+                 "sweep plus method sweeps on a live instance (0 disables class "
+                 "fuzzing in OOM mode, default: 5)",
+            type="int",
+            default=5,
+        )
+        oom_options.add_option(
+            "--oom-methods",
+            help="Number of method sweeps to generate per OOM-fuzzed class instance "
+                 "(default: 5)",
+            type="int",
+            default=5,
+        )
+        oom_options.add_option(
             "--oom-verbose",
             help="In OOM mode, also print the sweep start index before each "
                  "injection so the exact failing allocation can be pinpointed on "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -531,7 +531,7 @@ class WritePythonCode(WriteCode):
                     # (segfault/abort) terminates the process, the signal fusil scores.
                     # remove_mem_hooks runs in the inner finally so the except clauses
                     # allocate with the allocator restored.
-                    if not _OOM_AVAILABLE:
+                    if not _OOM_AVAILABLE or func is None:
                         return
                     print("[OOM] " + label, file=stderr)
                     for _start in range(_OOM_MAX_START):
@@ -618,8 +618,24 @@ class WritePythonCode(WriteCode):
 
         self.emptyLine()
 
-        # Phase 1 OOM mode targets module-level functions only.
+        # OOM mode (Phase 2): after module-level function sweeps, sweep class
+        # constructors and methods -- where the high-value unchecked-allocation bugs
+        # live -- then stop (the non-OOM class/object blocks below are skipped).
         if self.options.oom_fuzz:
+            if self.module_classes and self.options.oom_classes > 0:
+                self.write_print_to_stderr(
+                    0,
+                    f'"--- OOM-fuzzing {len(self.module_classes)} classes in {self.module_name} ---"',
+                )
+                for i in range(self.options.oom_classes):
+                    class_name = choice(self.module_classes)
+                    if class_name in OBJECT_BLACKLIST:
+                        continue
+                    try:
+                        class_obj = getattr(self.module, class_name)
+                    except AttributeError:
+                        continue
+                    self._generate_oom_class_fuzzing(f"oc{i + 1}", class_name, class_obj)
             return
 
         # Fuzz classes (instantiate and call methods)
@@ -1033,6 +1049,62 @@ class WritePythonCode(WriteCode):
         self.write(0, f'oom_call("{label}", getattr(fuzz_target_module, "{func_name}"),')
         self._write_arguments_for_call_lines(num_args, 1)
         self.write(0, ")")
+        self.emptyLine()
+
+    def _generate_oom_class_fuzzing(
+        self, prefix: str, class_name: str, class_obj: type
+    ) -> None:
+        """Emits an OOM sweep over a class constructor and, on a live instance, its methods.
+
+        Phase 2 of OOM fuzzing: constructors and methods reach allocation paths the
+        module-level function sweep cannot (e.g. OOM-0030 is a str-subclass constructor
+        bug). The constructor is swept directly -- the class is itself the callable -- and
+        methods are swept on a single instance built once outside the sweep, so each runs
+        against a real object. Argument values are built once at the oom_call(...)
+        expression; arming happens inside oom_call.
+        """
+        # 1. Constructor sweep -- the class object is the callable.
+        ctor_args = class_arg_number(class_name, class_obj)
+        ctor_label = f"{prefix}:{self.module_name}.{class_name}"
+        self.write(0, f"# OOM sweep: {class_name}() constructor")
+        self.write(0, f'oom_call("{ctor_label}", getattr(fuzz_target_module, "{class_name}", None),')
+        self._write_arguments_for_call_lines(ctor_args, 1)
+        self.write(0, ")")
+        self.emptyLine()
+
+        # 2. Discover methods (generation-time, blacklist-respecting). None -> done.
+        methods = self._get_object_methods(class_obj, class_name)
+        if not methods or self.options.oom_methods < 1:
+            return
+        method_names = sorted(methods.keys())
+
+        # 3. Build one live instance (plain, outside any sweep) to fuzz methods against.
+        inst = f"oom_inst_{prefix}_{class_name.lower().replace('.', '_')}"
+        self.write(0, f"{inst} = None")
+        self.write(0, "try:")
+        self.write(1, f'{inst} = callFunc("{prefix}_init", "{class_name}",')
+        self._write_arguments_for_call_lines(ctor_args, 2)
+        self.write(1, ")")
+        self.write(0, "except Exception:")
+        self.write(1, f"{inst} = None")
+        self.emptyLine()
+
+        # 4. Method sweeps on the live instance.
+        self.write(0, f"if {inst} is not None and {inst} is not SENTINEL_VALUE:")
+        saved = self.addLevel(1)
+        for j in range(self.options.oom_methods):
+            m_name = choice(method_names)
+            m_obj = methods[m_name]
+            min_arg, max_arg = get_arg_number(m_obj, m_name, 0)
+            num_args = randint(min_arg, max_arg)
+            m_label = f"{prefix}m{j + 1}:{self.module_name}.{class_name}.{m_name}"
+            self.write(0, f"# OOM sweep: {class_name}.{m_name}()")
+            self.write(0, f'oom_call("{m_label}", getattr({inst}, "{m_name}", None),')
+            self._write_arguments_for_call_lines(num_args, 1)
+            self.write(0, ")")
+        self.write(0, f"del {inst}")
+        self.write(0, "collect()")
+        self.restoreLevel(saved)
         self.emptyLine()
 
     def _generate_and_write_call(

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -1,8 +1,9 @@
-"""Tests for OOM (out-of-memory) fuzzing mode code generation (Phase 1).
+"""Tests for OOM (out-of-memory) fuzzing mode code generation (Phases 1 & 2).
 
 These verify that ``--oom-fuzz`` makes ``WritePythonCode`` emit the set_nomemory
-boilerplate, the ``oom_call`` dense-sweep harness, and per-function sweep sites,
-and that none of that appears when the mode is off (gating / regression).
+boilerplate, the ``oom_call`` dense-sweep harness, per-function sweep sites
+(Phase 1), and -- for modules with classes -- constructor and method sweeps
+(Phase 2); and that none of that appears when the mode is off (gating / regression).
 
 The fixture builds a ``MagicMock`` options object with the few real-typed
 attributes the generator needs; it does not depend on the (currently stale)
@@ -10,6 +11,7 @@ attributes the generator needs; it does not depend on the (currently stale)
 """
 
 import ast
+import json
 import math
 import os
 import sys
@@ -44,6 +46,10 @@ def _make_options(oom_fuzz, oom_verbose=False):
     o.classes_number = 0
     o.objects_number = 0
     o.methods_number = 2
+    # OOM class fuzzing (Phase 2). Real ints so `range(...)` / `> 0` work; default
+    # 0 keeps the function-only Phase-1 tests' oom_call counts exact.
+    o.oom_classes = 0
+    o.oom_methods = 0
     # JIT options (WriteJITCode is constructed unconditionally); OOM mode never
     # dispatches to it, so legacy defaults are fine.
     o.jit_fuzz = False
@@ -59,16 +65,21 @@ def _make_options(oom_fuzz, oom_verbose=False):
     return o
 
 
-def _generate(oom_fuzz, oom_verbose=False):
-    """Generate a fuzzing script against the ``math`` module and return its source."""
+def _generate(oom_fuzz, oom_verbose=False, module=math, module_name="math",
+              oom_classes=0, oom_methods=0, test_private=False):
+    """Generate a fuzzing script against ``module`` and return its source."""
     parent = MagicMock()
-    parent.options = _make_options(oom_fuzz, oom_verbose)
+    options = _make_options(oom_fuzz, oom_verbose)
+    options.oom_classes = oom_classes
+    options.oom_methods = oom_methods
+    options.test_private = test_private
+    parent.options = options
     parent.filenames = ["/bin/sh"]
     fd, path = tempfile.mkstemp(suffix="_oom_test.py")
     os.close(fd)
     try:
         writer = WritePythonCode(
-            parent, path, math, "math",
+            parent, path, module, module_name,
             threads=False, _async=False, plugin_manager=None,
         )
         writer.generate_fuzzing_script()
@@ -129,6 +140,43 @@ class TestOOMFuzzGeneration(unittest.TestCase):
             "remove_mem_hooks",
         ):
             self.assertNotIn(marker, src, f"unexpected OOM artifact {marker!r} in non-OOM script")
+
+
+class TestOOMClassFuzzGeneration(unittest.TestCase):
+    """Phase 2: constructor + method sweeps for module classes (json has classes)."""
+
+    def test_constructor_and_method_sweeps_emitted(self):
+        src = _generate(oom_fuzz=True, module=json, module_name="json",
+                        oom_classes=2, oom_methods=3)
+        ast.parse(src)  # valid Python
+        # A constructor sweep: the class object is the swept callable.
+        self.assertIn("() constructor", src)
+        self.assertIn('oom_call("oc1:json.', src)
+        self.assertIn('getattr(fuzz_target_module, ', src)
+        # A live instance is built once (outside the sweep) for method fuzzing.
+        self.assertIn('callFunc("oc1_init"', src)
+        self.assertIn("is not SENTINEL_VALUE:", src)
+        self.assertIn("oom_inst_oc1_", src)
+        # Method sweeps run on that instance: oom_call over a bound method.
+        self.assertRegex(src, r'oom_call\("oc1m\d+:json\.')
+        self.assertRegex(src, r"getattr\(oom_inst_oc1_\w+, ")
+
+    def test_oom_classes_zero_disables_class_fuzzing(self):
+        src = _generate(oom_fuzz=True, module=json, module_name="json",
+                        oom_classes=0, oom_methods=3)
+        ast.parse(src)
+        self.assertNotIn("constructor", src)
+        self.assertNotIn("oom_inst_", src)
+        # function sweeps still present
+        self.assertIn("oom_call(", src)
+
+    def test_method_target_uses_safe_getattr_default(self):
+        # getattr(inst, "m", None) + the harness's `func is None` guard means a
+        # missing bound method degrades to a no-op sweep, never a NameError/raise.
+        src = _generate(oom_fuzz=True, module=json, module_name="json",
+                        oom_classes=1, oom_methods=2)
+        self.assertIn(", None)", src)               # safe getattr default on method
+        self.assertIn("if not _OOM_AVAILABLE or func is None:", src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #86.

### What

Extends `--oom-fuzz` beyond module-level functions to **class constructors and methods**, where the high-value unchecked-allocation bugs live (e.g. OOM-0030 is a str-subclass constructor bug).

Implemented with a targeted `_generate_oom_class_fuzzing(prefix, class_name, class_obj)` that **reuses the existing `oom_call` harness** — not the `_emit_call` seam refactor the doc originally sketched (deferred as separate cleanup, since it would touch the working plain/JIT paths for no extra coverage). Per chosen class it emits:

1. **Constructor sweep** — the class object is itself the swept callable.
2. **One live instance**, built once *outside* any sweep via the existing `callFunc` helper in a `try/except`, so methods run against a real object (not re-created 1000×).
3. **Method sweeps** on that instance — methods discovered at generation time via `_get_object_methods` (blacklist-respecting), guarded by `is not None and is not SENTINEL_VALUE`, each `oom_call(..., getattr(inst, "m", None), ...)`.

New bounded options **`--oom-classes`** (default 5) and **`--oom-methods`** (default 5); `--oom-classes 0` disables class fuzzing in OOM mode. The `oom_call` harness gains `or func is None: return` so a missing bound method degrades to a no-op, never a raise.

### Validation

- Non-OOM and Phase-1 generation unchanged (regression-checked).
- `--only-generate` sample on `json` compiles; constructor + guarded method sweeps emitted as expected.
- A real `--oom-fuzz` run on `json` executes the sweeps and completes cleanly.
- New `TestOOMClassFuzzGeneration` (constructor+method sweeps, `--oom-classes 0` gating, safe-getattr); **40 OOM tests pass**, no new lint.
- `doc/oom-fuzzing.md` marks Phase 2 implemented + adds the class spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)