### PR TITLE
Phase 6: tests for crash-dir naming/labeling

### DIFF
--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -1,0 +1,62 @@
+"""Unit tests for fusil.directory.Directory.uniqueFilename / isEmpty.
+
+uniqueFilename names crash artifacts, so collisions must never overwrite. Uses a real
+temp dir; runtime-free.
+"""
+
+import os
+import tempfile
+import unittest
+
+from fusil.directory import Directory
+
+
+class TestUniqueFilename(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.d = Directory(self.tmp)
+
+    def test_first_use_has_no_suffix(self):
+        self.assertEqual(os.path.basename(self.d.uniqueFilename("a.txt")), "a.txt")
+
+    def test_collision_gets_numeric_suffix(self):
+        first = self.d.uniqueFilename("a.txt")
+        second = self.d.uniqueFilename("a.txt")
+        self.assertNotEqual(first, second)
+        self.assertEqual(os.path.basename(second), "a-2.txt")
+
+    def test_extensionless_collision(self):
+        self.d.uniqueFilename("foo")
+        self.assertEqual(os.path.basename(self.d.uniqueFilename("foo")), "foo-2")
+
+    def test_collision_with_existing_file_on_disk(self):
+        # A name already present on disk (not via the registry) still collides.
+        open(os.path.join(self.tmp, "x.log"), "w").close()
+        self.assertEqual(os.path.basename(self.d.uniqueFilename("x.log")), "x-2.log")
+
+    def test_save_false_does_not_register(self):
+        self.d.uniqueFilename("b.txt", save=False)
+        # Not registered => the next call reuses the bare name.
+        self.assertEqual(os.path.basename(self.d.uniqueFilename("b.txt", save=False)), "b.txt")
+
+    def test_empty_name_raises(self):
+        with self.assertRaises(ValueError):
+            self.d.uniqueFilename("")
+
+
+class TestIsEmpty(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+
+    def test_empty_dir(self):
+        self.assertTrue(Directory(self.tmp).isEmpty())
+
+    def test_non_empty_dir(self):
+        open(os.path.join(self.tmp, "f"), "w").close()
+        self.assertFalse(Directory(self.tmp).isEmpty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_directory.py
+++ b/tests/test_session_directory.py
@@ -1,0 +1,59 @@
+"""Unit tests for SessionDirectory.on_session_rename — the crash-dir labeling logic.
+
+The session directory's name encodes the crash signature (module, signal, exit code, OOM
+id, ...). on_session_rename normalizes, truncates, and de-dupes those parts. It's pure
+string logic on rename_parts/rename_set, so we exercise it on a bare instance (no MAS,
+no filesystem). Runtime-free.
+"""
+
+import unittest
+
+from fusil.session_directory import PART_MAXLEN, SessionDirectory
+
+
+def _bare_session_directory():
+    """A SessionDirectory with just the state on_session_rename touches."""
+    sd = SessionDirectory.__new__(SessionDirectory)
+    sd.rename_parts = []
+    sd.rename_set = set()
+    sd.info = lambda *a, **k: None
+    return sd
+
+
+class TestOnSessionRename(unittest.TestCase):
+    def test_simple_part_appended(self):
+        sd = _bare_session_directory()
+        sd.on_session_rename("json")
+        self.assertEqual(sd.rename_parts, ["json"])
+
+    def test_normalizes_disallowed_chars(self):
+        sd = _bare_session_directory()
+        sd.on_session_rename("xml.dom.minidom")
+        sd.on_session_rename("segfault:0x10")
+        self.assertEqual(sd.rename_parts, ["xml_dom_minidom", "segfault_0x10"])
+
+    def test_truncates_long_parts(self):
+        sd = _bare_session_directory()
+        sd.on_session_rename("a" * (PART_MAXLEN + 25))
+        self.assertEqual(len(sd.rename_parts[0]), PART_MAXLEN)
+
+    def test_deduplicates_parts(self):
+        sd = _bare_session_directory()
+        sd.on_session_rename("sigsegv")
+        sd.on_session_rename("sigsegv")
+        self.assertEqual(sd.rename_parts, ["sigsegv"])
+
+    def test_empty_part_ignored(self):
+        sd = _bare_session_directory()
+        sd.on_session_rename("")
+        self.assertEqual(sd.rename_parts, [])
+
+    def test_order_preserved_across_distinct_parts(self):
+        sd = _bare_session_directory()
+        for part in ("module", "segmentation_fault", "OOM-0004"):
+            sd.on_session_rename(part)
+        self.assertEqual(sd.rename_parts, ["module", "segmentation_fault", "OOM-0004"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #106. Tier-2 tests for the campaign-critical crash-artifact paths (runtime-free):

- **`tests/test_directory.py`** — `Directory.uniqueFilename` collision handling (numeric suffixes, extensionless names, on-disk collisions, `save=False`, empty-name guard) so a crash artifact is never overwritten — plus `isEmpty`.
- **`tests/test_session_directory.py`** — `SessionDirectory.on_session_rename`, the logic that builds a crash dir's self-describing name (module / signal / OOM id): char normalization, truncation at `PART_MAXLEN`, de-duplication, empty-part handling, order preservation. Exercised on a bare instance (no MAS, no filesystem).

Suite: **308 tests**, green. ruff clean. (`aggressivity.py`'s state machine remains a backlog item — see `doc/code-review-findings.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)