### PR TITLE
feat(plugins): instance-dispatcher, class-handler, blacklist/whitelist hooks (h5py Phase A)

### DIFF
--- a/fusil/plugin_manager.py
+++ b/fusil/plugin_manager.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
+from fnmatch import fnmatch
 from importlib.metadata import entry_points
 from typing import Any, Callable
 
@@ -49,6 +50,54 @@ class FuzzingMode:
 
 
 @dataclass
+class InstanceDispatcher:
+    """A per-instance dispatch provider.
+
+    Called from ``WritePythonCode._dispatch_fuzz_on_instance`` (after the
+    skip-trivial check, before the generic fallback). It emits specialized
+    ``elif isinstance(target, SomeType):`` fuzzing branches into the generated
+    script. To wrap the generic fallback in a trailing ``else:`` it may open an
+    indentation level and return the level to restore to (an int); returning
+    ``None`` means "no branches opened, run the generic fallback unconditionally".
+    """
+
+    provider_func: (
+        Callable  # (writer, current_prefix, target_expr, class_name_hint, depth) -> int | None
+    )
+
+
+@dataclass
+class ClassHandler:
+    """A class-instantiation handler.
+
+    Called from ``WritePythonCode._fuzz_one_class`` before the generic
+    ``callFunc`` instantiation. It may claim a class (e.g. an h5py.File) and emit
+    specialized instantiation code, returning ``True`` if it handled the class
+    (suppressing the generic instantiation) or ``False`` to fall through.
+    """
+
+    provider_func: Callable  # (writer, class_name, class_type, instance_var, prefix) -> bool
+
+
+@dataclass
+class NameFilterEntry:
+    """A blacklist/whitelist entry for discovered names.
+
+    ``kind`` is one of 'module', 'class', 'function', 'object', 'method'.
+    ``pattern_type`` is 'exact' (default) or 'glob' (fnmatch, e.g. '*Test').
+    """
+
+    kind: str
+    pattern: str
+    pattern_type: str = "exact"
+
+    def matches(self, name: str) -> bool:
+        if self.pattern_type == "glob":
+            return fnmatch(name, self.pattern)
+        return name == self.pattern
+
+
+@dataclass
 class PluginMetadata:
     """Metadata about a loaded plugin."""
 
@@ -72,6 +121,10 @@ class PluginManager:
         self.definitions_providers: list[DefinitionsProvider] = []
         self.scenario_providers: list[ScenarioProvider] = []
         self.fuzzing_modes: dict[str, FuzzingMode] = {}
