### PR TITLE
OOM dedup: print a symbolized ASan backtrace on target abort (handle_abort)

### DIFF
--- a/fusil/process/env.py
+++ b/fusil/process/env.py
@@ -6,6 +6,27 @@ from fusil.project_agent import ProjectAgent
 from fusil.unicode_generator import IntegerGenerator
 
 
+def augment_asan_options(value):
+    """Return ASAN_OPTIONS with crash-diagnostic defaults filled in.
+
+    ``handle_abort=1`` makes AddressSanitizer print a *symbolized* C backtrace when the
+    target ``abort()``s (a failed assertion, ``_Py_NegativeRefcount``, ``Py_FatalError``…);
+    without it an abort prints no native backtrace. ``abort_on_error=1`` keeps the process
+    exiting via SIGABRT after ASan prints, instead of ASan's plain ``exitcode`` -- so the
+    crash is still scored as a signal death (no scoring change) and other ASan errors
+    (segv/UAF) likewise abort consistently. The backtrace lands in the captured stdout,
+    letting the in-loop OOM dedup resolve the crash site straight from stdout instead of a
+    nondeterministic gdb re-run. Keys the caller already set are preserved; this is a no-op
+    on non-ASan builds, which ignore ASAN_OPTIONS entirely.
+    """
+    opts = [p for p in (value or "").split(":") if p]
+    have = {p.split("=", 1)[0] for p in opts}
+    for key, val in (("handle_abort", "1"), ("abort_on_error", "1")):
+        if key not in have:
+            opts.append("%s=%s" % (key, val))
+    return ":".join(opts)
+
+
 class EnvironmentVariable:
     def __init__(self, name, max_count=1):
         self.name = name
@@ -175,6 +196,11 @@ class Environment(ProjectAgent):
                         "Nul byte in environment variable value is forbidden!"
                     )
                 env[name] = value
+
+        # Make target aborts (assertions, _Py_NegativeRefcount, Py_FatalError) print a
+        # symbolized ASan backtrace to stdout, so in-loop crash dedup can resolve the site
+        # without re-running under gdb. No-op on non-ASan builds. See augment_asan_options.
+        env["ASAN_OPTIONS"] = augment_asan_options(env.get("ASAN_OPTIONS"))
 
         # Write result to logs
         self.info("Environment: %r" % env)

