### PR TITLE
Phase 0: re-enable fuzzed-child safety controls (ASan-safe memory cap)

### DIFF
--- a/fusil/process/create.py
+++ b/fusil/process/create.py
@@ -10,7 +10,7 @@ from fusil.process.cmdline import CommandLine
 from fusil.process.env import Environment
 from fusil.process.prepare import ChildError, prepareProcess
 from fusil.process.replay_python import createReplayPythonScript
-from fusil.process.tools import displayProcessStatus, locateProgram, splitCommand
+from fusil.process.tools import displayProcessStatus, locateProgram, splitCommand, target_is_asan
 from fusil.project_agent import ProjectAgent
 
 from pwd import getpwuid
@@ -54,6 +54,14 @@ class CreateProcess(ProjectAgent):
         self.cmdline = CommandLine(self, arguments)
         self.timeout = timeout
         self.max_memory = config.process_max_memory
+        # ASan targets reserve a huge virtual address space; applying RLIMIT_AS would
+        # kill them on startup (this is why the memory cap was historically disabled
+        # wholesale). Drop the cap for ASan builds (auto-detected) or when the user
+        # passes --no-memory-limit; the external cgroup cap (e.g. the fleet's systemd
+        # MemoryMax) is the real limit in that setup.
+        program = arguments[0] if arguments else None
+        if getattr(options, "no_memory_limit", False) or target_is_asan(program):
+            self.max_memory = 0
         self.max_user_process = config.process_max_user_process
         self.core_dump = config.process_core_dump
         self.stdout = stdout

--- a/fusil/process/prepare.py
+++ b/fusil/process/prepare.py
@@ -56,8 +56,7 @@ def prepareProcess(process):
 
     # Make sure that the program is executable by the current user
     program = process.current_arguments[0]
-    # if not access(program, X_OK):
-    if 0:
+    if not access(program, X_OK):
         user = getuid()
         user = getpwuid(user).pw_name
         message = "The user %s is not allowed to execute the file %s" % (user, program)
@@ -67,9 +66,9 @@ def prepareProcess(process):
         print(message, file=stderr)
         raise ChildError(message)
 
-    # Limit process resources
-    if 0:
-        limitResources(process, config, options)
+    # Limit process resources (memory cap is skipped for ASan targets / --no-memory-limit;
+    # see CreateProcess.__init__ where max_memory is zeroed in that case).
+    limitResources(process, config, options)
 
 
 def limitResources(process, config, options):

--- a/fusil/process/tools.py
+++ b/fusil/process/tools.py
@@ -1,8 +1,9 @@
 import re
+from functools import lru_cache
 from os import X_OK, access, devnull, getcwd, getenv, pathsep
 from os.path import dirname, isabs, normpath
 from os.path import join as path_join
