### PR TITLE
Fix CI: ruff format oom_dedup.py + document ruff format --check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,10 @@ python -m unittest tests.python.test_values    # single module
 python -m unittest tests.python.test_oom_dedup tests.python.test_oom_dedup_wiring  # OOM dedup
 
 python test_doc.py   # doctest-based tests over doc/*.rst and a few modules (not chmod +x)
-ruff check fusil/    # lint — ruff is installed; pyflakes.sh needs pyflakes, which is not
+# CI runs BOTH of these (ruff 0.15.18, pinned) over fusil/ tests/ fuzzers/fusil-python-threaded
+# -- run both before pushing; `ruff check` passing does NOT imply `ruff format --check` passes.
+ruff check fusil/ tests/ fuzzers/fusil-python-threaded          # lint (pyflakes.sh needs pyflakes, not installed)
+ruff format --check fusil/ tests/ fuzzers/fusil-python-threaded # format check; `ruff format <paths>` to fix
 
 # Build/install. Packaging is defined entirely in pyproject.toml (setuptools
 # backend; no setup.py). pip install pulls in python-ptrace; build isolation

--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -62,8 +62,7 @@ def _cap_lines(text):
     if _STDOUT_LINE_CAP <= 0:
         return text
     return "\n".join(
-        ln if len(ln) <= _STDOUT_LINE_CAP else ln[:_STDOUT_LINE_CAP]
-        for ln in text.split("\n")
+        ln if len(ln) <= _STDOUT_LINE_CAP else ln[:_STDOUT_LINE_CAP] for ln in text.split("\n")
     )
 
 
@@ -118,9 +117,7 @@ def classify(text):
             return dict(
                 kind="segv", file=None, line=None, func=None, assert_expr=None, fatal_msg=None
             )
-        return dict(
-            kind="fatal", file=None, line=None, func=None, assert_expr=None, fatal_msg=msg
-        )
+        return dict(kind="fatal", file=None, line=None, func=None, assert_expr=None, fatal_msg=msg)
     if SEGV.search(text):
         return dict(kind="segv", file=None, line=None, func=None, assert_expr=None, fatal_msg=None)
     if IMPORTERR.search(text):
@@ -160,8 +157,14 @@ def load_snapshot(lines):
             by_line.setdefault((f, int(ln)), set()).add(oid)
             per_file_lines[f].append((int(ln), oid))
     return dict(
-        func=by_func, assert_=by_assert, line=by_line, fl=per_file_lines, msg=by_msg,
-        msgfam=by_msgfam, kind=kind_of, funcname=by_funcname,
+        func=by_func,
+        assert_=by_assert,
+        line=by_line,
+        fl=per_file_lines,
+        msg=by_msg,
+        msgfam=by_msgfam,
+        kind=kind_of,
+        funcname=by_funcname,
     )
 
 


### PR DESCRIPTION
Closes #136.

CI's `ruff format --check` step has been red since the first `oom_dedup.py` edit — the file was lint-clean but not format-clean, and only `ruff check` was run locally. The reformat is purely cosmetic (ruff collapsing/exploding multi-arg calls in the recently-added `_cap_lines` / `classify` / `load_snapshot` code); behavior unchanged and the oom_dedup suite stays green (52 tests).

- `ruff format fusil/python/oom_dedup.py` → whole tree format-clean (106 files).
- CLAUDE.md: document that CI runs **both** `ruff check` and `ruff format --check`, so both must pass before pushing.

Verified locally (ruff 0.15.18, the CI pin): `ruff check` ✓, `ruff format --check` ✓ (106 files already formatted), full suite 326 passed / 32 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)