### PR TITLE
Don't fuzz real system files; abort on failed privilege drop

### DIFF
--- a/fusil/process/prepare.py
+++ b/fusil/process/prepare.py
@@ -1,5 +1,3 @@
-import grp
-import pwd
 from errno import EACCES
 from os import X_OK, access, chdir
 from shutil import chown
@@ -7,7 +5,7 @@ from shutil import chown
 from fusil.process.tools import allowCoreDump, beNice, limitMemory, limitUserProcess
 from fusil.unsafe import permissionHelp
 
-from os import getuid, setgid, setuid
+from os import getgid, getuid, setgid, setgroups, setuid
 from pwd import getpwuid
 
 
@@ -19,7 +17,6 @@ class ChildError(Exception):
 def prepareProcess(process):
     from sys import stderr
 
-    print(f"USER {getuid()}", file=stderr)
     project = process.project()
     config = project.config
     options = process.application().options
@@ -28,17 +25,18 @@ def prepareProcess(process):
     process.debugger.traceme()
     # Set current working directory
     directory = process.getWorkingDirectory()
-    try:
-        uid = pwd.getpwnam("fusil").pw_uid
-        gid = grp.getgrnam("fusil").gr_gid
-        chown(directory, uid, gid)
-    except Exception as e:
-        print(e)
-    # Change the user and group
-    try:
-        changeUserGroup(config, options)
-    except Exception as e:
-        print(e)
+    # Hand the working directory to the unprivileged process user -- while still
+    # privileged and before the drop below. Skipped when no drop is configured (--unsafe).
+    if config.process_uid is not None and config.process_gid is not None:
+        try:
+            chown(directory, config.process_uid, config.process_gid)
+        except OSError as err:
+            print("Unable to chown %s to %s:%s: %s"
+                  % (directory, config.process_uid, config.process_gid, err), file=stderr)
+    # Drop privileges. A failed or ineffective drop MUST abort the child (ChildError is
+    # turned into a ProcessError by the parent); never continue running as root -- that is
+    # how a fuzzed file-write clobbered /bin/sh and /etc/machine-id.
+    changeUserGroup(config, options)
 
     try:
         chdir(directory)
@@ -92,37 +90,48 @@ def limitResources(process, config, options):
 
 
 def changeUserGroup(config, options):
-    # Change group?
+    """Drop privileges to the configured process user/group.
+
+    No-op when neither is configured (e.g. under --unsafe). On any failure -- the drop
+    raising OSError, or silently not taking effect -- raises ChildError so the caller
+    aborts the child instead of continuing with elevated privileges.
+    """
+    uid = config.process_uid
     gid = config.process_gid
+    if uid is None and gid is None:
+        return  # nothing to drop (e.g. --unsafe)
+
     errors = []
+    # Group (and supplementary groups) first, while still privileged: after setuid() we
+    # can no longer change groups.
     if gid is not None:
+        try:
+            setgroups([gid])  # drop root's supplementary groups
+        except OSError:
+            pass  # best-effort; the effectiveness check below is authoritative
         try:
             setgid(gid)
         except OSError:
             errors.append("group to %s" % gid)
-        except Exception as e:
-            print(e)
-            raise
-
-    # Change user?
-    uid = config.process_uid
     if uid is not None:
         try:
             setuid(uid)
         except OSError:
             errors.append("user to %s" % uid)
-        except Exception as e:
-            print(e)
-            raise
+
+    # A drop that silently failed to take effect is as dangerous as one that raised, so
+    # verify it actually happened rather than trusting the calls above.
+    if gid is not None and getgid() != gid:
+        errors.append("effective gid (still %s, wanted %s)" % (getgid(), gid))
+    if uid is not None and getuid() != uid:
+        errors.append("effective uid (still %s, wanted %s)" % (getuid(), uid))
+
     if not errors:
         return
 
-    # On error: propose some help
+    # On error: propose some help and abort the child.
+    message = "Unable to drop privileges: " + " and ".join(errors)
     help = permissionHelp(options)
-
-    # Raise an error message
-    errors = " and ".join(reversed(errors))
-    message = "Unable to set " + errors
     if help:
         message += " (%s)" % help
     raise ChildError(message)

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -31,7 +31,11 @@ SHOW_STDOUT = False
 DEBUG = False
 TIMEOUT = 900.0
 PYTHON = sys.executable
-FILENAMES = "/etc/machine-id,/bin/sh"
+# Empty default => auto-created, expendable fixture files (fusil.python.fixtures).
+# NEVER default to real system files: a fuzzed call may open a --filenames path for
+# writing/truncation, and a privileged child (e.g. root under --unsafe) will clobber it.
+# The historical "/etc/machine-id,/bin/sh" default did exactly that.
+FILENAMES = ""
 DEFAULT_NB_CALL = 250
 DEFAULT_NB_METHOD = 15
 DEFAULT_NB_CLASS = 50
