### PR TITLE
OOM Phase 4: stateful call sequences (`--oom-seq`)

### DIFF
--- a/doc/oom-fuzzing.md
+++ b/doc/oom-fuzzing.md
@@ -37,6 +37,14 @@ signal fusil watches for. So **no per-iteration subprocess isolation is needed**
   Returned-object methods (depth > 1) remain a future Phase 2c.
 - **Phase 3:** libfiu / `LD_PRELOAD` system-malloc injection (reaches foreign C
   libraries that `set_nomemory` cannot), driven via the child process env.
+- **Phase 4 (prototype — stateful call sequences, behind `--oom-seq`):** let one OOM scan
+  exercise *several* calls so an allocation failure in one call can corrupt state that a
+  *later* call trips over (the cross-call "stale state" class — OOM-0033, OOM-0035, the
+  stale-exception family). Built on a **bounded failure window**
+  (`set_nomemory(start, start+k)`, which fails `k` allocations then auto-resumes) so probe
+  steps can run past the failure. Phase 4a (method chains + function sequences) is
+  implemented; producer→consumer (4b) and mutate-reread (4c) are deferred. Full design in
+  [`oom-sequences.md`](oom-sequences.md).
 
 ## Phase 2 specification (classes)
 

--- a/doc/oom-sequences.md
+++ b/doc/oom-sequences.md
@@ -1,0 +1,241 @@
+# OOM stateful call sequences ("corrupt-then-probe")
+
+**Idea 1**, prototyped behind `--oom-seq` (default off): let a single OOM scan exercise
+*more than one* call, so an allocation failure during one call can leave damaged state
+that a *later* call trips over. This targets the cross-call "stale state" bug class that
+the current single-call harness can only find by accident.
+
+Companion to [`oom-fuzzing.md`](oom-fuzzing.md) (Phase 1 = module functions, Phase 2 =
+constructors/methods, Phase 3 = libfiu). This is **Phase 4**.
+
+## Motivation
+
+The current harness (`oom_call`) is *stateless and single-call*: it sweeps the failure
+point through **one** call and can only catch a bug when the allocation failure **and**
+the thing that trips over the damage happen inside that one call. But several of our own
+findings are inherently multi-step — damage in step A, crash in step B:
+
+| Bug | Step A (damage under OOM) | Step B (clean-ish step that crashes) |
+|-----|---------------------------|--------------------------------------|
+| **OOM-0035** | `StringIO.write…` grows the buffer, leaves uninitialized `Py_UCS4` garbage | `getvalue()` scans the garbage → bad `maxchar` |
+| **OOM-0033** | `sys.path[:] = str` over-decrefs an entry | `__import__` walks the freed entry |
+| **stale-exception family** (0008/0010/0011/0015/0025/0032) | an OOM error path leaves an exception *pending* | a later op asserts none is pending |
+
+We caught these mostly by luck (Phase-2 method sweeps re-run the same method ~1000×, so
+accumulation happened inside one label). Making sequences first-class generalizes that.
+
+## Mechanism
+
+Two ingredients: a **bounded failure window** so execution can continue past the failure,
+and a **multi-step body** swept by that window.
+
+### 1. The windowed `set_nomemory` primitive (the key)
+
+`set_nomemory(start, stop)` (confirmed from `Modules/_testcapi/mem.c`): a global counter
+increments on every allocation; allocation #`n` fails iff `n > start` **and**
+(`stop <= 0` **or** `n <= stop`). So:
+
+- `set_nomemory(start, 0)` — the current sweep: fail allocation `start+1` and **every one
+  after, forever**.
+- `set_nomemory(start, start + k)` — fail exactly **k** allocations (`start+1 … start+k`),
+  then **resume succeeding**. The hook stays installed as a transparent passthrough (it
+  does *not* auto-uninstall — `remove_mem_hooks()` is still required), the counter keeps
+  ticking globally.
+
+That auto-resume is exactly what a sequence needs: with the current fail-*forever* mode,
+the moment you cross the threshold every later allocation also fails, so probe steps can't
+allocate and do nothing. A bounded window fails a burst, then lets execution continue so
+later steps run on whatever state the burst left behind.
+
+### 2. The `oom_run` harness (generated, gated)
+
+A sequence is emitted as a 0-arg thunk whose body is the multi-step scenario; `oom_run`
+sweeps the failure window around calling it:
+
+```python
+def oom_run(label, thunk, window=1):
+    if not _OOM_AVAILABLE:
+        try: thunk()
+        except BaseException: pass
+        return
+    print("[OOM-SEQ] " + label, file=stderr)
+    for _start in range(_OOM_MAX_START):
+        if _OOM_VERBOSE:
+            print("[OOM-SEQ]   start=" + str(_start) + " window=" + str(window), file=stderr)
+        _set_nomemory(_start, (_start + window) if window > 0 else 0)
+        try:
+            try:
+                thunk()
+            finally:
+                _remove_mem_hooks()
+        except MemoryError:
+            pass
+        except SystemError:
+            print("[OOM-SEQ] SystemError in " + label, file=stderr)
+        except BaseException:
+            pass
+```
+
+Because the counter resets on each arm and the window is armed **once** before the whole
+thunk, sweeping `_start` walks the failure burst across the sequence's allocation
+timeline: low `_start` lands the burst inside step A; once A's allocations are exhausted,
+higher `_start` lands it inside step B (which is now operating on A's output/state). One
+sweep covers "fail inside A" *and* "fail inside B after A set things up" — no explicit
+corruptor/probe split is needed in the mechanism; the corruptor/probe *structure* is just
+how we pick steps so that step _k_ tends to use state from step _k-1_.
+
+### 3. Generated shape
+
+The thunk guards each step so a step that fails (e.g. the corruptor `MemoryError`s)
+doesn't abort the tail — the probe still runs. Result vars are pre-bound to `None`:
+
+```python
+def _oom_seq_f1():
+    r1 = None
+    try:
+        r1 = getattr(fuzz_target_module, "dumps")(<arg>)
+    except BaseException:
+        pass
+    try:
+        getattr(fuzz_target_module, "loads")(r1)          # probe reuses A's (maybe half-built) result
+    except BaseException:
+        pass
+oom_run("f1:json[dumps>loads]", _oom_seq_f1, window=1)
+```
+
+A segfault/abort isn't catchable, so it still terminates the process and scores; only
+`MemoryError`/ordinary exceptions are swallowed per step, and `SystemError` is surfaced.
+
+## Assessment: variable-N failure windows
+
+> *Your question: does `set_nomemory(start, N)` with variable N make sense, and does
+> "variable number of failures" add useful variability the way module mixing would?*
+
+**Yes — and it's the enabling primitive above, not merely a variability knob.** The
+windowed mode is what makes probe steps runnable. Beyond that, the window width `k` is a
+genuine, *structured* coverage dimension — it selects **which slice of the failure space**
+you probe:
+
+| Window | What it tests | Yield |
+|--------|---------------|-------|
+| `k = 1` (recommended default) | a *single* unchecked allocation fails, program otherwise runs → both the immediate error path **and** deferred/aftermath bugs. Purest "what if exactly this alloc fails?" | highest signal |
+| `k` small (2–8) | a short **burst** fails → error paths that only break when *several* allocations fail (retry loops, multi-alloc ops partially failing) | real, lower density |
+| `k = 0` (fail-forever, current) | the operation **cannot allocate at all** → the immediate cleanup/error path of one call | already mined for all 35 bugs |
+
+So this axis is **orthogonal and complementary** to Idea 2's module-mixing: variable-N
+varies the *failure pattern*; module-mixing varies the *code surface*. Variable-N is much
+cheaper and more targeted, and it's the right first lever — fold it into Idea 1 as the
+injection primitive (`--oom-window`, default 1), optionally randomizing `k` per sequence
+for extra spread. Frame it as coverage, not noise.
+
+**Cost to be honest about:** auto-resume means the crash can occur *far* from the
+injection point (causal distance grows with `k` and sequence length), which weakens the
+"which allocation caused it" link and makes minimization harder. `k = 1` keeps it tight;
+fail-forever keeps the crash nearest the first failure. The `[OOM-SEQ] start=` markers +
+site-keyed dedup bound the damage, and the existing subprocess self-sweep repro convention
+already handles allocation-baseline drift.
+
+## Step selection (how steps come to share state)
+
+In increasing sophistication:
+
+1. **Phase 4a — independent steps over shared state** *(implemented)*. Two emitters,
+   both with steps that interact only through *shared* state (no return-value threading):
+   - **method chains** (`_generate_oom_class_fuzzing` under `--oom-seq`): one `oom_run`
+     over `oom_seq_len` methods of Phase 2's single live instance — the instance is the
+     shared state. Directly matches OOM-0035 (`write…` then `getvalue()`).
+   - **function sequences** (`_generate_oom_function_sequence`): `oom_seq_len` module
+     functions in a row — shared state is module/interpreter globals (a pending exception,
+     specializer/GC state), targeting the stale-exception family.
+2. **Phase 4b — producer → consumer** *(deferred)*. Capture a call's return value and feed
+   it to the next (`r = f(...); g(r)`), reusing fusil's object-passing. The shared state is
+   the returned object, possibly half-built under OOM. The thunk form already supports it;
+   only the generator needs to thread `r_k → arg_{k+1}`.
+3. **Phase 4c — mutate-then-reread shared state** *(deferred, research-y)*. `lst[:] = …`
+   then read it; `sys.path` mutation then import (OOM-0033). Higher-level and often
+   module-specific.
+
+## CLI options (new, gated behind `--oom-fuzz`)
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--oom-seq` | `False` | Emit stateful call sequences. **Opt-in**, so the default fleet behavior and baseline are unchanged and `--oom-seq` can be A/B'd. |
+| `--oom-seq-len` | `3` | Steps per sequence (corruptor + probes). |
+| `--oom-window` | `1` | Failure-burst width `k` for windowed injection; `0` = legacy fail-forever (only sensible for single calls). Applies to `oom_run`; `oom_call` stays fail-forever. |
+
+## Labeling & dedup
+
+- Sequence marker `[OOM-SEQ] <label>` once; `--oom-verbose` prints `start=`/`window=` per
+  iteration and (added) each step's sublabel as it executes, so the last line printed
+  before the signal pinpoints the crashing step on replay.
+- **In-loop dedup is unaffected** — `oom_dedup` keys off the crash *site* (native ASan
+  backtrace / abort assertion in stdout), independent of how many calls preceded. Sequences
+  will re-hit known sites more often; `--oom-dedup-*` + `--oom-dedup-prune` already handle
+  the duplicate volume.
+
+## Wiring (where the code goes)
+
+- **Harness:** add `oom_run` to the boilerplate block in
+  `_write_script_header_and_imports`, gated on `oom_fuzz and oom_seq`, beside `oom_call`.
+- **Generation:**
+  - 4a: in `_generate_oom_class_fuzzing`, when `--oom-seq`, emit a guarded multi-step
+    thunk over `oom_seq_len` instance methods + one `oom_run(...)` instead of the
+    independent per-method `oom_call`s.
+  - 4b: add `_generate_oom_function_sequence(prefix)` (pick `oom_seq_len` module
+    functions, optionally thread `r_k → arg_{k+1}`), driven from `_write_main_fuzzing_logic`
+    when `--oom-seq`.
+  - Reuse `_write_arguments_for_call_lines`; the one non-trivial bit is emitting a
+    **guarded multi-statement thunk** (per-step `try/except`, result vars pre-bound to
+    `None`) rather than a single call expression.
+- All gated; with `--oom-seq` absent, generated output is byte-for-byte the current
+  Phase-1/2 output.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Probe steps can't allocate | Bounded window (auto-resume) is the default mechanism; don't use fail-forever for sequences. |
+| Crash far from injection → harder triage/minimization | `--oom-window 1` default; keep `--oom-seq-len` small (≤3); rely on subprocess self-sweep + shrinkray. |
+| Allocation-baseline sensitivity amplified by length | In-loop dedup is site-keyed (unaffected); repro convention already cold-starts each `start`. |
+| More duplicate crashes | `--oom-dedup-catalog` + `--oom-dedup-prune` already in place. |
+| Default-behavior / fleet-baseline drift | `--oom-seq` opt-in, default off. |
+| Per-step swallow hides a signal | Segfault/abort uncatchable (still scores); `SystemError` surfaced per step. |
+
+## Acceptance criteria
+
+1. `--oom-fuzz --oom-seq` emits the `oom_run` helper and ≥1 multi-step sequence using
+   `set_nomemory(_start, _start + window)`; with `--oom-seq` absent, output is unchanged.
+2. Benign module (e.g. `io`, `json`) runs to completion; `MemoryError` neither kills nor
+   scores; probe steps demonstrably execute (verify under `--oom-verbose`).
+3. A segfault/abort in any step scores 1.0 via existing `WatchProcess`; in-loop dedup
+   labels it by site, unchanged.
+4. Defaults: `--oom-window 1`, `--oom-seq-len 3`.
+5. A short A/B fleet run (`--oom-seq` vs not) reaches at least the OOM-0035-class shape
+   (method-chain corrupt-then-read).
+
+## Trying it
+
+```bash
+# Inspect generated sequences only (functions, then a method chain):
+PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --force-unsafe --oom-fuzz --oom-seq \
+    --modules json --sessions 1 --oom-calls 2 --oom-seq-len 3 --oom-max-start 40 \
+    --only-generate --source-output-path /tmp/seq.py
+
+# Run for real on a benign module (debug build, set_nomemory available):
+PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --force-unsafe --oom-fuzz --oom-seq \
+    --modules io --sessions 3 --oom-classes 3 --oom-seq-len 3 --oom-window 1
+```
+
+Fleet A/B: add `--oom-seq` to one instance's flags (leave another on the current
+single-call harness) and compare `oomNEW` yield over a few hours against the same catalog.
+`--oom-seq` composes with `--oom-dedup-catalog`/`--oom-dedup-prune` unchanged (dedup is
+site-keyed). Defaults: `--oom-seq-len 3`, `--oom-window 1`.
+
+## Validation plan
+
+- **Unit:** add `TestOOMSeqGeneration` to `tests/python/test_oom_fuzz.py` — assert the
+  helper + a windowed multi-step `oom_run(...)` appear with the flag, and that legacy
+  output is unchanged without it.
+- **Manual:** `--only-generate` inspection on `io`/`json`.
+- **A/B fleet:** one instance `--oom-seq`, one without; compare `oomNEW` yield over a few
+  hours on the same catalog.

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -368,6 +368,28 @@ class Fuzzer(Application):
             default=5,
         )
         oom_options.add_option(
+            "--oom-seq",
+            help="OOM mode (Phase 4): emit stateful call SEQUENCES -- several calls per "
+                 "scan under one bounded failure window -- so a failure in one call can "
+                 "corrupt state a later call trips over (default: disabled)",
+            action="store_true",
+            default=False,
+        )
+        oom_options.add_option(
+            "--oom-seq-len",
+            help="Steps (calls) per OOM sequence when --oom-seq is set (default: 3)",
+            type="int",
+            default=3,
+        )
+        oom_options.add_option(
+            "--oom-window",
+            help="OOM failure-burst width for sequences: set_nomemory(start, start+k) "
+                 "fails k allocations then resumes succeeding so later steps run on the "
+                 "damaged state (default: 1); 0 = fail forever (legacy single-call mode)",
+            type="int",
+            default=1,
+        )
+        oom_options.add_option(
             "--oom-verbose",
             help="In OOM mode, also print the sweep start index before each "
                  "injection so the exact failing allocation can be pinpointed on "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -552,6 +552,47 @@ class WritePythonCode(WriteCode):
             ''')
             self.emptyLine()
 
+        if self.options.oom_fuzz and self.options.oom_seq:
+            self.write_block(0, f'''
+                _OOM_WINDOW = {self.options.oom_window}
+
+                def oom_run(label, thunk):
+                    # Stateful OOM sequence (Phase 4): sweep a bounded failure window
+                    # across a multi-step thunk so a failure in one step can corrupt
+                    # state a later step trips over. set_nomemory(start, start+_OOM_WINDOW)
+                    # fails _OOM_WINDOW allocations then resumes succeeding, so steps after
+                    # the burst run on the damaged state (_OOM_WINDOW == 0 -> fail forever,
+                    # the legacy single-call semantics). The thunk guards each step
+                    # internally so the tail still runs after an earlier step raises; a real
+                    # crash (segfault/abort) terminates the process and is scored.
+                    if not _OOM_AVAILABLE:
+                        try:
+                            thunk()
+                        except BaseException:
+                            pass
+                        return
+                    print("[OOM-SEQ] " + label, file=stderr)
+                    for _start in range(_OOM_MAX_START):
+                        if _OOM_VERBOSE:
+                            print("[OOM-SEQ]   start=" + str(_start) + " window=" + str(_OOM_WINDOW), file=stderr)
+                        if _OOM_WINDOW > 0:
+                            _set_nomemory(_start, _start + _OOM_WINDOW)
+                        else:
+                            _set_nomemory(_start, 0)
+                        try:
+                            try:
+                                thunk()
+                            finally:
+                                _remove_mem_hooks()
+                        except MemoryError:
+                            pass
+                        except SystemError:
+                            print("[OOM-SEQ] SystemError in " + label, file=stderr)
+                        except BaseException:
+                            pass
+            ''')
+            self.emptyLine()
+
     def _write_main_fuzzing_logic(self) -> None:
         """Writes the core fuzzing loops for functions, classes, and objects."""
         self.write(0, f"fuzz_target_module = {self.module_name}")
@@ -590,6 +631,11 @@ class WritePythonCode(WriteCode):
 
                 # --- SIMPLIFIED LOGIC ---
                 if self.options.oom_fuzz:
+                    if self.options.oom_seq:
+                        # OOM sequence: several functions under one failure window so a
+                        # failure in one can corrupt state a later one trips over.
+                        self._generate_oom_function_sequence(prefix)
+                        continue
                     # OOM injection: wrap a function call in a dense set_nomemory sweep
                     func_name = choice(self.module_functions)
                     try:
@@ -1051,6 +1097,69 @@ class WritePythonCode(WriteCode):
         self.write(0, ")")
         self.emptyLine()
 
+    def _write_oom_sequence(self, fn_name: str, seq_label: str, steps) -> None:
+        """Emit a guarded multi-step thunk plus an oom_run() call (Phase 4 sequence).
+
+        steps: list of (sublabel, target_expr, num_args), where target_expr is a string
+        evaluating to the callable (e.g. 'getattr(fuzz_target_module, "dumps", None)').
+        Each step is wrapped in try/except so a failing step does not abort the tail --
+        the shared state (a live instance, or module/interpreter globals such as a pending
+        exception) is what a later step may trip over. Result values are not threaded
+        between steps yet (Phase 4b); the steps interact only through shared state.
+        """
+        self.write(0, f"def {fn_name}():")
+        saved = self.addLevel(1)
+        wrote = False
+        for sublabel, target_expr, num_args in steps:
+            # The verbose marker is INSIDE the try: under a low window the failing
+            # allocation can land in the print itself, and we want that swallowed so the
+            # tail steps still run (it does perturb the allocation count, so verbose is for
+            # coarse pinpointing -- the authoritative locator is faulthandler's traceback).
+            self.write(0, "try:")
+            self.write(1, "if _OOM_VERBOSE:")
+            self.write(2, f'print("[OOM-SEQ]     step {sublabel}", file=stderr)')
+            self.write(1, f"{target_expr}(")
+            self._write_arguments_for_call_lines(num_args, 2)
+            self.write(1, ")")
+            self.write(0, "except BaseException:")
+            self.write(1, "pass")
+            wrote = True
+        if not wrote:
+            self.write(0, "pass")
+        self.restoreLevel(saved)
+        self.write(0, f'oom_run("{seq_label}", {fn_name})')
+        self.emptyLine()
+
+    def _generate_oom_function_sequence(self, prefix: str) -> None:
+        """Emit one OOM sequence (Phase 4) over several module-level functions.
+
+        The functions run in order under one bounded failure window, so a failure in one
+        can leave module/interpreter state (a pending exception, specializer/GC state)
+        that a later one trips over -- the stale-exception class (e.g. OOM-0008/0010/
+        0011/0015/0025/0032).
+        """
+        steps = []
+        names = []
+        for j in range(max(1, self.options.oom_seq_len)):
+            func_name = choice(self.module_functions)
+            try:
+                func_obj = getattr(self.module, func_name)
+            except AttributeError:
+                continue
+            min_arg, max_arg = get_arg_number(func_obj, func_name, 1)
+            num_args = randint(min_arg, max_arg)
+            steps.append((
+                f"s{j + 1}:{func_name}",
+                f'getattr(fuzz_target_module, "{func_name}", None)',
+                num_args,
+            ))
+            names.append(func_name)
+        if not steps:
+            return
+        seq_label = f"{prefix}:{self.module_name}[" + ">".join(names) + "]"
+        self.write(0, f"# OOM sequence: {' > '.join(names)}")
+        self._write_oom_sequence(f"_oom_seq_{prefix}", seq_label, steps)
+
     def _generate_oom_class_fuzzing(
         self, prefix: str, class_name: str, class_obj: type
     ) -> None:
@@ -1092,16 +1201,37 @@ class WritePythonCode(WriteCode):
         # 4. Method sweeps on the live instance.
         self.write(0, f"if {inst} is not None and {inst} is not SENTINEL_VALUE:")
         saved = self.addLevel(1)
-        for j in range(self.options.oom_methods):
-            m_name = choice(method_names)
-            m_obj = methods[m_name]
-            min_arg, max_arg = get_arg_number(m_obj, m_name, 0)
-            num_args = randint(min_arg, max_arg)
-            m_label = f"{prefix}m{j + 1}:{self.module_name}.{class_name}.{m_name}"
-            self.write(0, f"# OOM sweep: {class_name}.{m_name}()")
-            self.write(0, f'oom_call("{m_label}", getattr({inst}, "{m_name}", None),')
-            self._write_arguments_for_call_lines(num_args, 1)
-            self.write(0, ")")
+        if self.options.oom_seq:
+            # Phase 4: one sequence of methods on the SAME instance under a single
+            # failure window, so a failure in method A can leave the instance in a state
+            # method B trips over (e.g. OOM-0035: write... then getvalue()).
+            steps = []
+            mnames = []
+            for j in range(max(1, self.options.oom_seq_len)):
+                m_name = choice(method_names)
+                m_obj = methods[m_name]
+                min_arg, max_arg = get_arg_number(m_obj, m_name, 0)
+                num_args = randint(min_arg, max_arg)
+                steps.append((
+                    f"m{j + 1}:{m_name}",
+                    f'getattr({inst}, "{m_name}", None)',
+                    num_args,
+                ))
+                mnames.append(m_name)
+            seq_label = f"{prefix}:{self.module_name}.{class_name}[" + ">".join(mnames) + "]"
+            self.write(0, f"# OOM sequence on {class_name}: {' > '.join(mnames)}")
+            self._write_oom_sequence(f"_oom_seq_{prefix}", seq_label, steps)
+        else:
+            for j in range(self.options.oom_methods):
+                m_name = choice(method_names)
+                m_obj = methods[m_name]
+                min_arg, max_arg = get_arg_number(m_obj, m_name, 0)
+                num_args = randint(min_arg, max_arg)
+                m_label = f"{prefix}m{j + 1}:{self.module_name}.{class_name}.{m_name}"
+                self.write(0, f"# OOM sweep: {class_name}.{m_name}()")
+                self.write(0, f'oom_call("{m_label}", getattr({inst}, "{m_name}", None),')
+                self._write_arguments_for_call_lines(num_args, 1)
+                self.write(0, ")")
         self.write(0, f"del {inst}")
         self.write(0, "collect()")
         self.restoreLevel(saved)

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -50,6 +50,11 @@ def _make_options(oom_fuzz, oom_verbose=False):
     # 0 keeps the function-only Phase-1 tests' oom_call counts exact.
     o.oom_classes = 0
     o.oom_methods = 0
+    # OOM stateful sequences (Phase 4). Default OFF (real values, not MagicMock auto-attrs)
+    # so Phase-1/2 tests keep the single-call path and exact oom_call counts.
+    o.oom_seq = False
+    o.oom_seq_len = 3
+    o.oom_window = 1
     # JIT options (WriteJITCode is constructed unconditionally); OOM mode never
     # dispatches to it, so legacy defaults are fine.
     o.jit_fuzz = False
@@ -66,13 +71,17 @@ def _make_options(oom_fuzz, oom_verbose=False):
 
 
 def _generate(oom_fuzz, oom_verbose=False, module=math, module_name="math",
-              oom_classes=0, oom_methods=0, test_private=False):
+              oom_classes=0, oom_methods=0, test_private=False,
+              oom_seq=False, oom_seq_len=3, oom_window=1):
     """Generate a fuzzing script against ``module`` and return its source."""
     parent = MagicMock()
     options = _make_options(oom_fuzz, oom_verbose)
     options.oom_classes = oom_classes
     options.oom_methods = oom_methods
     options.test_private = test_private
+    options.oom_seq = oom_seq
+    options.oom_seq_len = oom_seq_len
+    options.oom_window = oom_window
     parent.options = options
     parent.filenames = ["/bin/sh"]
     fd, path = tempfile.mkstemp(suffix="_oom_test.py")
@@ -177,6 +186,54 @@ class TestOOMClassFuzzGeneration(unittest.TestCase):
                         oom_classes=1, oom_methods=2)
         self.assertIn(", None)", src)               # safe getattr default on method
         self.assertIn("if not _OOM_AVAILABLE or func is None:", src)
+
+
+class TestOOMSeqGeneration(unittest.TestCase):
+    """Phase 4 stateful call sequences (--oom-seq)."""
+
+    def test_seq_emits_windowed_oom_run_harness(self):
+        src = _generate(oom_fuzz=True, oom_seq=True, oom_seq_len=3, oom_window=2)
+        ast.parse(src)
+        # The oom_run harness + the bounded-window primitive (start .. start+k).
+        self.assertIn("def oom_run(label, thunk):", src)
+        self.assertIn("_OOM_WINDOW = 2", src)
+        self.assertIn("_set_nomemory(_start, _start + _OOM_WINDOW)", src)
+        self.assertIn("_set_nomemory(_start, 0)", src)   # window==0 fallback branch
+        self.assertIn('print("[OOM-SEQ] " + label', src)
+        # Function sequences: a guarded multi-step thunk fed to oom_run.
+        self.assertRegex(src, r"def _oom_seq_f\d+\(\):")
+        self.assertRegex(src, r"oom_run\(\"f\d+:math\[")
+
+    def test_seq_thunk_is_guarded_per_step_and_valid(self):
+        # Each step is wrapped so a failing step doesn't abort the tail; the thunk must
+        # contain >1 call (a real sequence) and parse.
+        src = _generate(oom_fuzz=True, oom_seq=True, oom_seq_len=3)
+        ast.parse(src)
+        thunk = src[src.index("def _oom_seq_f1"):]
+        thunk = thunk[:thunk.index("oom_run(")]
+        self.assertGreaterEqual(thunk.count("except BaseException:"), 3)
+        self.assertGreaterEqual(thunk.count("getattr(fuzz_target_module, "), 3)
+
+    def test_seq_default_window_is_one(self):
+        src = _generate(oom_fuzz=True, oom_seq=True)
+        self.assertIn("_OOM_WINDOW = 1", src)
+
+    def test_seq_method_chain_reuses_one_instance(self):
+        # Method-chain sequence: several methods on the SAME live instance under one
+        # window (the OOM-0035 write...->getvalue() shape).
+        src = _generate(oom_fuzz=True, oom_seq=True, module=json, module_name="json",
+                        oom_classes=1, oom_methods=3, oom_seq_len=3)
+        ast.parse(src)
+        self.assertRegex(src, r"def _oom_seq_oc1\(\):")
+        self.assertRegex(src, r'oom_run\("oc1:json\.')
+        # all steps target the same oom_inst_oc1_* instance (not the module)
+        self.assertRegex(src, r"getattr\(oom_inst_oc1_\w+, ")
+        self.assertNotIn('oom_call("oc1m', src)   # single-call method sweep replaced
+
+    def test_non_seq_oom_mode_has_no_seq_artifacts(self):
+        src = _generate(oom_fuzz=True, oom_seq=False)
+        for marker in ("oom_run", "_OOM_WINDOW", "[OOM-SEQ]", "_oom_seq_"):
+            self.assertNotIn(marker, src, f"unexpected seq artifact {marker!r} without --oom-seq")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #90.

Lets one OOM scan exercise several calls so an allocation failure in one call can corrupt
state that a *later* call trips over — the cross-call "stale state" class the single-call
harness only finds by accident (OOM-0033, OOM-0035, the stale-exception family).

## Mechanism
A **bounded failure window**: `set_nomemory(start, start + k)` fails `k` allocations then
*auto-resumes* succeeding (confirmed against `Modules/_testcapi/mem.c` — the second arg is
an absolute `stop` index, so `start + k` fails exactly `k`), so steps after the burst run
on the damaged state. A sequence is emitted as a guarded multi-step thunk; the new
`oom_run` helper arms the window once and sweeps `start`, walking the failure across the
sequence. Each step is wrapped so a failing step doesn't abort the tail.

## Scope (Phase 4a — independent steps sharing state)
- **method chains** — several methods of one live instance (the OOM-0035
  `write…→getvalue()` shape), replacing the independent per-method sweeps under `--oom-seq`;
- **function sequences** — several module functions in a row (shared module/interpreter
  state), targeting the stale-exception family.

Producer→consumer (4b) and mutate-then-reread (4c) are deferred.

## Flags (opt-in; default behavior byte-for-byte unchanged)
- `--oom-seq` (default off), `--oom-seq-len` (3), `--oom-window` (1; `0` = legacy
  fail-forever). Composes with `--oom-dedup-*` unchanged (dedup is site-keyed).

## Validation
- Generated scripts parse and **run to completion (exit 0)** on benign modules under the
  ft_debug_asan build; the windowed sweep executes, `MemoryError` is swallowed, all guarded
  tail steps run.
- 5 new `TestOOMSeqGeneration` tests; full OOM suite (51 tests) green; no new ruff.
- Design doc: `doc/oom-sequences.md`; roadmap entry in `doc/oom-fuzzing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