--- a/tests/python/test_handle_abort.py
+++ b/tests/python/test_handle_abort.py
@@ -1,0 +1,88 @@
+"""Tests for the handle_abort crash-diagnostics path.
+
+`augment_asan_options` ensures the target prints a symbolized ASan backtrace on abort
+(handle_abort) while still exiting via SIGABRT (abort_on_error), so the in-loop OOM dedup can
+resolve an abort's crash site straight from stdout -- no gdb re-run. Pure-Python.
+"""
+import os
+import tempfile
+import unittest
+
+from fusil.process.env import augment_asan_options
+from fusil.python import oom_dedup
+
+
+class TestAugmentAsanOptions(unittest.TestCase):
+    def _keys(self, s):
+        return {p.split("=", 1)[0] for p in s.split(":") if p}
+
+    def test_empty_gets_both_defaults(self):
+        self.assertEqual(augment_asan_options(None), "handle_abort=1:abort_on_error=1")
+        self.assertEqual(augment_asan_options(""), "handle_abort=1:abort_on_error=1")
+
+    def test_existing_options_preserved_and_extended(self):
+        out = augment_asan_options("detect_leaks=0")
+        self.assertTrue(out.startswith("detect_leaks=0:"))
+        self.assertEqual(self._keys(out), {"detect_leaks", "handle_abort", "abort_on_error"})
+
+    def test_explicit_keys_not_overridden(self):
+        # A caller who set handle_abort=0 on purpose keeps it; only the missing key is added.
+        out = augment_asan_options("handle_abort=0")
+        self.assertIn("handle_abort=0", out)
+        self.assertNotIn("handle_abort=1", out)
+        self.assertIn("abort_on_error=1", out)
+
+    def test_idempotent(self):
+        once = augment_asan_options("detect_leaks=0")
+        self.assertEqual(augment_asan_options(once), once)
+
+
+# A negrefcount abort the way the target prints it with handle_abort=1: the faulthandler
+# fatal + object dump, then ASan's symbolized C backtrace (stderr merged into stdout). The
+# innermost real frame after the _PyObject_AssertFailed/_Py_NegativeRefcount detector plumbing
+# is the dealloc cascade -- here tuple_dealloc, the discriminating site.
+ABORT_STDOUT = """\
+./Include/refcount.h:520: _Py_NegativeRefcount: Assertion failed: object has negative ref count
+Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed
+object type name: MemoryError
+AddressSanitizer:DEADLYSIGNAL
+==123==ERROR: AddressSanitizer: ABRT on unknown address 0x000000000000
+    #8 0x55 in _PyObject_AssertFailed /src/Objects/object.c:3278:5
+    #9 0x55 in _Py_NegativeRefcount /src/Objects/object.c:275:5
+    #12 0x55 in tuple_dealloc /src/Objects/tupleobject.c:277:9
+    #13 0x55 in subtype_dealloc /src/Objects/typeobject.c:2876:5
+    #14 0x55 in _Py_Dealloc /src/Objects/object.c:3319:5
+    #17 0x55 in list_dealloc /src/Objects/listobject.c:567:13
+"""
+
+SNAPSHOT = "\n".join([
+    "# oom_id\tkind\tkeytype\tkey",
+    "OOM-9001\tabort\tfunc\tObjects/tupleobject.c:tuple_dealloc",
+    "OOM-9001\tabort\tline\tObjects/tupleobject.c:277",
+])
+
+
+class TestDeduperResolvesAbortFromStdout(unittest.TestCase):
+    def test_extract_native_sites_skips_detector_plumbing(self):
+        sites = oom_dedup.extract_native_sites(ABORT_STDOUT)
+        # _PyObject_AssertFailed and _Py_NegativeRefcount are detector plumbing -> skipped,
+        # so the innermost reported frame is the real dealloc-cascade site.
+        self.assertEqual(sites[0], "tuple_dealloc@Objects/tupleobject.c:277")
+
+    def test_decide_resolves_abort_without_gdb(self):
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        os.write(fd, SNAPSHOT.encode())
+        os.close(fd)
+        try:
+            # resolve_segv=False and no resolver: the only way this resolves is the native
+            # backtrace in stdout -- exactly what handle_abort=1 provides for aborts.
+            d = oom_dedup.Deduper(path, resolve_segv=False)
+            keep, label = d.decide(ABORT_STDOUT, source_path=None)
+            self.assertTrue(keep)
+            self.assertEqual(label, "OOM-9001")
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #88.

## Implementation

`fusil/process/env.py`:

- New `augment_asan_options(value)` — fills in `handle_abort=1` and `abort_on_error=1` on the child's `ASAN_OPTIONS`, preserving any keys the caller already set. Idempotent; no-op on non-ASan builds (which ignore `ASAN_OPTIONS`).
- `Environment.create()` applies it when building the child environment, after the copy/generate steps.

### Why these two options

- **`handle_abort=1`** — ASan catches `SIGABRT` and prints a *symbolized* C backtrace. That backtrace is captured in stdout (stderr is merged), and `oom_dedup.extract_native_sites()` already parses this exact `#N 0x.. in func /path/file.c:line` format and prefers it over a gdb re-run. So abort sites now resolve deterministically from stdout — no second interpreter launch under gdb, no hash-seed/thread-timing nondeterminism, no spurious `oomSEGV`.
- **`abort_on_error=1`** — keeps the process exiting via `SIGABRT` after ASan prints (instead of ASan's plain `exitcode=1`), so `WatchProcess` still scores it as a signal death (`signal_score`, unchanged). As a side effect, ASan-detected segv/UAF errors also exit via SIGABRT consistently (was `exitcode=1`); both are still detected textually by `WatchStdout` (`AddressSanitizer` / `Fatal Python error`), and `signal_score (1.0) >= exitcode_score (0.50)`, so nothing is scored lower than before.

### Verified

- Crash scoring is unaffected: in the OOM abort output, `Fatal Python error` (score 1.0) precedes the `MemoryError` kill-word, so `WatchStdout.live()` reaches 1.0 and stops before the kill line either way; the new ASan backtrace is printed *after* the abort and doesn't enter scoring.
- End-to-end: captured a real `_Py_NegativeRefcount` abort with `handle_abort=1:abort_on_error=1` (exit code stays 134/SIGABRT) and fed it to `Deduper.decide(resolve_segv=False)` — it resolved the dealloc-cascade site from stdout with no gdb.

## Tests

`tests/python/test_handle_abort.py` (6 tests): `augment_asan_options` merging / explicit-key preservation / idempotency, and that the deduper resolves a negrefcount abort's cascade straight from the handle_abort stdout with no gdb resolver. Full `oom_dedup` suite (40 tests) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)