### PR TITLE
oom_dedup: skip tracemalloc allocator-hook frames (mirror the obmalloc skip)

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -148,10 +148,15 @@ _ASAN_FRAME = re.compile(
 # _PyMem_DebugFree) are likewise detectors: they catch a bad/double free ("bad ID") but the
 # real defect is the CALLER doing the bad free (e.g. free_threadstate), so skip them too -- the
 # resolved site becomes that caller, matching the catalog (gen_known_sites GENERIC_DETECTOR_FUNCS).
+# tracemalloc's allocator hooks (tracemalloc_alloc/realloc/free, raw_*) are the same kind of
+# pass-through layer when tracing is on -- skip them so the site is the real caller (e.g.
+# free_list_items = OOM-0004), not the hook. (The by-design "tracemalloc_realloc() failed to
+# allocate a trace" fatal is matched by its message, not this frame, so skipping it here is safe.)
 _BT_SKIP = re.compile(r'^(fatal_error(_exit)?|_Py_FatalError\w*|_PyObject_AssertFailed'
                       r'|_Py_NegativeRefcount|_Py_DumpStack|faulthandler\w*'
                       r'|_Py_DumpExtensionModules'
-                      r'|_PyMem_DebugCheckAddress|_PyMem_DebugRawFree|_PyMem_DebugFree)$')
+                      r'|_PyMem_DebugCheckAddress|_PyMem_DebugRawFree|_PyMem_DebugFree'
+                      r'|tracemalloc_(raw_)?(alloc|calloc|realloc|free))$')
 # Inlined refcount/atomic helpers live in these headers and show up as the innermost frame
 # of a "DECREF a freed object" segv -- skip them so the site is the real .c caller (e.g.
 # do_warn / PyContextVar_Set), not the shared Py_DECREF/_Py_atomic_load that masks dozens


### PR DESCRIPTION
Closes #102.

Extends `_BT_SKIP` (which #99 taught to skip the obmalloc debug-allocator free checks) to also
skip tracemalloc's allocator hooks `tracemalloc_(raw_)?(alloc|calloc|realloc|free)`. When
tracing is on they're a pass-through layer in every alloc/free and mask the real caller, so a
known bad-free (e.g. OOM-0004 `free_list_items`) resolves to `tracemalloc_free` and gets
mislabeled `oomNEW`.

Mirrors the catalog's `ingest.py` NATIVE_SKIP and `gen_known_sites` detector set so the live
resolver and the read-only snapshot agree.

### Verification
- `tests.python.test_oom_dedup` + `test_oom_dedup_wiring`: 34/34 pass.
- A `_PyMem_DebugCheckAddress -> ... -> tracemalloc_free -> free_list_items -> list_dealloc`
  gdb chain now resolves `chain[0]` to `free_list_items@Objects/listobject.c:68` (OOM-0004).

The by-design `tracemalloc_realloc() failed to allocate a trace` fatal is matched by its
message, not this frame, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)