### PR TITLE
doc: complexity-reduction report + reproducer-techniques analysis

### DIFF
--- a/doc/complexity-reduction-report.md
+++ b/doc/complexity-reduction-report.md
@@ -1,0 +1,263 @@
+# Fusil complexity-reduction report
+
+*Analysis date: 2026-06-30. Scope: the live `fusil/` tree (≈15.5k LOC), with a focus on
+the actively-developed Python fuzzing path. Read-only analysis — no code changed by this
+report. Every claim below was spot-verified against the source; file:line citations are
+current as of this date.*
+
+## TL;DR
+
+Fusil carries three kinds of avoidable complexity:
+
+1. **Clearly-dead code** still in the live tree (X11 support, an orphaned module, dead
+   config switches, dead MAS events). ~250 LOC, low risk to remove.
+2. **Two latent bugs** hiding in the config layer (the ptrace debugger and numpy support
+   are both silently off-by-default in the common case). Small fixes, real behavior impact.
+3. **Structural over-generality** inherited from Victor Stinner's original framework: a
+   general multi-agent pub/sub bus + adaptive scoring running what is, in practice, a
+   deterministic linear pipeline; and a 4.6k-LOC h5py carve-out that is ~30% of the live
+   tree.
+
+The recommended order is: land the quick wins + bug fixes first (cheap, safe, immediately
+reduce surface), then decide on the larger structural questions (h5py plug-in-ization; MAS
+simplification) which trade real risk for real payoff.
+
+---
+
+## 1. Clearly-dead code (quick wins)
+
+### 1.1 X11 / X support — fully dead (~60 LOC, LOW/LOW)
+
+X11 support is live (not under `notworking/`) but **unreachable**. The only function that
+would enable it, `CreateProcess.setupX11()` (`fusil/process/create.py:322`), has **zero
+callers** — confirmed by grep across the whole live tree. Everything downstream is therefore
+permanently inert:
+
+- `fusil/xhost.py` — entire 14-LOC file (`xhostCommand()`).
+- `fusil/application.py` — `from fusil.xhost import xhostCommand` (26), `self._setup_x11 =
+  False` (276, never set True), `initX11()`/`deinitX11()`/`_xhost()` (560-584), and the
+  unconditional `self.deinitX11()` in `exit()` (471, always a no-op).
+- `fusil/process/create.py` — `self.use_x11 = False` (65) + dead `setupX11()` (322).
+- `fusil/process/env.py` — `copyX11()` (205), only called from the dead `setupX11()`.
+- `fusil/process/replay_python.py` — `if process.use_x11` branches (183, 201-203), always False.
+- `fusil/config.py` — `fusil_xhost_program` default + getter.
+
+**Recommendation:** delete in one mechanical sweep. The only subtlety is the unconditional
+`deinitX11()` call in `Application.exit()` — drop it with the rest. This is the cleanest
+single removal available.
+
+### 1.2 `cmd_help_parser.py` — orphaned (188 LOC, LOW/LOW)
+
+`fusil/cmd_help_parser.py` is imported by **no** live or `notworking/` module. Its only
+references are `doc/code-review-findings.md` and a stale doctest (`tests/cmd_help_parser.rst`).
+**Recommendation:** delete the module + its doctest.
+
+### 1.3 Dead config switches (LOW/LOW)
+
+- **`process_use_cpu_probe`** (`config.py:22,89`) is set into `self.process_use_cpu_probe`
+  but **never read** — `CpuProbe` is created unconditionally in `process/watch.py:23`. The
+  knob has no effect.
+- **`fusil_slow_calm_load` / `fusil_slow_calm_sleep`** (`config.py:19-20,78-83`) are read into
+  attributes that have **zero consumers**. (The default `--slow` mode sets `system_calm =
+  None`; see §3.3.)
+
+**Recommendation:** remove these defaults + their getters.
+
+### 1.4 Dead MAS events and handlers (LOW/LOW–MED)
+
+Several events are broadcast but have **no live handler** (the handlers live only in
+`notworking/`), and one handler has no live sender:
+
+| Symbol | Sent at | Status |
+| --- | --- | --- |
+| `aggressivity_value` | `aggressivity.py:47` | no live `on_aggressivity_value` — the adaptive feedback loop is severed |
+| `process_pid` | `create.py:128` | no live `on_process_pid` |
+| `project_start` | `project.py:168` | no live `on_project_start` |
+| `session_success` | `session.py:116` | no live `on_session_success` |
+| `on_application_error` | `application.py:539` (handler) | no live sender of `application_error` |
+
+**Recommendation:** remove the dead sends/handler. Note `aggressivity_value` ties into §3.2.
+
+### 1.5 JIT leftovers — cosmetic only (LOW/LOW)
+
+The JIT subsystem is gone (PR #140). Remaining references are comments only:
+`python/__init__.py:214-217`, `write_python_code.py` ("Standard (non-JIT) function call"),
+`samples/weird_classes.py:166` ("attack the JIT optimizer"). **Recommendation:** scrub the
+stale comments opportunistically; no functional change.
+
+---
+
+## 2. Latent bugs found during the sweep (fix regardless of complexity)
+
+These are not style issues — they change runtime behavior and are almost certainly unintended.
+
+### 2.1 The ptrace debugger is off by default (config.py:110)
+
+```python
+self.debugger_use_debugger = self.getbool(
+    "debugger", "debugger_use_debugger", DEFAULTS["debugger_trace_forks"]   # <-- wrong default key
+)
+```
+
+The fallback default is `DEFAULTS["debugger_trace_forks"]` (**False**) instead of
+`DEFAULTS["debugger_use_debugger"]` (**True**). So with no `fusil.conf` present (the normal
+case), `debugger_use_debugger` resolves to **False**, and `debugger.py:46` gates the whole
+ptrace debugger on it. A copy-paste error that silently disables a core feature. **Fix:** use
+the correct default key. (Worth checking whether crash triage has been quietly running without
+the debugger.)
+
+### 2.2 numpy argument support silently requires h5py (argument_generator.py:189)
+
+```python
+if not self.options.no_numpy and use_numpy and H5PyArgumentGenerator:
+    ...
+    self.simple_argument_generators += (self.genTrickyNumpy,) * 50
+```
+
+The numpy generators (`genTrickyNumpy`) are gated on `H5PyArgumentGenerator` being truthy —
+i.e. on **h5py** importing successfully. Two independent optional dependencies are entangled:
+install numpy without h5py and the numpy tricky-value generators silently never activate.
+**Fix:** gate numpy on numpy and h5py on h5py (split the predicate).
+
+---
+
+## 3. Structural over-generality (the Victor-era framework)
+
+These are the "early days produced a complex piece of software" items. They are real
+functionality, not dead code — so simplifying them trades risk for payoff. Presented
+largest-payoff-first with an honest risk read.
+
+### 3.1 The MAS pub/sub bus runs a linear pipeline (≈400 LOC core, HIGH/HIGH)
+
+`fusil/mas/` (agent.py 179, mta.py 59, mailbox.py 42, univers.py 40, agent_list.py 40, +
+small files) implements a generic multi-agent system: agents register `on_<event>` handlers,
+`MTA` queues `Message` objects, per-agent `Mailbox`es are drained each step by `Univers`, and
+`getScore()`/`score_weight` aggregate a session score.
+
+The reality of the Python fuzzer:
+
+- **No competing agents.** Each role (source, process, watchers, directory, aggressivity…) is
+  a singleton in a fixed pipeline. There is no plurality the bus exists to mediate.
+- **Fan-out is trivial.** Of ~16 event types, only `session_start` broadcasts to >2 handlers
+  (4: aggressivity, python_source, watch, create); `session_done`/`session_stop` reach 2
+  each; **every other event is point-to-point (1→1)**. A deterministic call graph is being
+  run through generic pub/sub + a polling `live()` loop.
+- **Scoring generality is unused.** Only 4 `getScore()` implementations exist; the dominant
+  real signal is textual crash detection in `WatchStdout`. `score_weight` is **always 1.0**
+  (set once in `project_agent.py:17`, never reassigned), yet `Session.computeScore`
+  (session.py:46-70) calls `normalizeScore` three times per agent for an effectively
+  pass-through value.
+
+**Assessment:** this is the single largest *conceptual* simplification — collapsing the bus
+to direct method calls and the scoring to a boolean "did a watcher detect a crash" would make
+the control flow legible. But **every control-flow path runs through it**, including the
+session keep/drop logic that produces crash dirs, so the risk is high and the test coverage of
+the MAS itself is thin. **Recommendation:** do *not* rip it out wholesale. Instead, (a) delete
+the dead events/scoring generality (§1.4, the `score_weight` triple-normalize), and (b) treat a
+full MAS→pipeline rewrite as a separate, well-tested project only if maintenance pain justifies
+it. Document the actual event graph first (a one-page diagram) so the indirection is at least
+navigable.
+
+### 3.2 `AggressivityAgent` adaptive loop — broadcasts into the void (152 LOC, MED/MED)
+
+`fusil/aggressivity.py` maintains a feedback-control value (`update`/`updateState`/
+`writeGraphData`) and broadcasts `aggressivity_value` on every `session_start` — which, per
+§1.4, **nothing consumes** in the Python path. Its only live effect is `setValue` from
+`--aggressivity` and a line in the project summary (`project.py:282`). The adaptive control
+machinery is dead weight. **Recommendation:** collapse to a plain scalar option (the
+configured aggressivity) and drop the feedback loop + graph output. MED risk because the
+summary string and a few call sites touch it.
+
+### 3.3 `SystemCalm` + `linux/cpu_load` — off in the default config (≈213 LOC, MED/MED)
+
+`SystemCalm` (`system_calm.py`, 50 LOC) is instantiated **only** in `project.py`'s "medium"
+mode (`not fast and not slow`). The default is `--slow=True` (`application.py:127`), and the
+slow branch sets `system_calm = None` after printing the misleading warning *"SystemCalm class
+is not available"*. So the load-throttling wait loop and `SystemCpuLoad`/`linux/cpu_load.py`
+(163 LOC) are dead in the default configuration. **Recommendation:** either wire it on
+deliberately or remove the load-throttling path; at minimum fix the misleading warning.
+
+### 3.4 The h5py subsystem is 30% of the live tree (4,623 LOC, MED/MED)
+
+`fusil/python/h5py/` (`write_h5py_code.py` 2,166 + `h5py_tricky_weird.py` 1,442 +
+`h5py_argument_generator.py` 1,018) is a special-case carve-out for **one** third-party
+library — fully optional (guarded by `try: import h5py`). It is the largest single complexity
+sink in the project and dwarfs the generic fuzzer (`write_python_code.py` is 1,472 LOC). It is
+*not* dead (verified working with h5py installed), but it sits in the core tree.
+
+**Recommendation:** extract it into a **plugin**, mirroring the cereggii extraction (fusil
+already has a plugin system: `fusil.plugins` entry points, with argument-generator/definition/
+scenario hooks). This would (a) remove ~30% of the core LOC, (b) make the generic fuzzer the
+clear center of gravity, and (c) turn h5py into the reference example of a non-trivial plugin.
+MED effort (the h5py writer reaches into `self.parent` heavily, so the plugin boundary needs
+the parent's `write`/`indented`/`arg_generator` surface exposed cleanly). This is the
+highest-LOC, moderate-risk win.
+
+### 3.5 Config-file round-trip machinery (≈150 LOC, MED/MED)
+
+`config.py` (392 LOC) carries `ConfigParserWithHelp` + `OptionGroupWithSections` +
+`OptionParserWithSections` + `optparse_to_configparser()` + `write_sample_config()` to support
+`--write-config`/`--use-config` (generate and read a commented `fusil.conf`). It also
+hard-codes ~30 Python-fuzzer attribute defaults (`config.py:116-141`) that **duplicate** the
+optparse defaults in `python/__init__.py` — two sources of truth for the same options (and the
+source of bug §2.1). **Recommendation:** if config files aren't used in practice, remove the
+round-trip subsystem and collapse to optparse defaults as the single source of truth. MED risk
+(need to confirm no workflow depends on `fusil.conf`).
+
+### 3.6 Privilege-drop / `fusil`-user model (spread, HIGH/HIGH)
+
+`unsafe.py` + `process/prepare.py:changeUserGroup()` (setgid/setuid/setgroups) + the
+`process_user="fusil"` config + `safetyWarning()` flow (`application.py:367-415`) implement the
+dedicated-user sandboxing model, mostly bypassed by `--unsafe` in dev. It is real safety
+functionality, but heavy and never exercised on the dev path. **Recommendation:** leave as-is
+unless the project decides to standardize on container-based isolation; flag only as a known
+large surface. Do **not** treat as a quick win.
+
+### 3.7 Fine-grained class-per-concept style (minor)
+
+`score.py` (16 LOC wrapping trivial math), `agent_id.py` (14 LOC to hand out an incrementing
+int), `agent_list.py` (wraps a list), and the `Agent → ProjectAgent → SessionAgent` +
+`Directory` mixin hierarchies illustrate the framework's "a class for every concept" style.
+Individually minor; collectively they raise the cognitive cost of a linear pipeline. Fold
+opportunistically when touching adjacent code; not worth a dedicated pass.
+
+---
+
+## 4. Cross-cutting note: the lafleur ↔ fusil soft-coupling
+
+`argument_generator.py:40-66` does `try: from lafleur.mutator import (…10 genStateful*/
+genLying* functions…)` with a `HAS_MUTATOR` fallback, wiring them into the object-generator
+dispatch. This is a clean optional integration, but it means fusil now optionally imports
+argument generators **from its own spinoff**. Worth documenting explicitly (the two repos
+point at each other) so the dependency direction is intentional, not accidental. Notably, the
+"stateful/lying" generators lafleur contributes are exactly the bug-object family this report's
+companion (`reproducer-techniques-for-fusil.md`) recommends growing — see that doc.
+
+---
+
+## 5. Recommended roadmap
+
+**Phase 1 — quick wins + bug fixes (one or two small PRs, low risk):**
+1. Fix the two latent bugs (§2.1 debugger default, §2.2 numpy/h5py predicate).
+2. Delete X11 (§1.1) and `cmd_help_parser.py` (§1.2).
+3. Remove dead config switches (§1.3) and dead MAS events/handler (§1.4).
+4. Remove the always-1.0 `score_weight` generality + triple-normalize (§3.1.b).
+5. Scrub JIT comment leftovers (§1.5); fix the misleading SystemCalm warning (§3.3).
+
+Net: ~450 LOC removed, two real bugs fixed, no behavior change to the fuzzing path (modulo the
+two fixes, which *restore* intended behavior).
+
+**Phase 2 — the big structural decision (separate, well-tested):**
+6. Plugin-ize h5py (§3.4) — the largest LOC win. Decide first whether h5py coverage is a
+   current priority; if not, this is the clear next move.
+7. Collapse `AggressivityAgent` to a scalar (§3.2) and resolve the `SystemCalm` path (§3.3).
+
+**Phase 3 — only if maintenance pain justifies it (high risk):**
+8. Config round-trip removal (§3.5), single-source-of-truth defaults.
+9. MAS → direct-pipeline rewrite (§3.1) — document the event graph first; treat as its own
+   project with new tests for the keep/drop crash-dir logic before touching it.
+
+The golden-output test (`tests/python/test_golden_output.py`) and the OOM/feat/h5py
+before-after harnesses guard the *generation* path; none of the above touches generation
+except the h5py plugin move (which the h5py harness covers). The MAS/lifecycle work would need
+new tests around session keep/drop *before* starting — that coverage gap is itself a finding.

--- a/doc/reproducer-techniques-for-fusil.md
+++ b/doc/reproducer-techniques-for-fusil.md
@@ -1,0 +1,257 @@
+# Adapting cext-review-toolkit reproducer techniques to fusil
+
+*Analysis date: 2026-06-30. Source catalog:
+`~/projects/cext-review-toolkit/docs/reproducer-techniques.md` (32 techniques). Goal: find
+techniques fusil can adopt as fuzzing inputs — especially new **tricky objects** — building on
+the proven success of `set_nomemory` OOM injection (`--oom-fuzz`).*
+
+## How fusil uses "tricky objects" today
+
+The Python fuzzer injects hostile arguments through `ArgumentGenerator`
+(`fusil/python/argument_generator.py`). Predefined hostile values live in
+`fusil/python/samples/` and are surfaced by name via `fusil/python/tricky_weird.py`:
+
+- **`weird_classes.py`** — subclasses of every builtin container/number/bytes type
+  (`weird_list`, `weird_dict`, `weird_int`, …) under a `WeirdBase` metaclass with a *random*
+  `__hash__` and an `__eq__` that returns `False`, plus no-op/odd-return overrides of
+  `append`/`get`/`read`/`keys`/etc. Plus `FrameModifier` (a `__del__` that rewrites a caller
+  frame local — a JIT-era trick).
+- **`tricky_objects.py`** — odd builtin instances (self-referential `SimpleNamespace`, cyclic
+  list, capsule, mappingproxy, recursive function/lambda, a descriptor, a metaclass that
+  denies `__signature__` and rewrites `__mro_entries__`, a frame/traceback).
+- **`tricky_typing.py`** — every `type` from abc/builtins/collections/typing + a giant `Union`.
+- **`tricky_numpy.py`**, h5py objects, template strings — domain-specific.
+
+A generator method (`genTrickyObjects`, `genWeirdClass`, …) is registered into the
+`simple`/`hashable`/`complex` generator tuples; each emits a reference like
+`tricky_objects['name']` or `weird_instances['name']` into the generated script. **Adding a new
+tricky object is therefore cheap:** add it to a sample module, register its name in
+`tricky_weird.py`, add a one-line `genX` method, and append that method to the relevant
+generator tuple(s). fusil already optionally imports a `genStateful*`/`genLying*` family from
+`lafleur.mutator` when lafleur is installed (`argument_generator.py:40-66`), so the slot for
+"stateful bomb objects" already exists in spirit.
+
+The other proven mode is **global allocator coercion**: `--oom-fuzz` arms
+`_testcapi.set_nomemory` (Technique 18) and `--oom-seq` sweeps a *windowed* failure so a
+corrupted allocation in one call is tripped over by a later call (the stale-state class that
+found OOM-0036). This "make a normally-rare failure deterministic, process-globally" shape is
+the template the best new techniques below follow.
+
+## Coverage cross-reference
+
+| # | Technique | fusil status | Opportunity |
+| --- | --- | --- | --- |
+| 1 | Metaclass hides `__name__`/`__module__`… | ✗ | **New tricky object** (MED) |
+| 2 | Stateful `__hash__` (raises on Nth) | ~ random hash, not raising | **New tricky object** (LOW) |
+| 3 | `__eq__` that raises | ~ returns False, not raises | **New tricky object** (LOW) |
+| 4 | Descriptor `__get__` raises | partial (TrickyDescriptor returns self) | **New tricky object** (LOW) |
+| 5 | Builtin subclass w/ malicious methods | ~ weird_classes no-op, don't raise | **Extend** weird_classes (LOW) |
+| 5b/21 | Mischievous file-like objects | ✗ (h5py does files, not generic) | **New tricky object** (MED) |
+| 6 | `__del__` side effects | partial (FrameModifier) | **Extend** (LOW) |
+| 7 | `__index__`/`__int__`/`__float__` raises | ✗ | **New tricky object** (LOW) |
+| 8 | Iterator fails mid-iteration | ✗ | **New tricky object** (LOW) |
+| 9 | `__len__` lies or raises | ✗ | **New tricky object** (LOW) |
+| 10 | Out-of-range / boundary indices | ~ numeric boundaries in weird_classes | **Extend** (LOW) |
+| 11 | Mutating callback (clears container) | ✗ | New tricky object (HARD — needs container ref) |
+| 12 | Weakref callback during sensitive op | ✗ | New tricky object (MED) |
+| 13 | `__repr__`/`__str__` raises | ✗ | **New tricky object** (LOW) |
+| 14 | `__bool__` raises | ✗ | **New tricky object** (LOW) |
+| 15 | Buffer protocol abuse | partial (genBufferObject exists) | Extend (HARD) |
+| 16/17 | refleak / tracemalloc measurement | ✗ (fusil is crash-focused) | Off-mission (detection, not input) |
+| 18 | `set_nomemory` OOM injection | ✓ `--oom-fuzz` | Done (prolific) |
+| 19 | Stateful metaclass hash (type-keyed dict) | ✗ | New tricky object (MED) |
+| 20 | `str` subclass in `sys.modules` | ✗ | New harness option (MED, niche) |
+| 22 | Callback mutates caller state | ✗ | New tricky object (HARD) |
+| 23/27/31 | System-malloc fault (libfiu/LD_PRELOAD) | ✗ | **New mode — reaches foreign allocators** (HIGH) |
+| 24 | RSS growth leak monitoring | ✗ | Off-mission (detection) |
+| 25 | SystemError probe (PyCFunction contract) | ~ WatchStdout catches SystemError | **Lightweight new mode** (LOW-MED) |
+| 26 | Cyclic-GC threshold coercion `(1,1,1)` | ✗ | **New global knob — cheap, high value** (LOW) |
+| 28 | ctypes struct-field probe | ✗ | Off-mission (niche leak detection) |
+| 29 | MRO unbound-method bypass | ✗ | Off-mission (immutability audit) |
+| 30 | `python -O` assert-strip probe | ✗ | New run-variant (LOW, modest value) |
+| 32 | TSan triage on 3.14t | ✗ (fusil does FT fuzzing, manual triage) | Off-mission (triage methodology) |
+
+`✓` = covered, `~` = partially covered, `✗` = not covered.
+
+---
+
+## Recommendations, prioritized
+
+### A. The "exception-bomb object" family — biggest ROI, lowest effort
+
+This is the direct analogue of the OOM success at the *protocol* level. `set_nomemory` makes
+**allocations** fail deterministically; an exception-bomb object makes a **dunder callback**
+fail deterministically — exercising the huge class of C code that calls a Python protocol slot
+(`__hash__`, `__eq__`, `__index__`, `__len__`, `__bool__`, `__repr__`, iteration, `__get__`)
+and then does an unguarded `PyErr_Clear()` or assumes success. These are Techniques 2, 3, 7, 8,
+9, 13, 14 and they all collapse into one small, parameterized family.
+
+The key refinement, mirroring `--oom-seq`'s windowed failure: make the bomb **stateful /
+delayed** — succeed on the first N calls, then raise. The cross-call "succeeded during
+insert, fails during lookup" shape is exactly what surfaces swallowed-`MemoryError` bugs (it's
+how Technique 2/19 found the pymongo/bson and msgspec bugs). And raising **`MemoryError`** (not
+a generic error) is what makes these catch the *same* unguarded-error-path bug class as the OOM
+mode — but reaching sites `set_nomemory` can't (where the failure originates in user code, not
+the allocator).
+
+Concrete addition — a new `samples/bomb_objects.py`:
+
+```python
+class _Bomb:
+    """Base: succeed `delay` times, then raise `exc` from the armed dunder(s)."""
+    def __init__(self, delay=0, exc=MemoryError):
+        self._n, self._delay, self._exc = 0, delay, exc
+    def _fire(self):
+        self._n += 1
+        if self._n > self._delay:
+            raise self._exc("fusil bomb")
+
+class HashBomb(_Bomb):
+    def __hash__(self): self._fire(); return 42
+    def __eq__(self, other): return self is other
+
+class EqBomb:
+    def __eq__(self, other): raise MemoryError("fusil eq bomb")
+    def __ne__(self, other): raise MemoryError("fusil ne bomb")
+    def __hash__(self): return 0
+    def __iter__(self): return iter(())   # pass "is it a sequence?" pre-checks
+    def __len__(self): return 0
+
+class IndexBomb(_Bomb):
+    def __index__(self): self._fire(); return 1
+    def __int__(self): self._fire(); return 1
+    def __float__(self): self._fire(); return 1.0
+
+class LenBomb:
+    def __len__(self): raise MemoryError("fusil len bomb")
+    def __iter__(self): return iter([1, 2, 3])
+
+class LyingLen:
+    def __len__(self): return 1_000_000        # over-allocation
+    def __iter__(self): return iter([1, 2, 3])
+
+class FailingIterator:
+    """Yields a few items then raises mid-iteration (extend/update partial-mutation)."""
+    def __init__(self, n=3, fail=RuntimeError): self._i, self._n, self._fail = 0, n, fail
+    def __iter__(self): return self
+    def __next__(self):
+        if self._i >= self._n: raise self._fail("fusil iter bomb")
+        self._i += 1; return self._i
+    def __len__(self): return self._n          # trip the pre-allocation path
+
+class ReprBomb:
+    def __repr__(self): raise MemoryError("fusil repr bomb")
+    def __str__(self): raise RuntimeError("fusil str bomb")
+
+class BoolBomb:
+    def __bool__(self): raise RuntimeError("fusil bool bomb")
+```
+
+Wire each as a `genBomb*` returning e.g. `["HashBomb(delay=1)"]` (constructed inline so each
+call gets a fresh, freshly-armed instance — important: a module-level singleton would stay
+"fired"). Add them to the `simple`/`complex` (and `hashable`, for `HashBomb`) tuples. Because
+they're constructed per-call, the `delay` can even be randomized per emission, giving the same
+"sweep a range of windows" coverage `--oom-seq-randomize` gives. **Effort: LOW. Risk: LOW**
+(opt-in via the generator tuples; output guarded by the golden test once added to the default
+set, or behind a flag). This is the recommended first implementation.
+
+### B. Cyclic-GC threshold coercion — a cheap global knob like `set_nomemory` (Technique 26)
+
+`gc.set_threshold(1, 1, 1)` forces a gen-0 collection on essentially every tracked allocation,
+turning rare "GC fires while an object is tracked but half-initialized" races (`tp_traverse`
+reading a NULL field) into deterministic crashes. This is the same *shape* as the OOM win — a
+one-line global coercion that massively amplifies a latent error class — and it composes with
+everything else fusil already generates. Add a `--gc-aggressive` flag that emits
+`import gc; gc.set_threshold(1, 1, 1)` near the top of the generated script (next to the OOM
+harness). Pairs especially well with class-instantiation fuzzing and the bomb objects above.
+**Effort: LOW. Risk: LOW.** Strong second pick.
+
+### C. Mischievous file-like objects (Techniques 5b / 21)
+
+A small set of file-like bombs — `read()` returning the wrong type, `read()` succeeding once
+then raising (delayed failure, the most productive), `fileno()` raising while the object stays
+callable — targets the very common "try fd, fall back to `.read()`" C pattern and mid-parse
+error handling. fusil's h5py path exercises real files but nothing generic feeds hostile
+file-likes to arbitrary module functions that accept a file argument. Add a `FileBomb` family
+to the bomb module and a `genFileBomb` generator. **Effort: MED** (value depends on how often
+target functions take file-like args; pairs with a heuristic that prefers it for params named
+`file`/`fp`/`path`/`fileobj`). **Risk: LOW.**
+
+### D. Metaclass / descriptor attribute bombs (Techniques 1, 4, 19)
+
+- **Attribute-hiding metaclass** (T1): a class whose metaclass `__getattribute__` raises on
+  `__name__`/`__module__`/`__qualname__` — targets unchecked `PyObject_GetAttrString(Py_TYPE
+  (obj), …)` flowing into `strcmp`/`PyUnicode_AsUTF8`. fusil already passes types as arguments
+  (`tricky_typing`), so a `HiddenNameType` slots in naturally.
+- **Bomb descriptor** (T4): a descriptor whose `__get__` raises `KeyboardInterrupt`/
+  `MemoryError`, injected into a class dict — targets unguarded `PyErr_Clear` in getattr
+  fallbacks. fusil already has `TrickyDescriptor`; add a raising variant.
+- **Stateful metaclass hash** (T19): a type whose metaclass `__hash__` succeeds at
+  registration then fails after arming — targets `PyDict_GetItem` on type-keyed registries.
+
+**Effort: MED** (each is a distinct object; T19 needs the "register then arm" two-phase
+emission). **Risk: LOW.** Good third tranche after A/B.
+
+### E. SystemError contract probe as a light mode (Technique 25)
+
+fusil already *detects* `SystemError` (`WatchStdout` matches it, and `--oom-fuzz` explicitly
+surfaces `[OOM] SystemError`). What it doesn't do is *systematically* call every module
+function with deliberately-malformed args specifically to trip the
+`PyErr_SetString(...); Py_RETURN_NONE;` contract violation and assert zero SystemErrors. fusil
+already passes hostile args, so much of this happens incidentally; a focused `--contract-probe`
+mode (call each function with positional garbage and bad kwargs, flag any SystemError) would
+make it deterministic and fast. **Effort: LOW-MED. Risk: LOW.** Modest incremental value over
+what incidental fuzzing already finds.
+
+### F. System-malloc fault injection via libfiu / LD_PRELOAD (Techniques 23 / 27 / 31)
+
+This is the strategic, higher-effort complement to `set_nomemory`. `set_nomemory` only hooks
+CPython's allocator domains; it **cannot** reach `malloc`/`calloc`/`realloc` inside foreign C
+libraries an extension links (HDF5, libzstd, libxml2, …). libfiu (`LD_PRELOAD` +
+`fiu_posix_preload.so`) does, with call-site-specific targeting (`from_stack_of`). For fusil's
+mission of crashing C-extension modules, this opens a genuinely new bug surface that the OOM
+mode structurally can't see — the error/cleanup paths of the C libraries extensions wrap.
+**Effort: HIGH** (libfiu build + `LD_PRELOAD`/`PYTHONMALLOC=malloc` plumbing in the process
+launcher; subprocess isolation fusil already has). Technique 31's libfiu-free `LD_PRELOAD`
+shim (`mallocfault.c`) is a lighter-weight alternative needing only a one-time `gcc`. **Risk:
+MED** (env/launcher changes; the "bricks the interpreter under unconditional enable" footgun
+must be handled with scoped arming, exactly as fusil already disarms `set_nomemory` outside the
+window). Recommend as a separate project after A–D, *if* foreign-allocator coverage is a goal —
+it's the natural "OOM mode, part 2."
+
+### G. `python -O` assert-strip variant (Technique 30)
+
+Running the generated script under `-O` strips Python-level `assert`s; diffing `-O` vs default
+behavior surfaces asserts-used-as-validation. For fusil's C-crash focus this is modest (C
+`assert()` depends on build-time `NDEBUG`, not `-O`), but it's nearly free: occasionally launch
+the child interpreter with `-O`. **Effort: LOW. Risk: LOW. Value: modest.** Nice-to-have.
+
+### Off-mission (catalogued, not recommended for fusil)
+
+Leak-measurement harnesses (T16 refcount, T17 tracemalloc, T24 RSS, T28 ctypes struct probe)
+are *detection* methodologies for a leak-hunting workflow, not fuzzing inputs — fusil is
+crash-focused and its keep/drop logic is signal-based, so these belong in a separate leak-mode
+tool if ever wanted. MRO bypass (T29) is an immutability audit. TSan triage (T32) is a
+free-threaded race-interpretation methodology (fusil *does* free-threaded fuzzing, but
+automating TSan verdict interpretation is a triage tool, not a generator change).
+
+---
+
+## Suggested implementation order
+
+1. **A — exception-bomb object family** (`samples/bomb_objects.py` + generators). Highest
+   ROI, lowest risk, directly extends the proven unguarded-error-path bug class to protocol
+   slots `set_nomemory` can't reach. Make the bombs stateful/delayed (the `--oom-seq` insight).
+2. **B — `--gc-aggressive`** (`gc.set_threshold(1,1,1)`). One-line global coercion, composes
+   with everything.
+3. **C/D — file-like bombs + metaclass/descriptor/stateful-hash bombs.** Same mechanism,
+   broader protocol coverage.
+4. **E — `--contract-probe`** SystemError mode (small, mostly already incidental).
+5. **F — libfiu/LD_PRELOAD malloc fault** as "OOM mode part 2" reaching foreign allocators —
+   the high-effort strategic item, only if C-library coverage is a goal.
+6. **G — `-O` run variant** as a cheap nice-to-have.
+
+Each new tricky object is independently testable: add it, regenerate the golden snapshot
+intentionally (or gate behind a flag and verify via a before/after harness under a pinned
+`PYTHONHASHSEED`, exactly as the OOM/feat harnesses already do), confirm the emitted script
+parses, and dry-run with `--only-generate` against a real module.