+        self.instance_dispatchers: list[InstanceDispatcher] = []
+        self.class_handlers: list[ClassHandler] = []
+        self.blacklist_entries: list[NameFilterEntry] = []
+        self.whitelist_entries: list[NameFilterEntry] = []
         self.hooks: dict[str, list[Callable]] = {
             "startup": [],
             "shutdown": [],
@@ -201,6 +254,46 @@ class PluginManager:
         mode = FuzzingMode(name=name, activation_check=activation_check, setup_script=setup_script)
         self.fuzzing_modes[name] = mode
 
+    def add_instance_dispatcher(self, provider_func: Callable) -> None:
+        """Register a per-instance dispatch provider (see InstanceDispatcher).
+
+        Args:
+            provider_func: (writer, current_prefix, target_expr, class_name_hint, depth)
+                -> int | None. Emits specialized ``elif isinstance(...)`` branches and
+                optionally opens a trailing ``else:`` level (returned int) that the core
+                fills with the generic fallback; return None to leave the fallback
+                unconditional.
+        """
+        self.instance_dispatchers.append(InstanceDispatcher(provider_func=provider_func))
+
+    def add_class_handler(self, provider_func: Callable) -> None:
+        """Register a class-instantiation handler (see ClassHandler).
+
+        Args:
+            provider_func: (writer, class_name, class_type, instance_var, prefix) -> bool.
+                Emits specialized instantiation and returns True if it claimed the class
+                (suppressing the generic ``callFunc`` instantiation), else False.
+        """
+        self.class_handlers.append(ClassHandler(provider_func=provider_func))
+
+    def add_blacklist_entry(self, kind: str, pattern: str, pattern_type: str = "exact") -> None:
+        """Blacklist a discovered name (module/class/function/object/method).
+
+        Args:
+            kind: 'module', 'class', 'function', 'object', or 'method'.
+            pattern: the name (or glob pattern) to exclude.
+            pattern_type: 'exact' (default) or 'glob' (fnmatch, e.g. '*Test').
+        """
+        self.blacklist_entries.append(NameFilterEntry(kind, pattern, pattern_type))
+
+    def add_whitelist_entry(self, kind: str, pattern: str, pattern_type: str = "exact") -> None:
+        """Whitelist a discovered name so it is kept even when normally skipped.
+
+        Currently honoured for 'method' names: a whitelisted method (e.g. '__del__')
+        is kept even though private/dunder names are skipped by default.
+        """
+        self.whitelist_entries.append(NameFilterEntry(kind, pattern, pattern_type))
+
     def add_hook(self, hook_name: str, hook_func: Callable) -> None:
         """
         Register a lifecycle hook.
@@ -303,6 +396,22 @@ class PluginManager:
             if scenarios:
                 all_scenarios.update(scenarios)
         return all_scenarios
+
+    def get_instance_dispatchers(self) -> list[Callable]:
+        """Return the registered per-instance dispatch provider functions."""
+        return [d.provider_func for d in self.instance_dispatchers]
+
+    def get_class_handlers(self) -> list[Callable]:
+        """Return the registered class-instantiation handler functions."""
+        return [h.provider_func for h in self.class_handlers]
+
+    def is_blacklisted(self, kind: str, name: str) -> bool:
+        """True if a plugin blacklisted `name` for the given `kind`."""
+        return any(e.kind == kind and e.matches(name) for e in self.blacklist_entries)
+
+    def is_whitelisted(self, kind: str, name: str) -> bool:
+        """True if a plugin whitelisted `name` for the given `kind`."""
+        return any(e.kind == kind and e.matches(name) for e in self.whitelist_entries)
 
     def get_active_mode(self, config: Any) -> FuzzingMode | None:
         """

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -192,7 +192,10 @@ class WritePythonCode(WriteCode):
                 )
                 continue
 
+            pm = self.plugin_manager
             if isinstance(attr, (FunctionType, BuiltinFunctionType)):
+                if pm and pm.is_blacklisted("function", name):
+                    continue
                 functions.append(name)
             elif isinstance(attr, type) or inspect.isclass(attr):
                 if (
@@ -202,6 +205,8 @@ class WritePythonCode(WriteCode):
                     # and attr.__name__ in _EXCEPTION_NAMES
                 ):
                     continue
+                if pm and pm.is_blacklisted("class", name):
+                    continue
                 classes.append(name)
             else:
                 if isinstance(attr, ModuleType) or type(attr) in TRIVIAL_TYPES:
@@ -210,6 +215,8 @@ class WritePythonCode(WriteCode):
                     not self.options.fuzz_exceptions and isinstance(attr, BaseException)
                     # and attr.__class__.__name__ in _EXCEPTION_NAMES
                 ):
+                    continue
+                if pm and pm.is_blacklisted("object", name):
                     continue
                 objects.append(name)
         return functions, classes, objects
@@ -234,11 +241,17 @@ class WritePythonCode(WriteCode):
             and issubclass(obj_instance_or_class, BaseException)
         ) or isinstance(obj_instance_or_class, BaseException)
 
+        pm = self.plugin_manager
         for name in dir(obj_instance_or_class):
             if name in blacklist:
                 continue
+            if pm and pm.is_blacklisted("method", name):
+                continue
             if (
-                (not self.options.test_private) and name.startswith("_")
+                (not self.options.test_private)
+                and name.startswith("_")
+                # a plugin may whitelist a normally-skipped method (e.g. '__del__')
+                and not (pm and pm.is_whitelisted("method", name))
                 # and not name.endswith("__")
             ):
                 continue
