### PR TITLE
Phase 2b: route library prints through logging; de-flake h5py test

### DIFF
--- a/fusil/directory.py
+++ b/fusil/directory.py
@@ -1,12 +1,14 @@
 import grp
+import logging
 import pwd
-import resource
 from os import chmod, chown, mkdir, scandir, umask
 from os.path import basename
 from os.path import exists as path_exists
 from os.path import join as path_join
 from shutil import rmtree
 from sys import getfilesystemencoding
+
+logger = logging.getLogger(__name__)
 
 
 class Directory:
@@ -30,7 +32,7 @@ class Directory:
                 gid = grp.getgrnam("fusil").gr_gid
                 chown(self.directory, uid, gid)
             except Exception as e:
-                print(e)
+                logger.warning("Could not chown %s to fusil: %s", self.directory, e)
         umask(old_umask)
 
     def isEmpty(self, ignore_generated=False):
@@ -45,8 +47,7 @@ class Directory:
                 return False
             return True
         except OSError as e:
-            print(e)
-            print(resource.getrusage(resource.RUSAGE_SELF))
+            logger.warning("Could not scan directory %s: %s", self.directory, e)
             return False
 
     def rmtree(self):

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -54,7 +54,7 @@ class PythonSource(ProjectAgent):
             ).search_modules()
 
         if self.options.packages != "*":
-            print("\nAdding packages...")
+            self.info("Adding packages...")
             all_modules = ListAllModules(
                 self,
                 self.options.only_c,
@@ -72,12 +72,12 @@ class PythonSource(ProjectAgent):
                     continue
                 pack = __import__(package)
                 path = pack.__path__[0]
-                print(f"Adding package: {package} ({path})")
+                self.info("Adding package: %s (%s)" % (package, path))
                 package_walker = all_modules.discover_modules([path], package + ".")
                 self.modules |= set(name for finder, name, ispgk in package_walker)
 
-            if self.options.verbose:
-                print(f"\nKnown modules ({len(self.modules)}): {','.join(sorted(self.modules))}")
+            self.info("Known modules (%d): %s"
+                      % (len(self.modules), ",".join(sorted(self.modules))))
 
         blacklist_str = self.options.blacklist
         if blacklist_str:

--- a/fusil/python/tricky_weird.py
+++ b/fusil/python/tricky_weird.py
@@ -7,13 +7,16 @@ circular references, and other pathological objects that can expose crashes and 
 undesirable behavior in Python code and C extensions.
 """
 
+import logging
 import pathlib
 from fusil.python.samples import weird_classes, tricky_typing, tricky_objects
+
+logger = logging.getLogger(__name__)
 
 try:
     from fusil.python.samples import tricky_numpy
 except ImportError:
-    print("Could not import tricky_numpy.")
+    logger.info("Could not import tricky_numpy (numpy not available).")
     tricky_numpy = None
 
 weird_instance_names = list(weird_classes.weird_instances.keys())

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import inspect
+import logging
 import time
 from random import choice, randint, random
 from textwrap import dedent, indent
@@ -22,34 +23,39 @@ from fusil.write_code import WriteCode
 if TYPE_CHECKING:
     from fusil.python.python_source import PythonSource
 
+# Module logger for the optional-feature detection below. These run at import time (before
+# the ApplicationLogger configures the root logger), so they no longer print unconditionally
+# to stdout (which the crash detector scrapes); they surface in fusil.log / under -v instead.
+logger = logging.getLogger(__name__)
+
 try:
     from fusil.python.template_strings import TEMPLATES
 
-    print("Template strings available.")
+    logger.info("Template strings available.")
     _ARG_GEN_USE_TEMPLATES = True
 except ImportError:
-    print("Template strings not available.")
+    logger.info("Template strings not available.")
     _ARG_GEN_USE_TEMPLATES = False
 
 try:
     import numpy  # type: ignore
 
-    print(f"Numpy {numpy.__version__} is available, using it to build tricky arrays.")
+    logger.info("Numpy %s is available, using it to build tricky arrays.", numpy.__version__)
     _ARG_GEN_USE_NUMPY = True
 except ImportError:
-    print("Numpy is not available.")
+    logger.info("Numpy is not available.")
     _ARG_GEN_USE_NUMPY = False
 
 _ARG_GEN_USE_H5PY = False
 if _ARG_GEN_USE_NUMPY:
     try:
         import h5py
-        print(f"h5py is available.")
+        logger.info("h5py is available.")
         _ARG_GEN_USE_H5PY = True
         from fusil.python.h5py.write_h5py_code import WriteH5PyCode
         import fusil.python.h5py.h5py_tricky_weird
     except ImportError:
-        print("h5py is not available.")
+        logger.info("h5py is not available.")
         _ARG_GEN_USE_H5PY = False
 
 time_start = time.time()

--- a/tests/python/test_h5py_argument_generator.py
+++ b/tests/python/test_h5py_argument_generator.py
@@ -1130,6 +1130,7 @@ class TestH5PyArgumentGenerator(unittest.TestCase):
                     if base_dtype_expr.isidentifier() and base_dtype_expr in self.test_globals:
                         del self.test_globals[base_dtype_expr]
 
+    @unittest.skipUnless(USE_NUMPY, "evaluates a numpy.s_ slice expression; needs numpy")
     def test_genH5PySliceForDirectIO_expr_runtime(self):
         rank_var_name = "my_rank_variable"
         self.test_globals[rank_var_name] = 2  # Example rank for eval
@@ -1333,6 +1334,7 @@ class TestH5PyArgumentGenerator(unittest.TestCase):
                     if base_dtype_expr.isidentifier() and base_dtype_expr in self.test_globals:
                         del self.test_globals[base_dtype_expr]
 
+    @unittest.skipUnless(USE_NUMPY, "evaluates a numpy.s_ slice expression; needs numpy")
     def test_genH5PySliceForDirectIO_expr_runtime_2(self):
         # This was also previously tested. This ensures it's robust.
         rank_var_name = "my_rank_variable_for_runtime_slice"


### PR DESCRIPTION
Refs #106. The fuzzer's `ApplicationLogger` is a dual-sink (terse stdout + verbose `fusil.log`) with per-session/agent context prefixes — not bare prints. This routes the stdout-polluting library prints through it, mindful of that design:

- **`write_python_code.py` + `tricky_weird.py`:** import-time optional-feature banners ("Template strings available." / "Numpy … available" / "h5py …" / "Could not import tricky_numpy") now use a module logger instead of unconditional `print()` to stdout (which the crash detector scrapes). Silent by default; visible under `-v` / in `fusil.log`.
- **`python_source.py`:** the "Adding packages / Adding package / Known modules" prints become `self.info()`, picking up the agent logger's context prefix + dual-sink.
- **`directory.py`:** chown/scandir failures become module-logger warnings; drop the `resource.getrusage()` debug dump (+ the now-unused `import resource`).

The intentional `[OOM]`/`[OOM-SEQ]` markers written into the generated child script (`file=stderr`) are left as-is — they're harness output the dedup/triage rely on.

**De-flake:** the two `genH5PySliceForDirectIO_expr_runtime` tests `eval()` a possibly-`numpy.s_[...]` expression that fails only when numpy is absent (the generator picks that branch at random — this was the intermittent failure seen across earlier phases). Guarded with `skipUnless(USE_NUMPY)`; all other assertions in the class still run without numpy. **Suite now consistently green across repeated runs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)