### PR TITLE
oom_dedup: bound in-loop stdout reads to stop regex blowup on huge stdout

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -601,8 +601,12 @@ class Fuzzer(Application):
 
         session_dir = session.directory.directory
         try:
-            with open(os.path.join(session_dir, "stdout"), errors="replace") as fh:
-                text = fh.read()
+            from fusil.python.oom_dedup import read_crash_stdout
+
+            # Bounded read: a crashing session's stdout can be tens of MB (OOM-verbose spew /
+            # runaway vehicle); reading it whole would make decide()'s regexes backtrack
+            # catastrophically and stall this keep-policy (it runs synchronously in deinit).
+            text = read_crash_stdout(os.path.join(session_dir, "stdout"))
             return self._deduper.decide(text, source_path=os.path.join(session_dir, "source.py"))
         except Exception as err:
             # Never let a dedupe failure abort the session's keep/rename (deinit): keep the

--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -43,6 +43,52 @@ def _nf(f):
     return f.lstrip("./")
 
 
+# ---- bounded stdout reader ----
+# A crashing session's stdout can be huge: OOM-verbose `start=N` spew, or a runaway /
+# binary-emitting vehicle (tens of MB). Feeding the whole thing to the classification
+# regexes above makes the ``.*?`` patterns backtrack catastrophically (a multi-MB
+# no-newline binary blob is one giant "line"), which would stall the in-loop keep-policy
+# that runs synchronously in the session's deinit. The crash signature always lives at the
+# HEAD (early asserts / import errors) or the TAIL (the Fatal/ASan backtrace that ends the
+# process), never the middle, so read a bounded head+tail and cap each line -- lossless for
+# every signal decide() uses. Mirrors the catalog's ingest.read_stdout. Env-overridable.
+_STDOUT_HEAD = int(os.environ.get("OOM_STDOUT_HEAD", 256 * 1024))
+_STDOUT_TAIL = int(os.environ.get("OOM_STDOUT_TAIL", 1024 * 1024))
+_STDOUT_LINE_CAP = int(os.environ.get("OOM_STDOUT_LINE_CAP", 4096))
+
+
+def _cap_lines(text):
+    """Truncate over-long lines so a binary blob can't make the regexes backtrack."""
+    if _STDOUT_LINE_CAP <= 0:
+        return text
+    return "\n".join(
+        ln if len(ln) <= _STDOUT_LINE_CAP else ln[:_STDOUT_LINE_CAP]
+        for ln in text.split("\n")
+    )
+
+
+def read_crash_stdout(path):
+    """Read a crash's captured stdout, bounding huge files to head+tail and capping line
+    length (decoded, errors-replaced) so decide()'s regexes can't catastrophically
+    backtrack on OOM-verbose spew or embedded binary."""
+    with open(path, "rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        if size <= _STDOUT_HEAD + _STDOUT_TAIL:
+            fh.seek(0)
+            return _cap_lines(fh.read().decode("utf-8", "replace"))
+        fh.seek(0)
+        head = fh.read(_STDOUT_HEAD)
+        fh.seek(size - _STDOUT_TAIL)
+        tail = fh.read(_STDOUT_TAIL)
+    elided = size - _STDOUT_HEAD - _STDOUT_TAIL
+    return _cap_lines(
+        head.decode("utf-8", "replace")
+        + f"\n...[{elided} bytes elided by read_crash_stdout]...\n"
+        + tail.decode("utf-8", "replace")
+    )
+
+
 def all_asserts(text):
     """Every assertion in stdout as a list of (file, line, func|None, expr)."""
     out, seen = [], set()

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -432,5 +432,64 @@ class TestGdbResolveDropsPrivileges(unittest.TestCase):
         self.assertEqual(kw["cwd"], self.SESSION_DIR)
 
 
+class TestReadCrashStdout(unittest.TestCase):
+    """Bounded stdout reader: huge OOM-verbose / binary stdout must not stall the regexes."""
+
+    def _write(self, data):
+        fd, path = tempfile.mkstemp(suffix=".stdout")
+        os.write(fd, data)
+        os.close(fd)
+        self.addCleanup(os.remove, path)
+        return path
+
+    def test_small_file_read_whole(self):
+        path = self._write(b"hello\nFatal Python error: boom\n")
+        text = oom_dedup.read_crash_stdout(path)
+        self.assertIn("Fatal Python error: boom", text)
+        self.assertNotIn("elided", text)  # small files are returned intact
+
+    def test_huge_file_keeps_tail_fatal(self):
+        body = b"[OOM-SEQ] start=x\n" * 200000  # ~3.4 MB of spew in the middle
+        fatal = (
+            b"Fatal Python error: _Py_Dealloc: Deallocator of type "
+            b"'collections.deque' cleared the current exception\n"
+        )
+        text = oom_dedup.read_crash_stdout(self._write(body + fatal))
+        self.assertIn("'collections.deque' cleared the current exception", text)
+        self.assertIn("elided", text)  # the middle was dropped
+        self.assertTrue(oom_dedup.FATAL.search(text))
+
+    def test_huge_file_keeps_head_assert(self):
+        head = (
+            b"python: Objects/codeobject.c:2440: void code_dealloc(PyObject *): "
+            b"Assertion `co != NULL' failed.\n"
+        )
+        text = oom_dedup.read_crash_stdout(self._write(head + b"x" * (4 * 1024 * 1024)))
+        self.assertEqual(len(oom_dedup.all_asserts(text)), 1)  # head assert survives + parses
+
+    def test_giant_binary_line_is_capped(self):
+        # A multi-MB line with no newline is what makes the `.*?` regexes backtrack; it must
+        # be truncated, and a trailing crash signature must still be found.
+        blob = b"A(:)" * (3 * 1024 * 1024)  # ~12 MB, no newline -> one giant "line"
+        text = oom_dedup.read_crash_stdout(
+            self._write(blob + b"\nFatal Python error: Segmentation fault\n")
+        )
+        self.assertTrue(all(len(ln) <= oom_dedup._STDOUT_LINE_CAP for ln in text.split("\n")))
+        self.assertTrue(oom_dedup.SEGV.search(text))  # regexes complete and see the segv
+
+    def test_huge_tail_fatal_still_dedupes(self):
+        # End-to-end: a huge stdout whose tail carries a known fatal still labels correctly.
+        fd, snap = tempfile.mkstemp(suffix=".tsv")
+        os.write(fd, SNAPSHOT.encode())
+        os.close(fd)
+        self.addCleanup(os.remove, snap)
+        d = oom_dedup.Deduper(snap, keep=5, prune=True)
+        text = oom_dedup.read_crash_stdout(
+            self._write(b"[OOM] noise\n" * 200000 + FATAL_0022.encode() + b"\n")
+        )
+        keep, label = d.decide(text)
+        self.assertEqual(label, "OOM-0022")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #130.

## What

Adds `oom_dedup.read_crash_stdout()` — reads a crashing session's stdout as a bounded **head (256 KB) + tail (1 MB)** and caps each line to **4096 chars** (`_cap_lines`), then `Fuzzer._oom_keep_policy` reads through it instead of slurping the whole file. The crash signature is always at the head (asserts/import) or tail (Fatal/ASan backtrace), never the middle, so bounding is lossless; the per-line cap is what actually kills the catastrophic backtracking (a multi-MB no-newline binary blob is one giant "line"). Overridable via `OOM_STDOUT_{HEAD,TAIL,LINE_CAP}`.

Mirrors the same fix already merged in the `cpython-oom-findings` `ingest.py` batch tool, so the in-loop and batch dedupers stay consistent.

## Why

A crashing session can emit tens of MB of stdout; the `.*?` regexes in `decide()` backtracked catastrophically on it, and since the keep-policy runs synchronously in `deinit` it stalled the fuzzer loop on crashing sessions. (Same failure mode that timed out batch `ingest.py` on 67 MB stdouts.)

## Tests

5 new `TestReadCrashStdout` cases: small-file passthrough, head-assert and tail-fatal survive bounding, giant binary line capped, and a huge-tail-fatal still dedupes end-to-end through `Deduper`. Full `test_oom_dedup` suite (42) + `test_oom_dedup_wiring` (3) green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)