@@ -742,24 +755,35 @@ class WritePythonCode(WriteCode):
 
         num_constructor_args = class_arg_number(class_name_str, class_type)
         self.write(0, f"{instance_var_name} = None # Initialize instance variable")
-        # PoC of the indentation context manager: `with self.indented():` replaces the
-        # addLevel(1)/restoreLevel(self.base_level - 1) bookkeeping -- the block's nesting now
-        # mirrors the generated code's nesting and the level can't leak. Output is unchanged
-        # (guarded by tests/python/test_golden_output.py).
-        self.write(0, "try:")
-        with self.indented():
-            self.write(0, f"{instance_var_name} = callFunc('{prefix}_init', '{class_name_str}',")
-            self._write_arguments_for_call_lines(num_constructor_args, 1)  # Indent args by 1
-            self.write(0, "  )")  # Close callFunc
-        self.write(0, "except Exception as e_instantiate:")
-        with self.indented():
-            self.write(0, f"{instance_var_name} = None")
-            self.write_print_to_stderr(
-                0,
-                f'"[{prefix}] Failed to instantiate {class_name_str}: {{e_instantiate.__class__.__name__}} {{e_instantiate}}"',
-            )
-            # callFunc may not set instance_var_name on error, so set it explicitly.
-            self.write(0, f"{instance_var_name} = None")
+
+        # Plugin class handlers get first chance to emit specialized instantiation (e.g. an
+        # h5py.File needs a backing file, not a generic callFunc). A handler returns True to
+        # claim the class; otherwise we fall through to the standard callFunc instantiation.
+        # With no handlers registered this is byte-identical to the pre-plugin behaviour.
+        handled = False
+        if self.plugin_manager:
+            for handler in self.plugin_manager.get_class_handlers():
+                if handler(self, class_name_str, class_type, instance_var_name, prefix):
+                    handled = True
+                    break
+
+        if not handled:
+            self.write(0, "try:")
+            with self.indented():
+                self.write(
+                    0, f"{instance_var_name} = callFunc('{prefix}_init', '{class_name_str}',"
+                )
+                self._write_arguments_for_call_lines(num_constructor_args, 1)  # Indent args by 1
+                self.write(0, "  )")  # Close callFunc
+            self.write(0, "except Exception as e_instantiate:")
+            with self.indented():
+                self.write(0, f"{instance_var_name} = None")
+                self.write_print_to_stderr(
+                    0,
+                    f'"[{prefix}] Failed to instantiate {class_name_str}: {{e_instantiate.__class__.__name__}} {{e_instantiate}}"',
+                )
+                # callFunc may not set instance_var_name on error, so set it explicitly.
+                self.write(0, f"{instance_var_name} = None")
         self.emptyLine()
 
         self._dispatch_fuzz_on_instance(
@@ -830,12 +854,24 @@ class WritePythonCode(WriteCode):
                     0,
                     f"f'Skipping deep diving on {target_obj_expr_str} {{type({target_obj_expr_str})}}'",
                 )
-            # The h5py writer (when active) opens a trailing `else:` block and returns the
-            # level to restore to; the generic fuzzing below fills it, then we close it.
-            if self.h5py_writer:
-                L_else_generic = self.h5py_writer._dispatch_fuzz_on_h5py_instance(
-                    class_name_hint, current_prefix, generation_depth, target_obj_expr_str
-                )
+            # Plugin instance dispatchers emit specialized `elif isinstance(target, T):`
+            # branches here (after skip-trivial, before the generic fallback). A dispatcher
+            # may open a trailing `else:` and return the level to restore to, so the generic
+            # fallback below runs only when no specialized branch matched; None (the default,
+            # e.g. no plugins) leaves the fallback unconditional -- byte-identical to the
+            # pre-plugin behaviour.
+            L_else_generic = None
+            if self.plugin_manager:
+                for dispatcher in self.plugin_manager.get_instance_dispatchers():
+                    level = dispatcher(
+                        self,
+                        current_prefix,
+                        target_obj_expr_str,
+                        class_name_hint,
+                        generation_depth,
+                    )
+                    if level is not None:
+                        L_else_generic = level
             try:
                 self.write(0, "try:")
                 self.write_print_to_stderr(
@@ -855,7 +891,7 @@ class WritePythonCode(WriteCode):
                     self.options.methods_number,  # Generic number of calls
                 )
             finally:
