### PR TITLE
oom_dedup: drop privileges + confine cwd in the gdb segv resolver

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -560,6 +560,10 @@ class Fuzzer(Application):
                 python_bin=self.options.python,
                 gdb_timeout=self.options.oom_dedup_gdb_timeout,
                 resolve_segv=self.options.oom_dedup_resolve_segv,
+                # Drop the gdb segv re-run to the same unprivileged user the fuzzing
+                # children use, so the fuzzed source.py is never replayed as root.
+                drop_uid=self.config.process_uid,
+                drop_gid=self.config.process_gid,
             )
             self.session_keep_policy = self._oom_keep_policy
             project.error(

--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -201,16 +201,36 @@ def extract_site_from_bt(bt_text):
     return sites[0] if sites else None
 
 
-def gdb_crash_site(python_bin, source_path, timeout=120):
+def gdb_crash_site(python_bin, source_path, timeout=120, drop_uid=None, drop_gid=None):
     """Re-run source.py under gdb on ``python_bin`` (deterministic on the same binary) and
-    return the chain of real CPython frames ['func@file:line', ...] (innermost first)."""
+    return the chain of real CPython frames ['func@file:line', ...] (innermost first).
+
+    This re-executes the *fuzzed* source.py, so it must never run it with more privilege
+    than the original fuzzing child had. When the caller is root and a drop target is
+    configured (``drop_uid``/``drop_gid`` -- the same ``fusil`` user the children drop to),
+    gdb and the python it spawns are dropped to that user; a same-uid gdb can still ptrace
+    its own child. The replay also runs with ``cwd`` set to the session dir (where source.py
+    lives, matching the original child's cwd) rather than the root-owned run dir, so a fuzzed
+    ``os.chmod``/``os.makedirs``/... on a relative path can't escalate against the run tree.
+    """
+    cwd = os.path.dirname(source_path) or None
+    # Only drop when we are actually privileged: a non-root caller is already unprivileged
+    # (and setgroups() would fail for it), so there is nothing to drop.
+    drop = {}
+    if os.getuid() == 0 and (drop_uid is not None or drop_gid is not None):
+        if drop_gid is not None:
+            drop["group"] = drop_gid
+            drop["extra_groups"] = [drop_gid]  # drop root's supplementary groups
+        if drop_uid is not None:
+            drop["user"] = drop_uid
     try:
         out = subprocess.run(
             ["gdb", "-q", "-batch", "-ex", "set pagination off",
              "-ex", "set print frame-arguments none", "-ex", "set debuginfod enabled off",
              "-ex", "run", "-ex", "bt 30", "--args", python_bin, "-u", source_path],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True, text=True, timeout=timeout, cwd=cwd,
             env={**os.environ, "ASAN_OPTIONS": "detect_leaks=0:abort_on_error=0"},
+            **drop,
         ).stdout
     except (OSError, subprocess.SubprocessError):
         return []
@@ -234,7 +254,8 @@ class Deduper:
     injectable for testing; it defaults to :func:`gdb_crash_site`.
     """
     def __init__(self, snapshot_path, keep=5, prune=False, python_bin=None,
-                 gdb_timeout=120, resolve_segv=False, segv_resolver=None):
+                 gdb_timeout=120, resolve_segv=False, segv_resolver=None,
+                 drop_uid=None, drop_gid=None):
         self.snap = load_snapshot_file(snapshot_path)
         self.keep_cap = keep
         self.prune = prune
@@ -242,13 +263,18 @@ class Deduper:
         self.gdb_timeout = gdb_timeout
         self.resolve_segv = resolve_segv
         self._resolver = segv_resolver
+        # Drop target for the gdb segv re-run, so the fuzzed source.py is never replayed as
+        # root. Mirrors config.process_uid/gid (the user the fuzzing children drop to).
+        self.drop_uid = drop_uid
+        self.drop_gid = drop_gid
         self.seen = collections.Counter()   # bug/new-key -> total crashes seen
         self.kept = collections.Counter()   # bug -> directories kept
 
     def _resolve(self, source_path):
         """Return a list of 'func@file:line' chain frames (normalising the resolver)."""
         r = self._resolver(source_path) if self._resolver is not None else (
-            gdb_crash_site(self.python_bin, source_path, self.gdb_timeout)
+            gdb_crash_site(self.python_bin, source_path, self.gdb_timeout,
+                           drop_uid=self.drop_uid, drop_gid=self.drop_gid)
             if (self.python_bin and source_path) else None)
         if not r:
             return []

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -301,5 +301,58 @@ class TestSegvResolution(unittest.TestCase):
         self.assertEqual(called, [])
 
 
+class TestGdbResolveDropsPrivileges(unittest.TestCase):
+    """gdb_crash_site re-runs the *fuzzed* source.py, so it must never do so with more
+    privilege than the fuzzing children had: drop to the configured user when root, and
+    confine cwd to the session dir (not the root-owned run-dir root)."""
+
+    SRC = "/run/inst-01/python-2/session-9/source.py"
+    SESSION_DIR = "/run/inst-01/python-2/session-9"
+
+    def _capture(self, *, uid, drop_uid=None, drop_gid=None):
+        """Stub subprocess.run + os.getuid; return the kwargs gdb_crash_site passed to run."""
+        captured = {}
+
+        class _Result:
+            stdout = ""  # no frames -> extract_sites_from_bt returns []
+
+        def fake_run(cmd, **kwargs):
+            captured["kwargs"] = kwargs
+            return _Result()
+
+        orig_run, orig_getuid = oom_dedup.subprocess.run, oom_dedup.os.getuid
+        oom_dedup.subprocess.run = fake_run
+        oom_dedup.os.getuid = lambda: uid
+        try:
+            oom_dedup.gdb_crash_site("/bin/python", self.SRC,
+                                     drop_uid=drop_uid, drop_gid=drop_gid)
+        finally:
+            oom_dedup.subprocess.run = orig_run
+            oom_dedup.os.getuid = orig_getuid
+        return captured["kwargs"]
+
+    def test_drops_to_user_and_confines_cwd_when_root(self):
+        kw = self._capture(uid=0, drop_uid=1001, drop_gid=1001)
+        self.assertEqual(kw["user"], 1001)
+        self.assertEqual(kw["group"], 1001)
+        self.assertEqual(kw["extra_groups"], [1001])  # root's supplementary groups dropped
+        self.assertEqual(kw["cwd"], self.SESSION_DIR)
+
+    def test_no_drop_when_already_unprivileged(self):
+        # A non-root caller is already unprivileged (and setgroups() would fail for it).
+        kw = self._capture(uid=1001, drop_uid=1001, drop_gid=1001)
+        self.assertNotIn("user", kw)
+        self.assertNotIn("group", kw)
+        self.assertNotIn("extra_groups", kw)
+        self.assertEqual(kw["cwd"], self.SESSION_DIR)  # cwd confinement still applies
+
+    def test_no_drop_target_runs_as_is_even_as_root(self):
+        # --unsafe (no process user) configures no drop target: behaviour unchanged.
+        kw = self._capture(uid=0)
+        self.assertNotIn("user", kw)
+        self.assertNotIn("group", kw)
+        self.assertEqual(kw["cwd"], self.SESSION_DIR)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`--oom-dedup-resolve-segv` re-runs the **fuzzed** `source.py` under gdb to resolve a crash site. `gdb_crash_site()` did this via `subprocess.run(...)` with **no privilege drop** and **no `cwd`**. The fleet launches each fusil instance as **root** with cwd = the root-owned `inst-NN/` run dir, so this re-executed untrusted fuzzed code **as root, in the run dir**.

A fuzzed `os.chmod`/`os.makedirs`/`os.lchmod`/… call in `source.py` (the `os` module fuzzer emits these with fuzzed path + mode args) then ran as root with a setuid/setgid mode and a run-dir-reaching path, leaving `inst-NN/` with a `drws--S---`-style mode. The non-root operator could no longer traverse it, so `fleet status/finds/triage` reported **0 crashes for a live instance** (observed on inst-01 and inst-03). The root-owned litter in every `inst-NN/` top dir comes from the same replays.

Same class as the `--filenames` clobbering bug (#95): **fuzzed code must never run with more privilege than the fuzzing children had.** The fuzzing children already drop to the `fusil` user (`prepare.py:changeUserGroup`); the gdb resolver was the one path bypassing it.

## Fix

- `gdb_crash_site()` gains `drop_uid`/`drop_gid`. When running as **root** and a drop target is configured, it passes `user=`/`group=`/`extra_groups=` to `subprocess.run` so gdb (and the python it spawns) drop to that user. A same-uid gdb can still ptrace the child it spawns, so segv resolution is unaffected.
- The replay now runs with `cwd=` the **session dir** (where `source.py` lives, matching the original child's cwd) instead of the root-owned run dir, so fuzzed relative-path filesystem calls can't escalate against the run tree.
- The drop target (`config.process_uid`/`process_gid`) is threaded through `Deduper`.
- A non-root caller is already unprivileged (and `setgroups()` would fail for it), so no drop is attempted then. Under `--unsafe` (no drop target) behaviour is unchanged.

## Tests

3 new runtime-free unit tests in `test_oom_dedup.py` (stub `subprocess.run` + `os.getuid`): drop applied as root, no drop when already unprivileged, no drop target ⇒ run as-is; cwd confinement asserted in all cases. Full `test_oom_dedup` + `test_oom_dedup_wiring`: **37 passed**.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)