### PR TITLE
Phase 0: un-break the test suite

### DIFF
--- a/fusil/python/jit/ast_pattern_generator.py
+++ b/fusil/python/jit/ast_pattern_generator.py
@@ -372,7 +372,7 @@ class ASTPatternGenerator:
             self._create_call_node: 0.2,
             self._create_attribute_assignment_node: 0.2,
             self._create_attribute_deletion_node: 0.1,
-            # self._create_if_node: 0.15,
+            self._create_if_node: 0.15,
             self._create_for_node: 0.15,
         }
 

--- a/tests/python/_test_options.py
+++ b/tests/python/_test_options.py
@@ -1,0 +1,43 @@
+"""Shared test helper: a fully-populated fuzzer *options* object.
+
+Tests that instantiate ``WritePythonCode`` (and friends) need an options object that
+carries every ``--*`` attribute the generator reads. Hand-maintaining that list in each
+test's ``setUp`` is what rotted the suite before (a new option added to the code ->
+``AttributeError`` in every test). Instead we harvest the **real** defaults straight from
+the fuzzer's own option parser, so new options appear automatically.
+
+Not collected by ``unittest discover`` (the default pattern is ``test*.py``; this module's
+name starts with an underscore).
+"""
+from functools import lru_cache
+from types import SimpleNamespace
+
+from fusil.config import FusilConfig, OptionParserWithSections
+from fusil.python import Fuzzer
+
+
+@lru_cache(maxsize=1)
+def _harvested_defaults():
+    """All fuzzing-option defaults, harvested from Fuzzer.createFuzzerOptions().
+
+    createFuzzerOptions only touches the parser plus ``self.plugin_manager.get_cli_options``,
+    so a tiny stub is enough to drive it without constructing a full Application.
+    """
+    parser = OptionParserWithSections()
+    stub = SimpleNamespace(
+        plugin_manager=SimpleNamespace(get_cli_options=lambda: [])
+    )
+    Fuzzer.createFuzzerOptions(stub, parser)
+    return vars(parser.get_default_values())
+
+
+def make_test_options(**overrides):
+    """Return a ``FusilConfig(read=False)`` populated with every real fuzzer-option
+    default, then any ``overrides``. Use this in test ``setUp`` instead of hand-listing
+    options."""
+    options = FusilConfig(read=False)
+    for name, value in _harvested_defaults().items():
+        setattr(options, name, value)
+    for name, value in overrides.items():
+        setattr(options, name, value)
+    return options

--- a/tests/python/samples/test_tricky_numpy.py
+++ b/tests/python/samples/test_tricky_numpy.py
@@ -1,7 +1,6 @@
 import unittest
 import sys
 import os
-import numpy
 
 # --- Test Setup: Path Configuration ---
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -9,12 +8,16 @@ PROJECT_ROOT = os.path.join(SCRIPT_DIR, '..', '..', '..')
 sys.path.insert(0, PROJECT_ROOT)
 
 try:
+    # numpy is optional; when absent the whole suite skips (see skipIf below) rather
+    # than erroring on import.
+    import numpy
     # --- Import all the objects to be tested ---
     from fusil.python.samples import tricky_numpy
 
     NUMPY_AVAILABLE = True
 except (ImportError, TypeError) as e:
     print(f"Could not import tricky_numpy module, skipping tests: {e}", file=sys.stderr)
+    numpy = None
     tricky_numpy = None
     NUMPY_AVAILABLE = False
 

--- a/tests/python/test_write_jit_code.py
+++ b/tests/python/test_write_jit_code.py
@@ -10,7 +10,14 @@ from fusil.python.jit.write_jit_code import WriteJITCode
 from fusil.python.write_python_code import WritePythonCode
 from fusil.python.argument_generator import ArgumentGenerator
 from fusil.python.jit.bug_patterns import BUG_PATTERNS
