### PR TITLE
refactor: convert replay-script writeFunction to `with self.indented():`

### DIFF
--- a/fusil/process/replay_python.py
+++ b/fusil/process/replay_python.py
@@ -88,9 +88,8 @@ class WriteReplayScript(WriteCode):
 
     def writeFunction(self, name, callback, *args):
         self.write(0, "def %s:" % name)
-        old = self.addLevel(1)
-        callback(*args)
-        self.restoreLevel(old)
+        with self.indented():
+            callback(*args)
         self.emptyLine()
 
     def pythonImports(self):


### PR DESCRIPTION
The final manual `addLevel`/`restoreLevel` call site in a live code path. `WriteReplayScript` (`fusil/process/replay_python.py`, used by `process.create` to emit the crash-replay script) gets the same treatment as the generators (#145, #146, #147; under #106).

Provably equivalent (Pattern A), confirmed byte-identical with a direct equivalence check. After this, the only `addLevel`/`restoreLevel` references in the live tree are the `indented()` definition itself and the one documented callee-opens-a-level contract between `_dispatch_fuzz_on_instance` and the h5py dispatcher.

Suite **328 OK**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)