### PR TITLE
fix: decouple numpy argument generators from h5py (§2.2)

### DIFF
--- a/fusil/python/argument_generator.py
+++ b/fusil/python/argument_generator.py
@@ -185,12 +185,21 @@ class ArgumentGenerator:
                 self.genTrickyObjects,
             )
 
-        # Handle NumPy, h5py, and t-strings conditionally
-        if not self.options.no_numpy and use_numpy and H5PyArgumentGenerator:
-            if allow_external_references:
-                self.simple_argument_generators += (self.genTrickyNumpy,) * 50
-                self.complex_argument_generators += (self.genTrickyNumpy,) * 50
-            assert isinstance(self.h5py_argument_generator, H5PyArgumentGenerator)
+        # NumPy tricky arrays -- gated on numpy alone, NOT on h5py. (Previously this whole
+        # block required H5PyArgumentGenerator, so numpy support silently did nothing unless
+        # h5py was also installed.)
+        if (
+            not self.options.no_numpy
+            and use_numpy
+            and numpy is not None
+            and allow_external_references
+        ):
+            self.simple_argument_generators += (self.genTrickyNumpy,) * 50
+            self.complex_argument_generators += (self.genTrickyNumpy,) * 50
+
+        # h5py objects -- self.h5py_argument_generator is set only when use_h5py and h5py
+        # imported; h5py pulls in numpy, so keep the --no-numpy guard here.
+        if not self.options.no_numpy and self.h5py_argument_generator is not None:
             self.simple_argument_generators += (self.h5py_argument_generator.genH5PyObject,) * 50
 
         if (

--- a/tests/python/test_argument_generator.py
+++ b/tests/python/test_argument_generator.py
@@ -379,11 +379,15 @@ class TestArgumentGenerator(unittest.TestCase):
         self._setup_arg_gen(
             use_numpy=False, use_h5py_arg_gen=True, no_numpy_opt=False
         )  # use_numpy init flag is False
+        # NumPy generators are off when the use_numpy init flag is False...
         self.assertFalse(
             self._check_if_generator_in_tuple("genTrickyNumpy", "simple_argument_generators")
         )
-        self.assertFalse(
-            self._check_if_generator_in_tuple("genH5PyObject", "simple_argument_generators")
+        # ...but h5py support is now INDEPENDENT of numpy (it used to be wrongly gated on the
+        # numpy flag): genH5PyObject is present iff h5py is actually available.
+        self.assertEqual(
+            self._check_if_generator_in_tuple("genH5PyObject", "simple_argument_generators"),
+            self.arg_gen.h5py_argument_generator is not None,
         )
 
     def test_complex_generators_composition_with_templates(self):


### PR DESCRIPTION
Fixes the §2.2 latent bug from the complexity report.

The NumPy tricky-array generators (`genTrickyNumpy`) were gated on `if not no_numpy and use_numpy and H5PyArgumentGenerator:` — so **numpy support silently did nothing unless h5py was also installed**. Two independent optional dependencies wrongly entangled.

Split into two conditions:
- **numpy** generators → gated on numpy alone (importable + not `--no-numpy` + `use_numpy` + external refs).
- **h5py** `genH5PyObject` → gated on its own generator being set (`use_h5py` + h5py imported), keeping the `--no-numpy` guard (h5py pulls in numpy).

Updated `test_simple_generators_composition_without_numpy_init`, which encoded the old coupling — it now asserts h5py is present iff h5py is actually available, independent of the numpy init flag.

## Verification
When both deps are installed the generator tuples are **unchanged** (h5py harness byte-identical); the golden snapshot (`no_numpy`) is unaffected. Suite **328 OK**, ruff clean.

Part of Phase 1 (#106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)