### PR TITLE
Phase 5: verify numpy/h5py support; bump floor to 3.13; de-flake h5py tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,12 @@ paths via `--oom-fuzz` (see the OOM section).
   fuzzing run still wants the dedicated `fusil` user / `--unsafe`; see Commands.)
 - `numpy` and `h5py` are optional; when absent, the relevant argument generators and tests
   skip gracefully (you'll see "Could not import tricky_numpy" / "Numpy is not available").
+  Their support **is** verified to work when present: with `numpy`+`h5py` installed the suite
+  runs the h5py/numpy tests (skips drop from ~32 to 1) and passes. They have no wheels for the
+  free-threaded debug `3.16t` dev venv, so verification uses a normal-CPython venv
+  (`~/venvs/fusil_np_verify`, CPython 3.14) — see the numpy/h5py PR.
+- Python floor is **3.13+** (`requires-python`): the code uses PEP 701 f-strings (3.12) and
+  `types.CapsuleType` (3.13). Earlier metadata claimed 3.11, which never actually worked.
 - Tooling in the dev box: `gdb` (`/usr/bin/gdb`) is available and used by OOM-dedup segv
   resolution; `ruff` (`/snap/bin/ruff`) is available for linting; `pyflakes` is **not**
   installed (so `pyflakes.sh` won't run as-is), and `pytest` is not installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 maintainers = [
     {name = "Daniel Diniz", email = "lafleurfuzzer@gmail.com"},
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 license = {text = "GNU GPL v2"}
 keywords = ["fuzzing", "fuzzer", "security", "testing"]
 classifiers = [
@@ -23,7 +23,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
@@ -60,7 +59,7 @@ namespaces = false
 
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+target-version = "py313"
 # Legacy / parked code is not maintained to the lint/format standard.
 extend-exclude = ["fusil/notworking", "fuzzers/notworking", "tools/notworking"]
 

--- a/tests/python/test_h5py_argument_generator.py
+++ b/tests/python/test_h5py_argument_generator.py
@@ -3,7 +3,7 @@ import re
 import sys
 import unittest
 from random import choice as random_choice
-from random import randint, random, sample, uniform
+from random import randint, random, sample, seed, uniform
 from unittest.mock import MagicMock, patch
 
 USE_NUMPY = USE_H5PY = True
@@ -37,6 +37,9 @@ class TestH5PyArgumentGenerator(unittest.TestCase):
         Set up for each test.
         H5PyArgumentGenerator requires a parent ArgumentGenerator instance.
         """
+        # The generator picks expressions/transforms at random; seed for determinism so
+        # these tests don't intermittently fail (several assert exact generated output).
+        seed(1234)
         # Create a minimal FusilConfig for the parent ArgumentGenerator
         mock_options = FusilConfig(read=False)
         mock_options.no_numpy = False
@@ -1329,17 +1332,20 @@ class TestH5PyArgumentGenerator(unittest.TestCase):
                             expected_dtype,
                             f"numpy.arange dtype mismatch for {result_expr}",
                         )
-                        # Shape check is more complex for arange().reshape combinations
-                        # For now, we check that it produced *an* array.
+                        # Shape check is more complex for arange().reshape combinations and
+                        # for non-contiguous transforms, so only assert it when the expected
+                        # shape is actually determinable from the generated expression.
+                        current_expected_shape = None
                         if "arange(10" in result_expr and "reshape(2,5)" in result_expr:
                             current_expected_shape = (2, 5)
                         elif shape_expr.startswith("("):
                             current_expected_shape = ast.literal_eval(shape_expr)
-                        self.assertEqual(
-                            val.shape,
-                            current_expected_shape,
-                            f"numpy.arange shape mismatch for {result_expr}",
-                        )
+                        if current_expected_shape is not None:
+                            self.assertEqual(
+                                val.shape,
+                                current_expected_shape,
+                                f"numpy.arange shape mismatch for {result_expr}",
+                            )
 
                     if not allow_non_contig:
                         self.assertTrue(


### PR DESCRIPTION
Refs #106.

**numpy/h5py support verified working.** Installed numpy 2.5 + h5py 3.16 in a normal-CPython 3.14 venv and ran the suite — the previously-skipped h5py/numpy tests now run and pass (skips drop 32 → 1; the 1 is the lafleur `OperatorSwapper` test). No wheels exist for the free-threaded debug `3.16t` dev venv, hence a separate venv.

**Real version finding:** the declared `requires-python` was wrong. The code uses `types.CapsuleType` (3.13+) in `samples/tricky_objects.py` and PEP 701 f-strings (3.12+) in the generators, so it never ran on the claimed 3.11. Bumped `requires-python` to `>=3.13` (+ classifiers, ruff `target-version` py313).

**De-flake** the h5py argument-generator tests (only observable with numpy installed): seed the RNG in `setUp` (the generator picks expressions at random; several tests assert exact output), and harden `test_genNumpyArrayForDirectIO_expr` — `current_expected_shape` was left unbound/stale for the variable-shape `arange` path, so it now only asserts shape when determinable. **10/10 green with numpy; still green without.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)