### PR DESCRIPTION
Two analysis reports (documentation only — no code changes), requested to guide the next round of work.

## `doc/complexity-reduction-report.md`
Inventory of unneeded features and over-engineering in the live tree, with file:line evidence (gathered by an Explore agent, key claims hand-verified):

- **Quick wins (clearly dead):** X11 support is fully unreachable (`setupX11()` has zero callers — ~60 LOC across 6 files); orphaned `cmd_help_parser.py` (188 LOC); dead config switches (`process_use_cpu_probe`, `slow_calm_*`); dead MAS events (`aggressivity_value`, `process_pid`, `project_start`, `session_success`) + handler.
- **Two verified latent bugs:** (1) `debugger_use_debugger` defaults to `DEFAULTS["debugger_trace_forks"]` (False) → the ptrace debugger is **off by default** with no config file; (2) numpy arg generators are gated on `H5PyArgumentGenerator` → numpy support silently requires h5py installed.
- **Structural targets:** the MAS pub/sub bus + scoring runs what is a 1:1 linear pipeline (`score_weight` is always 1.0); the `fusil/python/h5py/` subsystem is **4.6k LOC ≈ 30% of the live tree** (candidate to plugin-ize, mirroring cereggii); `AggressivityAgent`'s adaptive loop broadcasts into the void; `SystemCalm` is dead in the default `--slow` mode.
- A phased roadmap (quick wins + bug fixes → h5py plugin-ization → optional MAS rewrite).

## `doc/reproducer-techniques-for-fusil.md`
Cross-references all 32 `cext-review-toolkit` reproducer techniques against fusil's existing tricky-object arsenal. Building on the `set_nomemory` success, recommends in priority order:

1. **Exception-bomb object family** — stateful/delayed raising dunders (`__hash__`/`__eq__`/`__index__`/`__len__`/`__bool__`/`__repr__`/iteration). The protocol-level analogue of `set_nomemory`: makes a dunder callback fail deterministically, reaching the unguarded-`PyErr_Clear` bug class at sites the allocator hook can't. Lowest effort, highest ROI.
2. **`--gc-aggressive`** (`gc.set_threshold(1,1,1)`) — a one-line global coercion like the OOM arming, turning rare GC-during-partial-init races into deterministic crashes.
3. Mischievous file-like + metaclass/descriptor/stateful-hash bombs.
4. A SystemError contract probe (mostly already incidental).
5. **libfiu / LD_PRELOAD malloc fault injection** as "OOM mode part 2" — reaches foreign C-library allocators (HDF5, zstd, …) that `set_nomemory` structurally cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)