### PR TITLE
oom_dedup: don't conflate type-specific fatal-msg keys

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -124,10 +124,16 @@ def match(c, snap):
         if hit:
             return hit, "assert"
     if c.get("fatal_msg"):
+        # Match when the cataloged key is a prefix of the crash message (a key may be a short
+        # signature, e.g. "_Py_CheckFunctionResult:") OR the (truncation-shortened) crash
+        # message is a prefix of the key. The second clause must use the FULL crash message,
+        # not a fixed [:30] slice -- a short slice stops before the discriminating content
+        # (e.g. "_Py_Dealloc: Deallocator of type '<TYPE>'") and conflates type-specific keys
+        # (OOM-0007 'Context' vs OOM-0023 '_StoreAction'), mislabelling any new type.
         hit = set(
             o
             for k, o in snap["msg"]
-            if c["fatal_msg"].startswith(k) or k.startswith(c["fatal_msg"][:30])
+            if c["fatal_msg"].startswith(k) or k.startswith(c["fatal_msg"])
         )
         if hit:
             return hit, "msg"

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -89,6 +89,30 @@ class TestMatch(unittest.TestCase):
         ids, _ = self._match(FATAL_0022)
         self.assertEqual(ids, {"OOM-0022"})
 
+    def test_msg_match_distinguishes_by_type(self):
+        # Two type-specific "Deallocator of type 'X'" msg keys must not be conflated by their
+        # shared prefix: each known type maps to its own bug, and a NEW type matches neither
+        # (a too-short prefix slice used to ignore the type and collide the whole family).
+        snap = oom_dedup.load_snapshot(
+            [
+                "OOM-0007\tfatal\tmsg\t"
+                "_Py_Dealloc: Deallocator of type 'Context' cleared the curre",
+                "OOM-0023\tfatal\tmsg\t"
+                "_Py_Dealloc: Deallocator of type '_StoreAction' cleared the ",
+            ]
+        )
+
+        def decide_type(t):
+            text = (
+                "Fatal Python error: _Py_Dealloc: Deallocator of type '%s' "
+                "cleared the current exception" % t
+            )
+            return oom_dedup.match(oom_dedup.classify(text), snap)[0]
+
+        self.assertEqual(decide_type("Context"), {"OOM-0007"})
+        self.assertEqual(decide_type("_StoreAction"), {"OOM-0023"})
+        self.assertEqual(decide_type("collections.deque"), set())  # new type -> no match
+
     def test_near_line(self):
         ids, how = self._match(ABORT_NEAR)
         self.assertEqual(ids, {"OOM-0004"})


### PR DESCRIPTION
Surfaced while fixing the spurious OOM-0003 catalog key (the matching catalog change is separate). `match()`'s fatal-message comparison had `k.startswith(c["fatal_msg"][:30])` — a 30-char prefix that stops **before** the discriminating content. For the `_Py_Dealloc: Deallocator of type '<TYPE>' cleared the current exception` family the type starts ~char 33, so every such fatal matched **all** type-specific keys (OOM-0007 `Context`, OOM-0023 `_StoreAction`, …) and the `sorted()[0]` tiebreak silently picked the lowest id — e.g. a `collections.deque` crash → OOM-0007, and even `_StoreAction` (OOM-0023's own vehicle) → OOM-0007.

Fix: use the **full** crash message as the prefix (`k.startswith(c["fatal_msg"])`). Still truncation-tolerant, but the type must agree — each known type maps to its own bug, a new type is correctly `oomNEW`.

Test added; suite green (311). (The catalog's `ingest.py` gets the same one-line fix in the cpython-oom-findings repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)