### PR TITLE
refactor: drop debug-comment cruft + finish converting _dispatch_fuzz_on_instance

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -809,20 +809,16 @@ class WritePythonCode(WriteCode):
             1,
             f'f"--- (Depth {generation_depth}) Error calling repr() prefix: {current_prefix}) ---"',
         )
-        self.write(0, f"# {self.base_level=}")
         self.write(0, f"if {target_obj_expr_str} is not None:")
-        # ---- BLOCK: Main if target_obj_expr_str not None ----
-        L_main_if_target_not_none = self.addLevel(1)
-        self.write(0, f"# {self.base_level=}")
-        self.write(0, f"# {L_main_if_target_not_none=}")
-        try:
+        with self.indented():
             self.write(0, f"if skip_trivial_type({target_obj_expr_str}):")
-            skiplevel = self.addLevel(1)
-            self.write_print_to_stderr(
-                0,
-                f"f'Skipping deep diving on {target_obj_expr_str} {{type({target_obj_expr_str})}}'",
-            )
-            self.restoreLevel(skiplevel)
+            with self.indented():
+                self.write_print_to_stderr(
+                    0,
+                    f"f'Skipping deep diving on {target_obj_expr_str} {{type({target_obj_expr_str})}}'",
+                )
+            # The h5py writer (when active) opens a trailing `else:` block and returns the
+            # level to restore to; the generic fuzzing below fills it, then we close it.
             if self.h5py_writer:
                 L_else_generic = self.h5py_writer._dispatch_fuzz_on_h5py_instance(
                     class_name_hint, current_prefix, generation_depth, target_obj_expr_str
@@ -848,9 +844,6 @@ class WritePythonCode(WriteCode):
             finally:
                 if self.h5py_writer:
                     self.restoreLevel(L_else_generic)
-        finally:
-            self.restoreLevel(L_main_if_target_not_none)
-        # ---- END BLOCK: Main if target_obj_expr_str not None ----
 
     def _fuzz_generic_object_methods(
         self, current_prefix: str, target_obj_expr_str: str, num_calls: int

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -489,10 +489,7 @@ try:
     print(f"--- (Depth 0) Dispatching Fuzz for: { instance_c1_widget!r } (hint: Widget, prefix: c1_widget_ops) ---", file=stderr)
 except Exception as e:
     print(f"--- (Depth 0) Error calling repr() prefix: c1_widget_ops) ---", file=stderr)
-# self.base_level=0
 if instance_c1_widget is not None:
-    # self.base_level=1
-    # L_main_if_target_not_none=0
     if skip_trivial_type(instance_c1_widget):
         print(f'Skipping deep diving on instance_c1_widget {type(instance_c1_widget)}', file=stderr)
     try:


### PR DESCRIPTION
Follow-up to #145 (under #106).

`_dispatch_fuzz_on_instance` emitted three diagnostic comment lines into **every generated fuzzing script** — leftover cruft from diagnosing an indentation bug long ago:

```
# self.base_level=0
    # self.base_level=1
    # L_main_if_target_not_none=0
```

This removes them. With the level variable no longer referenced in generated output, the method's manual `addLevel(1)`/`restoreLevel(...)` blocks convert cleanly to `with self.indented():` (the outer `if … is not None:` body and the skip-trivial block). The inner `try/finally` that restores the h5py writer's returned level **stays** — that's a genuine callee-opens-a-level contract, not the manual idiom.

## Verification
This is the one **intended** generated-output change. The golden snapshot is regenerated; the diff against the old snapshot is **exactly** those three comment lines and nothing else (confirmed under pinned `PYTHONHASHSEED`). Suite **328 OK**, ruff clean.

After this, `write_python_code.py` has no manual `addLevel`/`restoreLevel` left except the single h5py-contract restore. Next up: the h5py writer itself (`write_h5py_code.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)