### PR TITLE
Phase 5b: code-review pass — fix exit-code bug + dead code; backlog

### DIFF
--- a/doc/code-review-findings.md
+++ b/doc/code-review-findings.md
@@ -1,0 +1,78 @@
+# Code-review findings backlog (Phase 5b)
+
+Produced by a code-review-toolkit pass over the **live tree** (`fusil/` excl. `notworking/`,
+`fuzzers/fusil-python-threaded`) on 2026-06-23. Items already fixed in the Phase 5b PR are
+marked ✅; the rest are a backlog for the maintainer.
+
+## Fixed in Phase 5b
+- ✅ **Real bug — `fatalError()` exited 0.** `application.py` set `self.exit_code = 1` (typo)
+  then `exit(self.exitcode)` (still 0), so fatal config/safety errors reported success to
+  CI/fleet. Fixed to `self.exitcode = 1`.
+- ✅ **Dead code removed** (zero callers anywhere): `config.configparser_to_options`,
+  `file_tools.safeMkdir`, `file_tools.dumpFileInfo` (this also drops a `ptrace.linux_proc`
+  import from a core module), `python/utils.import_all`, and the unused `DEBUG = False`
+  constant in `python/__init__.py`.
+
+## Error handling (silent-failure audit) — backlog
+The core runtime is mostly healthy (narrow, well-targeted excepts). Real items:
+- **C2 — `Agent.__del__` calls `self.send()` during teardown** (`mas/agent.py`): on
+  `KeyboardInterrupt` it tries to `send("application_interrupt")`, but `send()` raises if the
+  agent is inactive (the usual case in `__del__`), so Ctrl-C during GC is eaten. Make `__del__`
+  best-effort only (no `send()`; guard on `is_active`, fall back to a stderr print).
+- **H1 — `python_source.on_session_start` catches `BaseException`** around `loadModule`: swallows
+  `KeyboardInterrupt`/`SystemExit` during a slow import. Catch `Exception`; let the base signals
+  propagate.
+- **H2 — `list_all_modules._process_package` uses `except (ImportError, Exception)`**: redundant
+  and aborts the whole discovery pass on any non-ImportError. Decide policy → `except Exception`
+  and skip the package.
+- **H3 — `utils.remove_logging_pycache`** runs unconditionally at startup, mutates the installed
+  stdlib, and is uncaught if `__pycache__` is missing; then `reload(logging)` runs regardless.
+  Make it a no-op on any failure (guard `iterdir()`), and reconsider whether the reload is needed.
+- **H4 — `Application.exit()` runs `deinitX11()` outside the cleanup try**: a non-ptrace error in
+  `agents.clear()` skips X11 deinit (leaves X access granted). Move to `finally`.
+- **M-series:** `Directory.rmtree_error`/`isEmpty` swallow then degrade silently; `runProject`'s
+  `finally` `destroy()` can mask the original exception; `allowCoreDump`/`target_is_asan`/
+  `_oom_keep_policy` return sentinels on failure that some callers ignore — add a WARNING where
+  the fallback materially changes behavior (cap applied, dir kept).
+- **Policy — no exception chaining anywhere.** Re-raises (`config.py`, `process/create.py`,
+  `session_directory.py`) drop context. Adopt `raise X from e` for triage-friendly tracebacks.
+
+## Architecture — backlog
+- **Benign-but-fragile runtime import cycle** through the package hub:
+  `python/__init__ → python_source → write_python_code → argument_generator → import fusil.python`.
+  Quick fix: in `argument_generator.py` import `fusil.python.tricky_weird` directly instead of the
+  package. (All the JIT/h5py "cycles" are TYPE_CHECKING-only — no action.)
+- **God-modules:** `jit/write_jit_code.py` (~2960 LOC) and `write_python_code.py` (~1470 LOC) hold
+  most of the generator logic and are the main change-risk. See complexity items.
+
+## Complexity hotspots — backlog (refactor opportunities)
+Concentrated entirely in the code generators; core (`application`/`project`/`config`/`session`/
+`process`) is clean. The systemic driver is the manual `self.write()/addLevel()/restoreLevel()`
+indentation idiom.
+- **Enabling change first:** add an indentation **context manager** (`with self.indent():`) to the
+  writer base — shrinks/de-risks nearly every generator hotspot. Land with golden-output tests
+  (snapshot generated `source.py` for fixed seeds).
+- `WritePythonCode._write_main_fuzzing_logic` (cognitive 73) — split per mode/target.
+- `WritePythonCode._generate_and_write_call` (9 params) — introduce a `CallSpec` dataclass; extract
+  deep-dive/thread/async blocks.
+- `WritePythonCode._get_module_members`, `PythonSource.__init__`,
+  `ArgumentGenerator._gen_collection_internal` — small, low-risk extractions.
+- h5py `_fuzz_one_*_instance` family + `WriteJITCode._generate_variational_scenario` — large but
+  mechanical (opt-in paths, lower priority).
+
+## Remaining dead code (coordinated legacy cleanup — defer)
+Only reachable from `notworking/` / `examples/` / doctests, so remove together with the legacy
+fuzzers (or when they're formally retired): `process/env.py` `EnvVar{Length,Integer,IntegerRange,
+Random}`; `file_tools.filenameExtension`; `cmd_help_parser.py`. Also `weird_classes.FrameModifier`
+is defined after the registry-population loop so it's never registered — verify intent before
+removing. `oom_dedup.classify` / `extract_site_from_bt` and `fixtures.fixture_dir` are test-only
+back-compat helpers (keep if the contract matters).
+
+## Test coverage gaps → feeds Phase 6
+Strong but narrow (almost all under `fusil/python/`). Highest-value untested units:
+`fusil/mas/*` (the message bus — zero tests, highest fan-in), `python/arg_numbers.py` (branchy
+parser, doctests don't run), `score.py`/`tools.py` (pure logic), `bytes_generator`/
+`unicode_generator`, `aggressivity.py` (state machine), `directory.py` + `session_directory`
+keep/rename logic, `blacklists.py` structural guards (+ a likely `_builtin__:set` typo at
+`blacklists.py:135`). Also: **`test_doc.py` is broken** (references `fusil.bits`, now in
+`notworking/`) so its doctests don't run — fix or retire it and wire into the unittest path.

--- a/fusil/application.py
+++ b/fusil/application.py
@@ -473,7 +473,7 @@ class Application(ApplicationAgent):
         Fatal error: display a message (if message is set) and exit
         the fuzzer.
         """
-        self.exit_code = 1
+        self.exitcode = 1
         if message:
             self.error(message)
         self.exit(keep_log=False)

--- a/fusil/config.py
+++ b/fusil/config.py
@@ -269,16 +269,6 @@ def optparse_to_configparser(parser, output=None, defaults=False, options=None):
     return output.read()
 
 
-def configparser_to_options(parser):
-    """Convert a configparser to optparse options."""
-    options = optparse.Values()
-
-    for section in parser.sections():
-        for key in parser[section]:
-            setattr(options, key, parser[section][key])
-    return options
-
-
 class OptionGroupWithSections(OptionGroup):
     """
     OptionGroup class with sections:

--- a/fusil/file_tools.py
+++ b/fusil/file_tools.py
@@ -1,19 +1,5 @@
-from datetime import datetime
-from errno import EEXIST
-from os import fstat, getcwd, getpid, mkdir
+from os import getcwd
 from os.path import basename
-
-from ptrace.linux_proc import readProcessLink
-
-
-def safeMkdir(path):
-    try:
-        mkdir(path)
-    except OSError as err:
-        if err.errno == EEXIST:
-            return
-        else:
-            raise
 
 
 def filenameExtension(filename):
@@ -22,24 +8,6 @@ def filenameExtension(filename):
         return "." + ext.rsplit(".", 1)[-1]
     else:
         return None
-
-
-def dumpFileInfo(logger, file_obj):
-    try:
-        fileno = file_obj.fileno()
-    except AttributeError:
-        logger.info("File object class: %s" % file_obj.__class__.__name__)
-        return
-    filename = readProcessLink(getpid(), "fd/%s" % fileno)
-    logger.info("File name: %r" % filename)
-    logger.info("File descriptor: %s" % fileno)
-
-    stat = fstat(fileno)
-    logger.info("File user/group: %s/%s" % (stat.st_uid, stat.st_gid))
-    logger.info("File size: %s bytes" % stat.st_size)
-    logger.info("File mode: %04o" % stat.st_mode)
-    mtime = datetime.fromtimestamp(stat.st_mtime)
-    logger.info("File modification: %s" % mtime)
 
 
 def relativePath(path, cwd=None):

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -26,7 +26,6 @@ with warnings.catch_warnings():
 IGNORE_TIMEOUT = True
 IGNORE_CPU = True
 SHOW_STDOUT = False
-DEBUG = False
 TIMEOUT = 900.0
 PYTHON = sys.executable
 # Empty default => auto-created, expendable fixture files (fusil.python.fixtures).

--- a/fusil/python/utils.py
+++ b/fusil/python/utils.py
@@ -7,22 +7,7 @@ import importlib
 import logging
 import pathlib
 import resource
-import sys
 import time
-
-from fusil.python.blacklists import MODULE_BLACKLIST
-
-
-def import_all() -> None:
-    """Import all standard library C modules before running the fuzzer."""
-    # Currently we have to import all C modules before running the fuzzer.
-    # TODO: figure out why and fix it properly.
-    for name in sys.stdlib_module_names:
-        if name not in MODULE_BLACKLIST and "test" not in name:
-            try:
-                sys.modules[name] = __import__(name)
-            except ImportError as e:
-                print("Failed to import module %s\n" % name, e)
 
 
 def remove_logging_pycache() -> None:


### PR DESCRIPTION
Refs #106. Ran the code-review-toolkit over the live tree; acted on the safe, verified findings and recorded the rest in `doc/code-review-findings.md`.

**Real bug fixed:** `Application.fatalError()` set `self.exit_code = 1` (a typo) then `exit(self.exitcode)`, so fatal config/safety errors exited **0** — CI/fleet treated them as success. Now sets `self.exitcode`.

**Dead code removed** (zero callers anywhere — verified across `notworking/`, tests, docs, and generated strings): `config.configparser_to_options`, `file_tools.safeMkdir`, `file_tools.dumpFileInfo` (also drops a `ptrace.linux_proc` import from a core module), `python/utils.import_all`, and the unused `DEBUG` constant.

**Backlog** (`doc/code-review-findings.md`): error-handling hardening (Ctrl-C swallowed in `Agent.__del__` and module-load loops; exception-chaining policy), the benign runtime import cycle, generator complexity hotspots + an indentation-context-manager enabling refactor, legacy-coupled dead code to retire with the old fuzzers, and the test-coverage gaps that feed Phase 6.

ruff clean; suite green (231 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)