-from subprocess import STDOUT, Popen
+from subprocess import STDOUT, Popen, SubprocessError, run
 
 
 from resource import (
@@ -40,6 +41,36 @@ def _setrlimit(key, value, change_hard):
 
 def limitMemory(nbytes, hard=False):
     return _setrlimit(RLIMIT_AS, nbytes, hard)
+
+
+@lru_cache(maxsize=8)
+def target_is_asan(program):
+    """Best-effort: is ``program`` (an interpreter) built with AddressSanitizer?
+
+    ASan reserves an enormous virtual address space, so applying ``RLIMIT_AS`` (the
+    fuzzed-child memory cap) to an ASan target kills it on startup. Detected from the
+    interpreter's own build configuration (``CONFIG_ARGS`` records
+    ``--with-address-sanitizer``), with an ``ldd`` fallback. Any failure -> ``False``
+    (assume not ASan; the caller then applies the normal cap). Cached so the one-time
+    probe doesn't re-run per process.
+    """
+    if not program:
+        return False
+    try:
+        out = run(
+            [program, "-c",
+             "import sysconfig; print(sysconfig.get_config_var('CONFIG_ARGS') or '')"],
+            capture_output=True, text=True, timeout=15,
+        ).stdout.lower()
+        if "sanitiz" in out or "address-sanitizer" in out:
+            return True
+    except (OSError, ValueError, SubprocessError):
+        pass
+    try:
+        out = run(["ldd", program], capture_output=True, text=True, timeout=15).stdout.lower()
+        return "asan" in out
+    except (OSError, ValueError, SubprocessError):
+        return False
 
 
 def limitUserProcess(nproc, hard=False):

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -23,8 +23,6 @@ with warnings.catch_warnings():
     from fusil.python.utils import print_running_time, remove_logging_pycache
     from fusil.python.write_python_code import time_start
 
-print(sys.version)
-
 IGNORE_TIMEOUT = True
 IGNORE_CPU = True
 SHOW_STDOUT = False
@@ -104,6 +102,14 @@ class Fuzzer(Application):
             help="Python executable program path (default: %s)" % PYTHON,
             type="str",
             default=PYTHON,
+        )
+        running_options.add_option(
+            "--no-memory-limit",
+            help="Don't apply the per-child memory cap (RLIMIT_AS). Automatically "
+                 "implied for AddressSanitizer targets, whose huge address-space "
+                 "reservation is incompatible with RLIMIT_AS (default: False)",
+            action="store_true",
+            default=False,
         )
         running_options.add_option(
             "--record-timeouts",

--- a/tests/python/test_process_limits.py
+++ b/tests/python/test_process_limits.py
@@ -1,0 +1,81 @@
+"""Characterization tests for the fuzzed-child resource limits (fusil.process).
+
+Pins the behavior re-enabled in Phase 0: the per-child memory cap is applied again,
+but skipped for AddressSanitizer targets (whose huge address-space reservation is
+incompatible with RLIMIT_AS) and when --no-memory-limit is set. Runtime-free: the
+subprocess probe and the rlimit helpers are mocked, so no real limits are set.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fusil.process import prepare, tools
+
+
+class TestTargetIsAsan(unittest.TestCase):
+    def setUp(self):
+        tools.target_is_asan.cache_clear()
+        self.addCleanup(tools.target_is_asan.cache_clear)
+
+    def _run_returning(self, config_args="", ldd=""):
+        """Return a fake subprocess.run that answers the CONFIG_ARGS probe then ldd."""
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "ldd":
+                return SimpleNamespace(stdout=ldd)
+            return SimpleNamespace(stdout=config_args)
+        return fake_run
+
+    def test_detects_asan_from_config_args(self):
+        with patch.object(tools, "run",
+                          self._run_returning(config_args="'--with-address-sanitizer'")):
+            self.assertTrue(tools.target_is_asan("/builds/asan/python"))
+
+    def test_non_asan_build_from_config_args(self):
+        with patch.object(tools, "run",
+                          self._run_returning(config_args="'--with-pydebug' 'CC=clang'")):
+            self.assertFalse(tools.target_is_asan("/builds/plain/python"))
+
+    def test_ldd_fallback_when_config_args_silent(self):
+        # CONFIG_ARGS has no sanitizer hint, but ldd reveals libasan.
+        with patch.object(tools, "run",
+                          self._run_returning(config_args="", ldd="libasan.so.8 => ...")):
+            self.assertTrue(tools.target_is_asan("/builds/ldd-asan/python"))
+
+    def test_none_program_is_not_asan(self):
+        self.assertFalse(tools.target_is_asan(None))
+
+    def test_probe_failure_is_not_asan(self):
+        def boom(cmd, **kwargs):
+            raise OSError("no such program")
+        with patch.object(tools, "run", boom):
+            self.assertFalse(tools.target_is_asan("/nonexistent"))
+
+
+class TestLimitResourcesGating(unittest.TestCase):
+    """limitResources should not apply a hard memory cap when max_memory is 0 (the value
+    CreateProcess uses for ASan / --no-memory-limit), but should otherwise."""
+
+    def _call(self, max_memory, fusil_max_memory=0):
+        process = SimpleNamespace(max_memory=max_memory, core_dump=False,
+                                  max_user_process=0)
+        config = SimpleNamespace(fusil_max_memory=fusil_max_memory, process_user=None)
+        options = SimpleNamespace(fast=True)  # fast => skip beNice
+        with patch.object(prepare, "limitMemory") as lm, \
+                patch.object(prepare, "allowCoreDump"), \
+                patch.object(prepare, "limitUserProcess"), \
+                patch.object(prepare, "beNice"):
+            prepare.limitResources(process, config, options)
+        return lm
+
+    def test_no_hard_cap_when_max_memory_zero(self):
+        lm = self._call(max_memory=0, fusil_max_memory=0)
+        lm.assert_not_called()
+
+    def test_hard_cap_applied_when_max_memory_positive(self):
+        cap = 2000 * 1024 * 1024
+        lm = self._call(max_memory=cap)
+        lm.assert_called_once_with(cap, hard=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #106. Restores two safety controls in `process/prepare.py` that were disabled with orphaned `if 0:` blocks (leftovers from a hasty Oct-2025 "Temp fix") and still live in the tree — these are genuine bugs, not just debt.

## What was broken
- **`limitResources()` was fully disabled** → the per-child memory cap (`RLIMIT_AS`), core-dump control, nice level, and process-count cap silently did not apply. For an OOM fuzzer that deliberately drives allocation failure, an unbounded child can OOM the whole machine; `doc/safety.rst` still advertised the cap as active.
- **The executable-permission check was disabled.**

## ASan-safe memory cap
The cap was originally disabled because ASan targets reserve a ~20 TB virtual address space that `RLIMIT_AS` kills on startup. Instead of all-or-nothing:
- `tools.target_is_asan(program)` — best-effort detection from the interpreter's own `CONFIG_ARGS` (`--with-address-sanitizer`), with an `ldd` fallback; cached.
- `CreateProcess.__init__` zeroes `max_memory` (so `limitResources` skips `RLIMIT_AS`) for ASan targets **or** when the new `--no-memory-limit` option is set. The external cgroup cap (e.g. the fleet's systemd `MemoryMax`) is the real limit there. **Non-ASan runs get the `RLIMIT_AS` safety back.**

Also drops a stray import-time `print(sys.version)` that polluted stdout (scraped by the crash detector).

## Verification
- New runtime-free tests (`tests/python/test_process_limits.py`): ASan detection (CONFIG_ARGS + ldd fallback + failure modes) and the limit gating (no hard cap when `max_memory==0`, cap applied otherwise).
- Auto-detect confirmed on the matrix builds: `ft-nojit-asan` → True, `ft-nojit` → False.
- End-to-end: a 1-session run on the ASan build executes the child without the cap killing it.
- Full suite: **236 tests, OK (skipped=30)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)