-from fusil.python.jit.ast_mutator import OperatorSwapper
+
+# The AST mutator was extracted into the lafleur project; fusil imports it from there
+# (write_jit_code.py degrades gracefully when lafleur is absent). The test below that
+# exercises OperatorSwapper directly is skipped when lafleur is not installed.
+try:
+    from lafleur.mutator import OperatorSwapper
+except ImportError:
+    OperatorSwapper = None
 
 
 class TestWriteJITCode(unittest.TestCase):
@@ -335,6 +342,8 @@ class TestWriteJITCode(unittest.TestCase):
         self.assertTrue(found_if, "ASTPatternGenerator failed to generate an 'if' statement after 100 attempts.")
         self.assertTrue(found_for, "ASTPatternGenerator failed to generate a 'for' statement after 100 attempts.")
 
+    @unittest.skipUnless(OperatorSwapper is not None,
+                         "lafleur (ASTMutator/OperatorSwapper) is not installed")
     def test_ast_mutator_operator_swapper(self):
         """
         Logic Test: Unit tests the OperatorSwapper transformer to ensure it

--- a/tests/python/test_write_python_code.py
+++ b/tests/python/test_write_python_code.py
@@ -17,6 +17,7 @@ sys.path.insert(0, PROJECT_ROOT)
 # --- Imports of Code to be Tested ---
 from fusil.python.write_python_code import WritePythonCode, PythonFuzzerError
 from fusil.config import FusilConfig
+from python._test_options import make_test_options
 # The following are imported to create realistic mocks or for type checks
 import fusil.python.tricky_weird
 
@@ -88,16 +89,18 @@ class TestWritePythonCode(unittest.TestCase):
         # This simulates the environment in which WritePythonCode operates.
         self.mock_python_source = MagicMock()
 
-        # We use a real FusilConfig object to hold realistic options.
-        options = FusilConfig(read=False)
-        options.functions_number = 5
-        options.methods_number = 3
-        options.classes_number = 2
-        options.objects_number = 2
-        options.fuzz_exceptions = False
-        options.test_private = False
-        options.no_numpy = True  # Disable numpy-dependent features by default for simpler tests
-        options.no_tstrings = True  # Disable template strings by default
+        # All real fuzzer-option defaults (harvested from the option parser so the suite
+        # doesn't rot when new options are added), with test-specific overrides.
+        options = make_test_options(
+            functions_number=5,
+            methods_number=3,
+            classes_number=2,
+            objects_number=2,
+            fuzz_exceptions=False,
+            test_private=False,
+            no_numpy=True,  # Disable numpy-dependent features by default for simpler tests
+            no_tstrings=True,  # Disable template strings by default
+        )
         self.mock_python_source.options = options
         self.mock_python_source.filenames = ["/tmp/test_file1.txt", "/tmp/test_file2.log"]
         self.mock_python_source.warning = MagicMock()  # Mock the logger to avoid printing during tests
@@ -223,11 +226,13 @@ class TestWritePythonCode(unittest.TestCase):
 
     def test_write_arguments_for_call_lines_formatting(self):
         """Logic Test: Ensures _write_arguments_for_call_lines places commas and newlines correctly."""
+        # _write_arguments_for_call_lines appends a trailing comma after every argument
+        # (valid Python in a multi-line call; long-standing behavior).
         test_cases = {
             "zero_args": (0, [], ""),
-            "one_arg": (1, [["'arg1'"]], "'arg1'"),
-            "two_args": (2, [["'arg1'"], ["'arg2'"]], "'arg1',\n 'arg2'"),
-            "one_multiline_arg": (1, [["'line1'", "'line2'"]], "'line1' 'line2'")
+            "one_arg": (1, [["'arg1'"]], "'arg1',"),
+            "two_args": (2, [["'arg1'"], ["'arg2'"]], "'arg1',\n 'arg2',"),
+            "one_multiline_arg": (1, [["'line1'", "'line2'"]], "'line1' 'line2',")
         }
         for name, (num_args, arg_gen_return, expected_output) in test_cases.items():
             with self.subTest(name=name):

--- a/tests/python/test_write_python_code_private.py
+++ b/tests/python/test_write_python_code_private.py
@@ -15,6 +15,7 @@ sys.path.insert(0, PROJECT_ROOT)
 # --- Imports of Code to be Tested ---
 from fusil.python.write_python_code import WritePythonCode, PythonFuzzerError
 from fusil.config import FusilConfig
+from python._test_options import make_test_options
 import fusil.python.tricky_weird
 
 # Conditional import for h5py to match the logic in the tested code
@@ -68,15 +69,17 @@ class TestWritePythonCodePrivateMethods(unittest.TestCase):
     def setUp(self):
         """Set up a fresh test fixture before each test method runs."""
         self.mock_python_source = MagicMock()
-        options = FusilConfig(read=False)
-        options.functions_number = 5
-        options.methods_number = 3
-        options.classes_number = 2
-        options.objects_number = 2
-        options.fuzz_exceptions = False
-        options.test_private = False
-        options.no_numpy = True
-        options.no_tstrings = True
+        # All real fuzzer-option defaults (harvested from the option parser) + overrides.
+        options = make_test_options(
+            functions_number=5,
+            methods_number=3,
+            classes_number=2,
+            objects_number=2,
+            fuzz_exceptions=False,
+            test_private=False,
+            no_numpy=True,
+            no_tstrings=True,
+        )
         self.mock_python_source.options = options
         self.mock_python_source.filenames = ["/tmp/test_file.txt"]
         self.mock_python_source.warning = MagicMock()
@@ -120,11 +123,13 @@ class TestWritePythonCodePrivateMethods(unittest.TestCase):
 
     def test_write_arguments_for_call_lines_formatting(self):
         """Logic Test: Ensures _write_arguments_for_call_lines places commas and newlines correctly."""
+        # _write_arguments_for_call_lines appends a trailing comma after every argument
+        # (valid Python in a multi-line call; long-standing behavior).
         test_cases = {
             "zero_args": (0, [], ""),
-            "one_arg": (1, [["'arg1'"]], "'arg1'"),
-            "two_args": (2, [["'arg1'"], ["'arg2'"]], "'arg1',\n 'arg2'"),
-            "one_multiline_arg": (1, [["'line1'", "'line2'"]], "'line1' 'line2'"),
+            "one_arg": (1, [["'arg1'"]], "'arg1',"),
+            "two_args": (2, [["'arg1'"], ["'arg2'"]], "'arg1',\n 'arg2',"),
+            "one_multiline_arg": (1, [["'line1'", "'line2'"]], "'line1' 'line2',"),
         }
         for name, (num_args, arg_gen_return, expected_output) in test_cases.items():
             with self.subTest(name=name):


### PR DESCRIPTION
First step of the tech-debt sweep (refs #106): make `python -m unittest discover -s tests` a reliable safety net before the structural work.

Before this PR the suite had 1 import error + 22 errors + ~7 failures (a mix of test rot and one masked real check). After: **229 tests, OK (skipped=30)** without numpy/h5py installed.

Changes:
- **Un-break the import:** `test_write_jit_code.py` imported the removed `fusil.python.jit.ast_mutator` (moved to lafleur). Guard the import; skip only the `OperatorSwapper` test when lafleur is absent.
- **Stop the option-stub rot:** add `tests/python/_test_options.py`, which harvests the *real* fuzzer-option defaults from the option parser, and use it in `TestWritePythonCode` / `_private` setUps. The hand-maintained stubs had gone stale (missing `jit_external_references`, `oom_*`), erroring every test in `setUp`. Now new options appear automatically.
- **Stale expectations:** `test_write_arguments_for_call_lines_formatting` expected no trailing comma, but the generator has appended one after every argument since May 2025 (valid Python). Update the expectations.
- **Re-enable `_create_if_node`** in `ASTPatternGenerator`'s grammar — it was accidentally commented out though the method and its dispatch handling remained — fixing `test_ast_pattern_generator_creates_control_flow`.
- **Graceful numpy skip:** `test_tricky_numpy` imported numpy before its own try/except, erroring instead of skipping when numpy is absent.

Note: `test_h5py_argument_generator.test_genH5PySliceForDirectIO_expr_runtime` is a pre-existing *flaky* (randomized) test — passes consistently here but should be seeded; tracked for Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)