-                if self.h5py_writer:
+                if L_else_generic is not None:
                     self.restoreLevel(L_else_generic)
 
     def _fuzz_generic_object_methods(

--- a/tests/python/test_write_python_code.py
+++ b/tests/python/test_write_python_code.py
@@ -347,35 +347,38 @@ class TestWritePythonCode(unittest.TestCase):
                     mock_write_args.assert_called_with(expected_num_args, 1)
 
     @unittest.skipIf(not H5PY_AVAILABLE, "h5py not installed")
-    def test_dispatch_fuzz_on_instance_dispatches_correctly(self):
-        """Logic Test: Validates _dispatch_fuzz_on_instance generates code for the correct fuzzer."""
-        # This test checks the generated code string to ensure the correct `isinstance`
-        # branch is created.
+    def test_dispatch_fuzz_on_instance_invokes_plugin_dispatchers(self):
+        """_dispatch_fuzz_on_instance calls plugin instance-dispatchers, then the generic fallback.
 
-        # Test 1: Generate code for a known h5py type hint ('Dataset')
+        Specialized per-type dispatch (e.g. the h5py Dataset/Group branches) now lives in a
+        plugin registered via add_instance_dispatcher, not hard-coded in core.
+        """
+        from fusil.plugin_manager import PluginManager
+
+        # With a registered dispatcher: it is invoked with the dispatch context, and the
+        # generic fallback still runs.
+        pm = PluginManager()
+        calls = []
+
+        def dispatcher(writer, current_prefix, target_expr, class_hint, depth):
+            writer.write(0, f"# plugin dispatch for {class_hint}")
+            calls.append((current_prefix, target_expr, class_hint, depth))
+            return None
+
+        pm.add_instance_dispatcher(dispatcher)
+        self.writer.plugin_manager = pm
         self.writer.output = StringIO()
-        self.writer._dispatch_fuzz_on_instance("h5_dispatch", "my_dataset_var", "Dataset", 0)
-        generated_code_h5py = self.writer.output.getvalue()
+        self.writer._dispatch_fuzz_on_instance("disp", "my_var", "Dataset", 0)
+        out = self.writer.output.getvalue()
+        self.assertEqual(calls, [("disp", "my_var", "Dataset", 0)])
+        self.assertIn("# plugin dispatch for Dataset", out)
+        self.assertIn("doing generic calls", out)
 
-        # It should generate the specific 'elif' for h5py.Dataset
-        self.assertIn("elif isinstance(my_dataset_var, h5py.Dataset):", generated_code_h5py)
-        # It should contain code specific to dataset fuzzing
-        self.assertIn("--- Fuzzing Dataset Instance:", generated_code_h5py)
-        # It should NOT fall back to the generic fuzzer if we want specialized fuzzing
-        # to avoid generic fuzzing. So far, we don't.
-        # self.assertNotIn("doing generic calls", generated_code_h5py)
-
-        # Test 2: Generate code for a generic type hint
+        # With no plugin manager: only the generic fallback is emitted.
+        self.writer.plugin_manager = None
         self.writer.output = StringIO()
-        self.writer._dispatch_fuzz_on_instance(
-            "generic_dispatch", "my_generic_var", "SomeGenericClass", 0
-        )
-        generated_code_generic = self.writer.output.getvalue()
-
-        # It should NOT contain specific h5py checks
-        # self.assertNotIn("elif isinstance(my_generic_var, h5py.Dataset):", generated_code_generic)
-        # It should fall back to the generic case
-        self.assertIn("doing generic calls", generated_code_generic)
+        self.writer._dispatch_fuzz_on_instance("generic", "my_generic_var", "SomeGenericClass", 0)
+        self.assertIn("doing generic calls", self.writer.output.getvalue())
 
     @patch("fusil.python.write_python_code.class_arg_number", return_value=2)
     def test_fuzz_one_class_orchestration(self, mock_arg_num):

--- a/tests/python/test_write_python_code_private.py
+++ b/tests/python/test_write_python_code_private.py
@@ -209,6 +209,80 @@ class TestWritePythonCodePrivateMethods(unittest.TestCase):
                 mock_fuzz_methods.call_args.kwargs["target_obj_expr_str"], "instance_c1_testclass"
             )
 
