### PR TITLE
Phase 3: make deep-diving opt-in (--deep-dive, default off)

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -174,6 +174,13 @@ class Fuzzer(Application):
             default=False,
         )
         fuzzing_options.add_option(
+            "--deep-dive",
+            help="Recursively fuzz the return value of every method call (multiplicative; "
+                 "off by default)",
+            action="store_true",
+            default=False,
+        )
+        fuzzing_options.add_option(
             "--no-async",
             help="Don't run code asynchronously (default: False)",
             action="store_true",

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -1273,38 +1273,40 @@ class WritePythonCode(WriteCode):
             self.emptyLine()
             return
 
-        self.write(0, f"# Deep dive on result of {callable_name}")
-        self.write(
-            0,
-            f"if 'res_{prefix}' in locals() and res_{prefix} is not None and res_{prefix} is not SENTINEL_VALUE:",
-        )
-        # We need to ensure SENTINEL_VALUE is defined if callMethod uses it.
-        # Let's assume res_{prefix} is the actual return value.
-        L_deep_dive_res = self.addLevel(1)
-        try:
-            self.write(0, f"{prefix}_res_type_name = type(res_{prefix}).__name__")
-            self.write(0, f"try:")
-            L_before_repr = self.addLevel(1)
-            self.write_print_to_stderr(
+        # Deep dive on the result: recursively fuzz the method's return value. This is
+        # opt-in (--deep-dive, default off) -- it is multiplicative (every returning call
+        # spawns another round of fuzzing on the result) and has not historically paid off.
+        if self.options.deep_dive:
+            self.write(0, f"# Deep dive on result of {callable_name}")
+            self.write(
                 0,
-                f"f'CALL_RESULT ({prefix}): Method {callable_name} returned {{res_{prefix}!r}} of type {{{prefix}_res_type_name}}. Attempting deep dive.'",
+                f"if 'res_{prefix}' in locals() and res_{prefix} is not None and res_{prefix} is not SENTINEL_VALUE:",
             )
-            self.restoreLevel(L_before_repr)
-            self.write(0, f"except Exception as e:")
-            L_after_repr = self.addLevel(1)
-            self.write_print_to_stderr(
-                0,
-                f"f'EXCEPTION printing CALL_RESULT: {{ e }}'",
-            )
-            self.restoreLevel(L_after_repr)
-            self._dispatch_fuzz_on_instance(
-                current_prefix=f"{prefix}_res_dive",
-                target_obj_expr_str=f"res_{prefix}",  # The variable holding the result
-                class_name_hint=f"{prefix}_res_type_name",  # Runtime type name
-                generation_depth=generation_depth + 1,  # Incremented depth
-            )
-        finally:
-            self.restoreLevel(L_deep_dive_res)
+            L_deep_dive_res = self.addLevel(1)
+            try:
+                self.write(0, f"{prefix}_res_type_name = type(res_{prefix}).__name__")
+                self.write(0, f"try:")
+                L_before_repr = self.addLevel(1)
+                self.write_print_to_stderr(
+                    0,
+                    f"f'CALL_RESULT ({prefix}): Method {callable_name} returned {{res_{prefix}!r}} of type {{{prefix}_res_type_name}}. Attempting deep dive.'",
+                )
+                self.restoreLevel(L_before_repr)
+                self.write(0, f"except Exception as e:")
+                L_after_repr = self.addLevel(1)
+                self.write_print_to_stderr(
+                    0,
+                    f"f'EXCEPTION printing CALL_RESULT: {{ e }}'",
+                )
+                self.restoreLevel(L_after_repr)
+                self._dispatch_fuzz_on_instance(
+                    current_prefix=f"{prefix}_res_dive",
+                    target_obj_expr_str=f"res_{prefix}",  # The variable holding the result
+                    class_name_hint=f"{prefix}_res_type_name",  # Runtime type name
+                    generation_depth=generation_depth + 1,  # Incremented depth
+                )
+            finally:
+                self.restoreLevel(L_deep_dive_res)
 
         if self.enable_threads or self.enable_async:
             self.write(0, "target_func = None")

--- a/tests/python/test_write_python_code.py
+++ b/tests/python/test_write_python_code.py
@@ -246,6 +246,36 @@ class TestWritePythonCode(unittest.TestCase):
                 expected = " ".join(expected_output.split())
                 self.assertEqual(actual, expected)
 
+    def _generate_one_call(self):
+        """Run _generate_and_write_call for a simple function and return the generated code."""
+        def sample_func_for_test(a, b): pass
+        self.mock_module.sample_func_for_test = sample_func_for_test
+        self.writer.output = StringIO()
+        with patch.object(self.writer, '_write_arguments_for_call_lines'):
+            self.writer._generate_and_write_call(
+                prefix="dd",
+                callable_name="sample_func_for_test",
+                callable_obj=sample_func_for_test,
+                min_arg_count=1,
+                target_obj_expr="fuzz_target_module",
+                is_method_call=True,
+                generation_depth=0,
+            )
+        return self.writer.output.getvalue()
+
+    def test_deep_dive_is_off_by_default(self):
+        """--deep-dive defaults off: no recursive result-fuzzing code is generated."""
+        self.writer.options.deep_dive = False
+        code = self._generate_one_call()
+        self.assertNotIn("Deep dive on result", code)
+        self.assertNotIn("Attempting deep dive", code)
+
+    def test_deep_dive_emitted_when_enabled(self):
+        """With --deep-dive, the result of the call is recursively fuzzed."""
+        self.writer.options.deep_dive = True
+        code = self._generate_one_call()
+        self.assertIn("Deep dive on result", code)
+
     @patch('fusil.python.write_python_code.get_arg_number', return_value=(2, 4))
     @patch('fusil.python.write_python_code.randint')
     def test_generate_and_write_call_argument_logic(self, mock_randint, mock_get_args):


### PR DESCRIPTION
Refs #106. "Deep diving" recursively fuzzes the **return value of every method call** — multiplicative (each returning call spawns another round, up to `MAX_FUZZ_GENERATION_DEPTH`) and it has never found a bug. Now it costs nothing unless requested.

- Add `--deep-dive` (default `False`) to the Fuzzing option group.
- Gate the recursive result-dive block in `_generate_and_write_call` behind `self.options.deep_dive`. The depth-0 dispatch (initial fuzzing of a top-level instance's own methods) is unchanged — only the recursion into call *results* is gated.
- Tests: off → no deep-dive code emitted; on → present.

Left as-is (revisit in Phase 5 when h5py is installed/testable): the analogous recursive dispatches inside the optional h5py generator.

Suite green (231 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)