### PR TITLE
refactor: drop dead locals + remove unused CodeTemplate

### DIFF
--- a/fusil/python/h5py/write_h5py_code.py
+++ b/fusil/python/h5py/write_h5py_code.py
@@ -1682,8 +1682,6 @@ class WriteH5PyCode:
         locking_expr_list = self.parent.arg_generator.h5py_argument_generator.genH5PyLocking()
         locking_expr = "".join(locking_expr_list) if locking_expr_list else "None"
 
-        fs_kwargs_expr = ""
-
         all_kwargs_parts = []  # Store parts like "driver='core'"
         if actual_driver:
             all_kwargs_parts.append(f"driver={driver_expr}")
@@ -1710,7 +1708,6 @@ class WriteH5PyCode:
                     all_kwargs_parts.append(fs_kwargs_expr_temp[2:])
                 elif fs_kwargs_expr_temp:  # If it's just "kw=val"
                     all_kwargs_parts.append(fs_kwargs_expr_temp)
-                fs_kwargs_expr = fs_kwargs_expr_temp  # For logging
 
         # Construct the final kwargs string for the File() call
         # Filter out any genuinely empty strings that might have resulted from non-chosen optional args

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -403,15 +403,13 @@ class WritePythonCode(WriteCode):
 
     def _write_helper_call_functions(self) -> None:
         """Writes helper functions for calling code, comparing results, etc."""
-        self.write(
-            0, "# Helper for correctness testing that handles NaN, lambdas, and complex numbers."
-        )
-        self.write(0, "import math")
-        self.write(0, "import types")
         # Fixed-shape helper: emit it as one block rather than line-by-line self.write calls.
         self.write_block(
             0,
             """
+            # Helper for correctness testing that handles NaN, lambdas, and complex numbers.
+            import math
+            import types
             def compare_results(a, b):
                 if isinstance(a, types.FunctionType) and a.__name__ == '<lambda>' and \\
                    isinstance(b, types.FunctionType) and b.__name__ == '<lambda>':

--- a/fusil/write_code.py
+++ b/fusil/write_code.py
@@ -1,46 +1,6 @@
-import re
-import textwrap
 from contextlib import contextmanager
 from os import chmod
 from textwrap import dedent
-
-
-class CodeTemplate:
-    def __init__(self, template_text: str):
-        # Dedent the template to handle templates defined in indented code
-        self.template = textwrap.dedent(template_text)
-
-    def render(self_, **kwargs) -> str:
-        """
-        Renders the template by substituting placeholders, handling both
-        multi-line indented blocks and single-line inline values.
-        """
-        output = self_.template
-
-        # For each key-value pair, perform both block and inline substitutions.
-        for key, value in kwargs.items():
-            placeholder = f"{{{key}}}"
-
-            # 1. BLOCK SUBSTITUTION:
-            # First, find and replace all occurrences of the placeholder that are
-            # at the beginning of a line (i.e., need indentation).
-            block_pattern = re.compile(f"^(?P<indent>\\s*){re.escape(placeholder)}", re.MULTILINE)
-
-            def replacer(match):
-                """A replacer function for re.sub that indents the value."""
-                indent_str = match.group("indent")
-                # Dedent the value to normalize it, then re-indent it to match the placeholder.
-                return textwrap.indent(textwrap.dedent(str(value)).strip(), indent_str)
-
-            # Perform the substitution for all block-style placeholders.
-            output = block_pattern.sub(replacer, output)
-
-            # 2. INLINE SUBSTITUTION:
-            # After handling the blocks, any remaining placeholders must be inline.
-            # Perform a simple, global string replacement for them.
-            output = output.replace(placeholder, str(value))
-
-        return output
 
 
 class WriteCode:


### PR DESCRIPTION
Cleanup follow-up to the generator refactor (under #106).

- **`write_h5py_code.py`**: remove the dead `fs_kwargs_expr` local in `_write_h5py_file` (assigned "for logging" but never read — the only `F841` in the file once the per-file ignore is bypassed with `ruff --isolated`).
- **`write_code.py`**: remove **`CodeTemplate`** (−40 LOC) and its now-unused `re`/`textwrap` imports. It has been dead since the JIT subsystem was deleted. Its distinctive feature — injecting a re-indented **multi-line** value into a `{placeholder}` — isn't needed anywhere: every fixed-shape block in the generator interpolates only scalars/identifiers, which f-strings handle. `write_block` + f-strings cover all current needs. (If a future block needs multi-line placeholder substitution, revive from git history.)
- **`write_python_code.py`**: fold the `# Helper…` comment + `import math`/`import types` into the adjacent `compare_results` `write_block` (they belong to that helper) — the last small static `self.write` run.

## Verification
Golden snapshot unchanged; h5py harness byte-identical; **328 OK**; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)