### PR TITLE
oom_dedup: parse GCC-build ASan frames; skip free-plumbing

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -155,9 +155,14 @@ _BT_FRAME = re.compile(
 #   "    #5 0x.. in _excinfo_clear_type /abs/path/Python/crossinterp.c:1319:15"
 # The CPython source dir is matched anywhere in the absolute path; leading libc/pthread
 # frames carry no such path and are skipped, as is fatal/dump plumbing (via _BT_SKIP).
+# The source path may be absolute (Clang builds: /home/.../Objects/foo.c:12:3) or relative
+# (GCC builds: Objects/foo.c:12, also no column). Make the absolute prefix and the column
+# optional so GCC-built crashes are parsed too -- otherwise extract_native_sites finds nothing
+# in the ASan trace and the dedup falls back to faulthandler's sparser (GCC-inlined) C-stack,
+# mislabelling known bugs as new (e.g. a whole OOM-0004 batch keyed on _Py_MergeZeroLocalRefcount).
 _ASAN_FRAME = re.compile(
-    r"#\d+\s+0x[0-9a-fA-F]+\s+in\s+(\w+)\s+\S*?"
-    r"/((?:Objects|Python|Modules|Include|Parser)/[\w./+-]+\.(?:c|h)):(\d+)"
+    r"#\d+\s+0x[0-9a-fA-F]+\s+in\s+(\w+)\s+(?:\S*?/)?"
+    r"((?:Objects|Python|Modules|Include|Parser)/[\w./+-]+\.(?:c|h)):(\d+)"
 )
 # fatal/assert/dump plumbing -- skip so a recorded frame is the real crash/assert site.
 # The debug allocator's free-time checks (_PyMem_DebugCheckAddress / _PyMem_DebugRawFree /
@@ -173,6 +178,14 @@ _BT_SKIP = re.compile(
     r"|_Py_NegativeRefcount|_Py_DumpStack|faulthandler\w*"
     r"|_Py_DumpExtensionModules"
     r"|_PyMem_DebugCheckAddress|_PyMem_DebugRawFree|_PyMem_DebugFree"
+    # The _testcapi set_nomemory injection hooks and the PyMem_/PyObject_ free/realloc
+    # wrappers are pass-through allocator plumbing: when one is the innermost frame the real
+    # defect is the CALLER doing the bad free (e.g. free_list_items = OOM-0004), so skip them
+    # too. Without this, a double-free caught in the free hook resolves to hook_ffree/PyMem_Free
+    # (not a catalog site) and the crash is mislabelled oomNEW -- notably on GCC builds, whose
+    # ASan trace exposes these frames where Clang inlines them away.
+    r"|hook_fmalloc|hook_fcalloc|hook_frealloc|hook_ffree"
+    r"|PyMem_Free|PyMem_RawFree|PyObject_Free|PyMem_Realloc|PyMem_RawRealloc|PyObject_Realloc"
     r"|tracemalloc_(raw_)?(alloc|calloc|realloc|free))$"
 )
 # Inlined refcount/atomic helpers live in these headers and show up as the innermost frame

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -272,6 +272,22 @@ class TestNativeBacktrace(unittest.TestCase):
         # and it matches the catalog bug keyed on that .c line, not labelled oomNEW.
         self.assertEqual(self._deduper().decide(bt, source_path=None), (True, "OOM-0003"))
 
+    def test_gcc_relative_path_frames_parsed(self):
+        # GCC-built ASan traces use a RELATIVE source path and no column (Objects/foo.c:68),
+        # vs Clang's absolute path + column (/abs/Objects/foo.c:68:9). Both must parse, else
+        # GCC crashes fall back to faulthandler's inlined C-stack and known bugs (here the
+        # OOM-0003 site) get mislabelled oomNEW.
+        bt = "\n".join(
+            [
+                "==1==ERROR: AddressSanitizer: SEGV on unknown address",
+                "    #5 0x5e in Py_DECREF Include/refcount.h:359",
+                "    #6 0x5e in code_dealloc Objects/codeobject.c:2440",
+            ]
+        )
+        sites = oom_dedup.extract_native_sites(bt)
+        self.assertEqual(sites[0], "code_dealloc@Objects/codeobject.c:2440")
+        self.assertEqual(self._deduper().decide(bt, source_path=None), (True, "OOM-0003"))
+
 
 class TestExtractSite(unittest.TestCase):
     def test_skips_plumbing_returns_real_site(self):


### PR DESCRIPTION
A batch of 186 `oomNEW` crashes from a **GCC-built** free-threaded ASan interpreter turned out to be **all OOM-0004** (the `PyList_New` list double-free). Two GCC-vs-Clang differences defeated the in-loop dedup:

1. **ASan path format** — Clang emits `/abs/Objects/foo.c:68:9`, GCC emits `Objects/foo.c:68` (relative, no column). `_ASAN_FRAME` required the leading `/`, so GCC frames matched nothing and the dedup fell back to faulthandler's C-stack — which GCC inlines down to `_Py_MergeZeroLocalRefcount` (not a catalog site) → `oomNEW`. Now the absolute prefix + column are optional.
2. **Free plumbing** — the innermost frames are the `set_nomemory` hook (`hook_ffree`) and `PyMem_Free`; added them + the `PyMem_/PyObject_` free/realloc wrappers to `_BT_SKIP` (same rationale as the existing `_PyMem_Debug*` detector skips) so the site descends to the real caller (`free_list_items`).

Result: the batch resolves **184/186 → OOM-0004** in-loop; the 2 with unsymbolized ASan traces → `oomSEGV` (correctly kept for gdb, not flagged new). Regression test added for the GCC relative-path frame. Suite green (309).

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)