### PR TITLE
oom: install the allocation-failure hook once instead of swapping it under live threads

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -324,11 +324,23 @@ class WritePythonCode(WriteCode):
                 import faulthandler
                 faulthandler.enable()
                 try:
-                    from _testcapi import set_nomemory as _set_nomemory, remove_mem_hooks as _remove_mem_hooks
+                    from _testcapi import set_nomemory as _set_nomemory
                     _OOM_AVAILABLE = True
                 except ImportError:
                     _OOM_AVAILABLE = False
                     print("OOM mode requested but _testcapi.set_nomemory unavailable; running without injection", file=stderr)
+                # set_nomemory()/remove_mem_hooks() install/restore the allocation-failure hook by
+                # swapping the process-global allocator via PyMem_SetAllocator(), which is NOT
+                # thread-safe. Performing that swap inside the per-call/per-sequence OOM loops races
+                # any worker threads the fuzzed code spawned and corrupts the heap -- false-positive
+                # "crashes" (mimalloc asserts, _PyMem_DebugRawFree bad-ID, segvs). So install the hook
+                # EXACTLY ONCE here, before any fuzzed code runs, in a disarmed state, and thereafter
+                # only re-arm/disarm the failure WINDOW with set_nomemory() (which never swaps the
+                # allocator). _OOM_DISABLE is a start count no real run reaches, so every allocation
+                # passes through (injection effectively off).
+                _OOM_DISABLE = 2_000_000_000
+                if _OOM_AVAILABLE:
+                    _set_nomemory(_OOM_DISABLE, 0)
             ''')
             self.emptyLine()
 
@@ -529,8 +541,10 @@ class WritePythonCode(WriteCode):
                     # the expected outcome and is swallowed silently; SystemError is
                     # surfaced (PyCFunction contract violations); a real crash
                     # (segfault/abort) terminates the process, the signal fusil scores.
-                    # remove_mem_hooks runs in the inner finally so the except clauses
-                    # allocate with the allocator restored.
+                    # The inner finally DISARMS injection (set_nomemory with an unreachable start)
+                    # so the except clauses allocate freely, WITHOUT swapping the allocator -- the
+                    # swap is not thread-safe and would corrupt the heap if the fuzzed call left
+                    # worker threads running (see the one-time install note above).
                     if not _OOM_AVAILABLE or func is None:
                         return
                     print("[OOM] " + label, file=stderr)
@@ -542,7 +556,7 @@ class WritePythonCode(WriteCode):
                             try:
                                 func(*args, **kwargs)
                             finally:
-                                _remove_mem_hooks()
+                                _set_nomemory(_OOM_DISABLE, 0)
                         except MemoryError:
                             pass
                         except SystemError:
@@ -583,7 +597,7 @@ class WritePythonCode(WriteCode):
                             try:
                                 thunk()
                             finally:
-                                _remove_mem_hooks()
+                                _set_nomemory(_OOM_DISABLE, 0)
                         except MemoryError:
                             pass
                         except SystemError:

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -114,7 +114,13 @@ class TestOOMFuzzGeneration(unittest.TestCase):
         self.assertIn("def oom_call(label, func", src)
         self.assertIn(f"_OOM_MAX_START = {OOM_MAX_START}", src)
         self.assertIn("range(_OOM_MAX_START)", src)
-        self.assertIn("_remove_mem_hooks()", src)
+        # The allocation hook is installed ONCE (disarmed) and the loop re-arms/disarms the
+        # failure window without swapping the allocator -- swapping (remove_mem_hooks) inside
+        # the loop races fuzzed worker threads and corrupts the heap. So the per-iteration
+        # _remove_mem_hooks() swap is gone; the finally disarms via set_nomemory instead.
+        self.assertIn("_OOM_DISABLE", src)
+        self.assertIn("_set_nomemory(_OOM_DISABLE, 0)", src)
+        self.assertNotIn("_remove_mem_hooks()", src)
 
         # Per-call marker (the pinpointing signal) and exception policy:
         # MemoryError swallowed silently, SystemError surfaced.


### PR DESCRIPTION
Closes #96.

### Problem

The `--oom-fuzz` harness wrapped each swept call/sequence in `set_nomemory()` /
`remove_mem_hooks()`, which swap the process-global allocator via the **not-thread-safe**
`PyMem_SetAllocator()` — and it did that swap **every loop iteration**. When the fuzzed call
spawned worker threads, the swap raced their concurrent alloc/free and corrupted the heap,
producing false-positive "crashes" (mimalloc `mi_page_usable_size_of` asserts,
`_PyMem_DebugRawFree: bad ID` with mismatched alloc/free API tags, segvs). See #96 for the full
analysis and evidence.

### Fix

Install the hook **exactly once**, before any fuzzed code can spawn threads, in a disarmed state,
and thereafter only re-arm/disarm the failure **window** with `set_nomemory()` (no allocator
swap). The inner `finally` now disarms via `set_nomemory(_OOM_DISABLE, 0)` (an unreachable start
count) instead of `remove_mem_hooks()`, so the `except` clauses still allocate freely without a
swap. The now-unused `remove_mem_hooks` import is dropped.

### Verification

- `tests/python/test_oom_fuzz.py` updated to assert the one-time install + window disarm and the
  absence of the per-iteration `_remove_mem_hooks()` swap; full OOM suite passes (11/11).
- Full `unittest discover` shows no new failures vs `main` (identical pre-existing errors).
- On `debug-ft-nojit-asan` (`PYTHON_GIL=0`): a `_thread.start_new_thread` OOM vehicle that
  corrupted **10/10** before now shows **zero** swap-artifact corruption, while OOM injection
  stays active and still surfaces real bugs (e.g. a list-freelist UAF on the main thread).

Single-threaded OOM fuzzing behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)