@@ -194,7 +198,9 @@ class Fuzzer(Application):
         )
         fuzzing_options.add_option(
             "--filenames",
-            help="Names separated by commas of readable files (default: %s)" % FILENAMES,
+            help="Comma-separated readable files to feed as fuzz arguments. WARNING: a "
+                 "fuzzed call may open these for writing -- pass only expendable files. "
+                 "Default: auto-created throwaway fixtures (fusil.python.fixtures).",
             type="str",
             default=FILENAMES,
         )

--- a/fusil/python/fixtures.py
+++ b/fusil/python/fixtures.py
@@ -1,0 +1,85 @@
+"""Safe, throwaway fixture files used as ``--filenames`` fuzzing inputs.
+
+The Python fuzzer feeds the ``--filenames`` paths as arguments to randomly chosen
+functions/methods. Some fuzzed call *will* eventually open one of those paths for
+writing/truncation, so the files must be **expendable**: never point ``--filenames`` at
+real, valuable files. The historical default (``/etc/machine-id,/bin/sh``) did exactly
+that, and clobbered both when a fuzzed call wrote to them while the child ran with write
+permission (e.g. as root under ``--unsafe``).
+
+This module creates a small set of valueless fixture files and returns their paths. They
+are made read-only (so a child running as the unprivileged ``fusil`` user cannot clobber
+them — the write just fails and exercises the error path), and they are regenerated every
+run, so even if a privileged child does truncate one, only a throwaway file is lost and it
+comes back next session.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+# Candidate directories, in preference order. The first that exists or can be created is
+# used. /var/lib/fusil is the natural home when running as root (the fleet); the tempdir
+# fallback keeps unprivileged/dev runs working. Override with $FUSIL_FIXTURE_DIR.
+_CANDIDATE_DIRS = [
+    "/var/lib/fusil/fixtures",
+    os.path.join(tempfile.gettempdir(), "fusil-fixtures"),
+]
+
+# Valueless fixture content: a small text file and a small binary file, enough to be
+# realistic inputs for file-reading code without containing anything worth keeping.
+_FIXTURES: dict[str, bytes] = {
+    "fusil_fixture.txt": b"fusil fuzzing fixture - safe to clobber, regenerated each run\n" * 4,
+    "fusil_fixture.bin": bytes(range(256)) * 8,
+}
+
+
+def _select_dir() -> str:
+    """Return the fixture directory to use (creating nothing yet)."""
+    override = os.environ.get("FUSIL_FIXTURE_DIR")
+    if override:
+        return override
+    for d in _CANDIDATE_DIRS:
+        if os.path.isdir(d) or os.access(os.path.dirname(d) or "/", os.W_OK):
+            return d
+    return _CANDIDATE_DIRS[-1]
+
+
+def fixture_dir() -> str:
+    return _select_dir()
+
+
+def ensure_fixture_files() -> list[str]:
+    """Create the throwaway fixture files (idempotent) and return their absolute paths.
+
+    Restores any file that is missing or has been clobbered (zero-sized). Files are left
+    read-only; the directory is left traversable so an unprivileged child can read them.
+    """
+    directory = _select_dir()
+    os.makedirs(directory, exist_ok=True)
+    try:
+        os.chmod(directory, 0o755)
+    except OSError:
+        pass
+
+    paths: list[str] = []
+    for name, content in _FIXTURES.items():
+        path = os.path.join(directory, name)
+        try:
+            need = (not os.path.exists(path)) or os.path.getsize(path) != len(content)
+        except OSError:
+            need = True
+        if need:
+            # Make writable first in case a stale read-only copy exists.
+            try:
+                os.chmod(path, 0o644)
+            except OSError:
+                pass
+            with open(path, "wb") as fp:
+                fp.write(content)
+        try:
+            os.chmod(path, 0o444)  # read-only: an unprivileged child cannot clobber it
+        except OSError:
+            pass
+        paths.append(path)
+    return paths

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -12,6 +12,7 @@ from fusil.project import Project
 from fusil.project_agent import ProjectAgent
 from fusil.python.blacklists import MODULE_BLACKLIST
 from fusil.python.list_all_modules import ListAllModules
+from fusil.python.fixtures import ensure_fixture_files
 from fusil.python.utils import print_running_time
 from fusil.python.write_python_code import WritePythonCode
 
@@ -90,7 +91,15 @@ class PythonSource(ProjectAgent):
         for name in self.modules_list:
             self.info("Python module: %s" % name)
 
-        self.filenames = self.options.filenames.split(",")
+        if self.options.filenames:
+            # User-supplied paths. WARNING: a fuzzed call may open these for writing,
+            # so only ever pass expendable files here.
+            self.filenames = self.options.filenames.split(",")
+        else:
+            # Default: auto-created, read-only, throwaway fixture files. Never default to
+            # real system files (the historical /etc/machine-id,/bin/sh default could be
+            # clobbered when a fuzzed call wrote to them as root).
+            self.filenames = ensure_fixture_files()
         for filename in self.filenames:
             if not isabs(filename):
                 raise ValueError(

--- a/tests/python/test_fixtures.py
+++ b/tests/python/test_fixtures.py
@@ -1,0 +1,68 @@
+import importlib.util
+import os
+import stat
+import tempfile
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_PY = os.path.join(SCRIPT_DIR, "..", "..", "fusil", "python", "fixtures.py")
+
+
+def _load_fixtures():
+    # fixtures.py is intentionally dependency-free; load it directly so the test does not
+    # require the fusil.python package __init__ (which pulls in python-ptrace).
+    spec = importlib.util.spec_from_file_location("fusil_fixtures_under_test", FIXTURES_PY)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+fx = _load_fixtures()
+
+
+class TestSafeFixtures(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old = os.environ.get("FUSIL_FIXTURE_DIR")
+        os.environ["FUSIL_FIXTURE_DIR"] = os.path.join(self._tmp.name, "fixtures")
+
+    def tearDown(self):
+        if self._old is None:
+            os.environ.pop("FUSIL_FIXTURE_DIR", None)
+        else:
+            os.environ["FUSIL_FIXTURE_DIR"] = self._old
+        self._tmp.cleanup()
+
+    def test_creates_absolute_existing_readonly_files(self):
+        paths = fx.ensure_fixture_files()
+        self.assertTrue(paths)
+        for p in paths:
+            self.assertTrue(os.path.isabs(p))
+            self.assertTrue(os.path.exists(p))
+            self.assertGreater(os.path.getsize(p), 0)
+            mode = stat.S_IMODE(os.stat(p).st_mode)
+            self.assertEqual(mode & 0o222, 0, f"{p} is writable (mode {oct(mode)})")
+
+    def test_never_points_at_system_files(self):
+        # The whole point of the fix: defaults must be expendable, never real system files.
+        for p in fx.ensure_fixture_files():
+            self.assertNotIn(p, ("/bin/sh", "/etc/machine-id"))
+            self.assertTrue(p.startswith(fx.fixture_dir()))
+
+    def test_idempotent(self):
+        self.assertEqual(fx.ensure_fixture_files(), fx.ensure_fixture_files())
+
+    def test_self_heals_after_clobber(self):
+        paths = fx.ensure_fixture_files()
+        victim = paths[0]
+        size = os.path.getsize(victim)
+        os.chmod(victim, 0o644)
+        open(victim, "wb").close()  # simulate a fuzzed call truncating it
+        self.assertEqual(os.path.getsize(victim), 0)
+        fx.ensure_fixture_files()
+        self.assertEqual(os.path.getsize(victim), size)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #94.

The Python fuzzer could destroy real system files: `--filenames` defaulted to
`/etc/machine-id,/bin/sh`, those paths are fed as arguments to randomly fuzzed calls (one of
which opened a path for writing), and the child could run as root because a failed/ineffective
privilege drop was silently swallowed. A fleet run clobbered the `/bin/sh` symlink and
`/etc/machine-id`.

## Changes
**1. Stop defaulting `--filenames` to real system files** (`fusil/python/fixtures.py`, new)
- Default to auto-created, read-only, self-healing **throwaway fixture files** (in
  `/var/lib/fusil/fixtures` when writable, else `<tmpdir>/fusil-fixtures`; override with
  `$FUSIL_FIXTURE_DIR`). Regenerated each run, so even if a privileged child truncates one,
  only an expendable file is lost. Read-only, so an unprivileged child cannot clobber it.
- `--filenames` still accepts user paths, now documented as expendable-only.
- New `tests/python/test_fixtures.py` (4 tests).

**2. Abort the child on a failed privilege drop** (`fusil/process/prepare.py`)
- `changeUserGroup()`: drop supplementary groups + `setgid` before `setuid`, then **verify
  `getuid()`/`getgid()` actually changed** and raise `ChildError` on any failure or
  ineffective drop. No-op when no uid/gid is configured (so `--unsafe` is unchanged).
- `prepareProcess()`: stop swallowing the drop — let `ChildError` propagate (the parent turns
  it into `ProcessError`, so the target is never exec'd as root). This is also self-diagnosing:
  a misconfigured drop now surfaces loudly instead of silently running as root.
- `chown` the working dir using the configured `process_uid`/`process_gid` (not a hardcoded
  `getpwnam("fusil")`), skipped when no drop is configured; removed a leftover debug `print`.

## Not addressed here
The other `if 0:`-disabled "temp fix" bypasses (`limitResources`, the `X_OK` check) are left
as-is — separate tech debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