+    @patch("fusil.python.write_python_code.class_arg_number", return_value=1)
+    def test_fuzz_one_class_uses_plugin_class_handler(self, mock_arg_num):
+        """A plugin class handler that claims a class suppresses the generic callFunc init."""
+        from fusil.plugin_manager import PluginManager
+
+        pm = PluginManager()
+        seen = []
+
+        def handler(writer, class_name, class_type, instance_var, prefix):
+            writer.write(0, f"{instance_var} = make_special()  # claimed by plugin")
+            seen.append((class_name, instance_var, prefix))
+            return True
+
+        pm.add_class_handler(handler)
+        self.writer.plugin_manager = pm
+        self.writer.output = StringIO()
+        with (
+            patch.object(self.writer, "_dispatch_fuzz_on_instance"),
+            patch.object(self.writer, "_fuzz_methods_on_object_or_specific_types"),
+        ):
+            self.writer._fuzz_one_class(0, "TestClass", self.mock_module.TestClass)
+        out = self.writer.output.getvalue()
+        self.assertEqual(seen, [("TestClass", "instance_c1_testclass", "c1")])
+        self.assertIn("make_special()  # claimed by plugin", out)
+        # generic callFunc instantiation is suppressed
+        self.assertNotIn("callFunc('c1_init', 'TestClass'", out)
+
+    @patch("fusil.python.write_python_code.class_arg_number", return_value=1)
+    def test_fuzz_one_class_falls_through_when_handler_declines(self, mock_arg_num):
+        """A class handler returning False leaves the generic callFunc instantiation in place."""
+        from fusil.plugin_manager import PluginManager
+
+        pm = PluginManager()
+        pm.add_class_handler(lambda *a: False)
+        self.writer.plugin_manager = pm
+        self.writer.output = StringIO()
+        with (
+            patch.object(self.writer, "_dispatch_fuzz_on_instance"),
+            patch.object(self.writer, "_fuzz_methods_on_object_or_specific_types"),
+        ):
+            self.writer._fuzz_one_class(0, "TestClass", self.mock_module.TestClass)
+        self.assertIn("callFunc('c1_init', 'TestClass'", self.writer.output.getvalue())
+
+    def test_get_object_methods_respects_plugin_blacklist_and_whitelist(self):
+        """Plugin method blacklist drops names; whitelist keeps normally-skipped ones (__del__)."""
+        from fusil.plugin_manager import PluginManager
+
+        class Obj:
+            def keep_me(self):
+                pass
+
+            def drop_me(self):
+                pass
+
+            def __del__(self):
+                pass
+
+        # Baseline (no plugin): public methods discovered, __del__ skipped as private.
+        self.writer.plugin_manager = None
+        base = self.writer._get_object_methods(Obj(), "Obj")
+        self.assertIn("keep_me", base)
+        self.assertIn("drop_me", base)
+        self.assertNotIn("__del__", base)
+
+        # With a plugin blacklist + whitelist.
+        pm = PluginManager()
+        pm.add_blacklist_entry("method", "drop_me")
+        pm.add_whitelist_entry("method", "__del__")
+        self.writer.plugin_manager = pm
+        got = self.writer._get_object_methods(Obj(), "Obj")
+        self.assertIn("keep_me", got)
+        self.assertNotIn("drop_me", got)  # blacklisted
+        self.assertIn("__del__", got)  # whitelisted through the private-name skip
+
     def test_fuzz_one_module_object_orchestration(self):
         """Wiring Test: Ensures _fuzz_one_module_object calls the method fuzzer correctly."""
         with patch.object(
@@ -267,25 +341,35 @@ class TestWritePythonCodePrivateMethods(unittest.TestCase):
         self.assertIn("Max fuzz code generation depth", generated_code)
         self.assertNotIn("Dispatching Fuzz for", generated_code)
 
-    @unittest.skipIf(not H5PY_AVAILABLE, "h5py not installed")
     def test_dispatch_fuzz_on_instance_dispatching_logic(self):
-        """Logic Test: Validates _dispatch_fuzz_on_instance generates code for the correct fuzzer."""
-        # Test for h5py.Dataset dispatch
+        """_dispatch_fuzz_on_instance invokes plugin instance-dispatchers, then the generic fallback.
+
+        Specialized per-type dispatch (e.g. h5py Dataset/Group) is registered by a plugin via
+        add_instance_dispatcher rather than hard-coded in core.
+        """
+        from fusil.plugin_manager import PluginManager
+
+        pm = PluginManager()
+        seen = []
+
+        def dispatcher(writer, current_prefix, target_expr, class_hint, depth):
+            seen.append((current_prefix, target_expr, class_hint, depth))
+            return None
+
+        pm.add_instance_dispatcher(dispatcher)
+        self.writer.plugin_manager = pm
         self.writer.output = StringIO()
         self.writer._dispatch_fuzz_on_instance("h5_dispatch", "my_dataset_var", "Dataset", 0)
-        generated_code_h5py = self.writer.output.getvalue()
-        self.assertIn("elif isinstance(my_dataset_var, h5py.Dataset):", generated_code_h5py)
-        self.assertIn("--- Fuzzing Dataset Instance:", generated_code_h5py)
-        # self.assertNotIn("doing generic calls", generated_code_h5py)
+        self.assertEqual(seen, [("h5_dispatch", "my_dataset_var", "Dataset", 0)])
+        self.assertIn("doing generic calls", self.writer.output.getvalue())
 
-        # Test for generic object dispatch
+        # No plugin manager -> only the generic fallback.
+        self.writer.plugin_manager = None
         self.writer.output = StringIO()
         self.writer._dispatch_fuzz_on_instance(
             "generic_dispatch", "my_generic_var", "SomeGenericClass", 0
         )
-        generated_code_generic = self.writer.output.getvalue()
-        # self.assertNotIn("elif isinstance(my_generic_var, h5py.Dataset):", generated_code_generic)
-        self.assertIn("doing generic calls", generated_code_generic)
+        self.assertIn("doing generic calls", self.writer.output.getvalue())
 
     def test_write_main_fuzzing_logic_call_counts(self):
         """Wiring Test: Checks the main logic method calls the correct number of fuzzing sub-methods."""

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,74 @@
+"""Unit tests for the PluginManager registration API (Phase A additions).
+
+Covers the newer hooks a plugin needs to express deep, per-type fuzzing:
+instance dispatchers, class handlers, and the blacklist/whitelist name filters.
+Runtime-free (no python-ptrace / subprocess); imports only fusil.plugin_manager.
+"""
+
+import unittest
+
+from fusil.plugin_manager import PluginManager
+
+
+class TestInstanceDispatchers(unittest.TestCase):
+    def test_register_and_get(self):
+        m = PluginManager()
+        self.assertEqual(m.get_instance_dispatchers(), [])
+
+        def d(writer, prefix, target, hint, depth):
+            return None
+
+        m.add_instance_dispatcher(d)
+        self.assertEqual(m.get_instance_dispatchers(), [d])
+
+    def test_order_preserved(self):
+        m = PluginManager()
+        funcs = [lambda *a: None for _ in range(3)]
+        for f in funcs:
+            m.add_instance_dispatcher(f)
+        self.assertEqual(m.get_instance_dispatchers(), funcs)
+
+
+class TestClassHandlers(unittest.TestCase):
+    def test_register_and_get(self):
+        m = PluginManager()
+        self.assertEqual(m.get_class_handlers(), [])
+
+        def h(writer, name, typ, var, prefix):
+            return False
+
+        m.add_class_handler(h)
+        self.assertEqual(m.get_class_handlers(), [h])
+
+
+class TestBlacklistWhitelist(unittest.TestCase):
+    def test_exact_blacklist_is_kind_scoped(self):
+        m = PluginManager()
+        m.add_blacklist_entry("method", "_rehash")
+        self.assertTrue(m.is_blacklisted("method", "_rehash"))
+        self.assertFalse(m.is_blacklisted("method", "other"))
+        # kind-scoped: a 'method' entry does not match a 'class' query
+        self.assertFalse(m.is_blacklisted("class", "_rehash"))
+
+    def test_glob_blacklist(self):
+        m = PluginManager()
+        m.add_blacklist_entry("class", "*Test", pattern_type="glob")
+        self.assertTrue(m.is_blacklisted("class", "FooTest"))
+        self.assertTrue(m.is_blacklisted("class", "Test"))
+        self.assertFalse(m.is_blacklisted("class", "TestCase"))  # trailing chars
+        self.assertFalse(m.is_blacklisted("class", "Foo"))
+
+    def test_whitelist(self):
+        m = PluginManager()
+        m.add_whitelist_entry("method", "__del__")
+        self.assertTrue(m.is_whitelisted("method", "__del__"))
+        self.assertFalse(m.is_whitelisted("method", "__init__"))
+
+    def test_empty_manager_matches_nothing(self):
+        m = PluginManager()
+        self.assertFalse(m.is_blacklisted("method", "anything"))
+        self.assertFalse(m.is_whitelisted("method", "anything"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase A of plugin-izing h5py** (checkpoint before Phase B/C). Completes the plugin API so a plugin can express the deep, per-type fuzzing h5py needs — and unblocks the **cereggii** plugin, which already calls a blacklist/whitelist API that never existed (the "plugin feature isn't complete" gap).

### Investigation that shaped this
- The plugin API was missing `add_blacklist_entry`/`add_whitelist_entry` (cereggii `AttributeError`s on load).
- The h5py **`WriteH5PyCode` writer is dead code**: `use_h5py=True` is never passed to `WritePythonCode`, so `h5py_writer` is always `None` and its dispatch/header methods never run. Per your call, we'll **wire it up** as a real plugin (Phase B), in a **separate repo** (Phase C). The live h5py bits are the arg-generator + tricky-object defs.

### PluginManager additions
- **`add_instance_dispatcher(func)`** — called from `_dispatch_fuzz_on_instance` to emit specialized `elif isinstance(target, T): …` branches; may open a trailing `else:` and return the level to restore (so the generic fallback runs only when no branch matched), or return `None`.
- **`add_class_handler(func)`** — called from `_fuzz_one_class` before the generic `callFunc` instantiation; returns `True` to claim a class (e.g. `h5py.File` needs a backing file).
- **`add_blacklist_entry`/`add_whitelist_entry(kind, pattern, pattern_type='exact'|'glob')`** + `is_blacklisted`/`is_whitelisted`, wired into `_get_module_members` (class/function/object) and `_get_object_methods` (method blacklist + a whitelist that keeps normally-skipped names like `__del__`).

### Core wiring
Replaces the never-wired, always-`None` `if self.h5py_writer:` dispatch branch with the generic instance-dispatcher loop. **With no plugins registered, every new branch is a no-op → output byte-identical** (golden snapshot unchanged). The h5py writer itself is untouched here.

### Tests
New `tests/test_plugin_manager.py` (API units) + integration tests for the dispatcher/class-handler/blacklist wiring. The two old h5py-specific `_dispatch_fuzz_on_instance` tests were rewritten to exercise the generic mechanism (h5py-specific coverage travels with the plugin). Suite **328 → 338 OK**; golden byte-identical; ruff clean.

Next: **Phase B** — build `fusil_h5py_plugin` (separate repo) that registers genH5PyObject (args), the tricky defs (definitions), and the writer's dispatch/class-handling via these hooks — verified by really fuzzing h5py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)