### PR TITLE
refactor(config): remove the config-file round-trip machinery

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2,76 +2,25 @@
 Fusil configuration
 +++++++++++++++++++
 
-You can configure Fusil using a fusil.conf file in your configuration directory
-($XDG_CONFIG_HOME environment variable or ~/.config/). Template file: ::
+Fusil is configured entirely through **command-line options**. Run a fuzzer with
+``--help`` to see every option and its default::
 
-    ###############################################################
-    # General Fusil options
-    ###############################################################
-    [fusil]
+    fusil-python-threaded --help
 
-    # Maximum number of session (0=unlimited)
-    session = 0
+Options are grouped (Input, Running, Fuzzing, OOM Fuzzing, Logging, ...). See
+``doc/python-fuzzer.md`` for a narrative reference of the Python fuzzer's options.
 
-    # Maximum number of success before exit (0=unlimited)
-    success = 1
+.. note::
 
-    # Minimum score for a successful session
-    success_score = 0.50
+    Older versions of Fusil also read a ``fusil.conf`` file (``--use-config`` /
+    ``--write-config``). That round-trip was removed: it duplicated the option defaults
+    and the file it read never actually reached the running configuration. Command-line
+    options are now the single source of truth.
 
-    # Maximum score for a session error
-    error_score = -0.50
+Non-command-line defaults
+=========================
 
-    # Maximum memory in bytes (0=unlimited)
-    max_memory = 0
-
-    # (Normal) Maximum system load
-    normal_calm_load = 0.50
-
-    # (Normal) Seconds to sleep until system load is low
-    normal_calm_sleep = 0.5
-
-    # (Slow) Maximum system load
-    slow_calm_load = 0.30
-
-    # (Slow) Seconds to sleep until system load is low
-    slow_calm_sleep = 3.0
-
-    # xhost program path (change X11 permissions)
-    xhost_program = xhost
-
-    ###############################################################
-    # Debugger used to trace child processes
-    ###############################################################
-    [debugger]
-
-    # Use the debugger?
-    use_debugger = True
-
-    # Enable trace forks option
-    trace_forks = True
-
-
-    ###############################################################
-    # Child processes options
-    ###############################################################
-    [process]
-
-    # Dump core on crash
-    core_dump = True
-
-    # Maximum user process (RLIMIT_NPROC)
-    max_user_process = 10
-
-    # Default maximum memory in bytes (O=unlimited)
-    max_memory = 104857600
-
-    # Change the user (setuid)
-    user = fusil
-
-    # Change the group (setgid)
-    group = fusil
-
-    # Use a probe to watch CPU activity
-    use_cpu_probe = True
-
+A small number of settings have no command-line flag -- session scoring thresholds, the
+memory limit, and the dedicated-``fusil``-user subprocess sandbox (user/group). These live
+as constants in ``fusil/config.py`` (:class:`fusil.config.FusilConfig`) and are rarely
+changed. Edit that class if you need to adjust them.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ User documentation
 
 Start with `Fusil usage guide`_: quick guide to learn how to execute a fuzzer.
 
- * configuration_: Fusil configuration file
+ * configuration_: How to configure Fusil (command-line options)
  * safety_: Protection used in Fusil to avoid denial of service of your computer
 
 .. _`Fusil usage guide`: usage.html

--- a/fusil/application.py
+++ b/fusil/application.py
@@ -1,6 +1,5 @@
-import pathlib
 from grp import getgrgid, getgrnam
-from io import StringIO
+from optparse import OptionGroup, OptionParser
 from os import getgid, getuid
 from pwd import getpwnam, getpwuid
 from sys import exit, stderr, stdout
@@ -8,13 +7,7 @@ from sys import exit, stderr, stdout
 from ptrace.error import PTRACE_ERRORS, writeError
 
 from fusil.application_logger import ApplicationLogger
-from fusil.config import (
-    ConfigError,
-    FusilConfig,
-    OptionGroupWithSections,
-    OptionParserWithSections,
-    optparse_to_configparser,
-)
+from fusil.config import ConfigError, FusilConfig
 from fusil.file_tools import relativePath
 from fusil.mas.agent_list import AgentList
 from fusil.mas.application_agent import ApplicationAgent
@@ -86,11 +79,11 @@ class Application(ApplicationAgent):
         Create command line options specific to a fuzzer
         """
 
-    def createOptionParser(self, output=None):
+    def createOptionParser(self):
         """
         Create all command line options, including Fusil options.
         """
-        parser = OptionParserWithSections(usage=self.USAGE)
+        parser = OptionParser(usage=self.USAGE)
         parser.add_option(
             "--version",
             help="Display Fusil version (%s) and exit" % VERSION,
@@ -98,8 +91,7 @@ class Application(ApplicationAgent):
         )
 
         self.createFuzzerOptions(parser)
-        config_options = StringIO()
-        fuzzer = OptionGroupWithSections(parser, "Fuzzer")
+        fuzzer = OptionGroup(parser, "Fuzzer")
         fuzzer.add_option(
             "--success",
             help="Maximum number of success sessions (default: %s)"
@@ -157,7 +149,7 @@ class Application(ApplicationAgent):
         )
         parser.add_option_group(fuzzer)
 
-        log = OptionGroupWithSections(parser, "Logging")
+        log = OptionGroup(parser, "Logging")
         log.add_option(
             "-v",
             "--verbose",
@@ -173,7 +165,7 @@ class Application(ApplicationAgent):
         )
         parser.add_option_group(log)
 
-        debug = OptionGroupWithSections(parser, "Development")
+        debug = OptionGroup(parser, "Development")
         debug.add_option(
             "--debug",
             help="Enable debug mode (set log level to DEBUG)",
@@ -188,33 +180,13 @@ class Application(ApplicationAgent):
         )
         parser.add_option_group(debug)
 
-        if output:
-            optparse_to_configparser(parser, config_options, defaults=True)
-            output.write(config_options.getvalue())
-
         return parser
 
-    def parseOptions(self, with_options=False):
+    def parseOptions(self):
         """Create command line options and parse them."""
-        default_config = FusilConfig(read=False)
-        config_output = default_config.write_sample_config(write_file=False)
-        parser = self.createOptionParser(config_output)
+        parser = self.createOptionParser()
 
         self.options, self.arguments = parser.parse_args()
-        filename = configdir = None
-        if self.options.use_config:
-            file_path = pathlib.Path(self.options.config_file)
-            filename = file_path.name
-            configdir = file_path.parent
-
-        if with_options:
-            self.options = FusilConfig(
-                self.options,
-                filename=filename,
-                configdir=configdir,
-                read=self.options.use_config,
-                write=self.options.write_config,
-            )
 
         # Just want to know the version?
         if self.options.version:
@@ -231,22 +203,15 @@ class Application(ApplicationAgent):
             self.options.verbose = True
         if self.options.verbose:
             print("\nReceived options:")
-            default_configs = self.options.write_sample_config(False)
-            received_options = optparse_to_configparser(
-                parser, default_configs, defaults=False, options=self.options
-            )
-            print("\n")
-            print(received_options, "\n\n")
+            for name, value in sorted(vars(self.options).items()):
+                print(f"  {name} = {value}")
+            print("")
 
         # --force-unsafe enables --unsafe
         if self.options.force_unsafe:
             self.options.unsafe = True
 
         self.processOptions(parser, self.options, self.arguments)
-
-        # Just want to write a config file?
-        if self.options.write_config:
-            exit(0)
 
     def processOptions(self, parser, options, arguments):
         """Check the number of arguments."""
@@ -284,7 +249,7 @@ class Application(ApplicationAgent):
             self.fatalError("Configuration error: %s" % err)
 
         # Read command line options
-        self.parseOptions(with_options=True)
+        self.parseOptions()
 
         # Setup the logger and display Fusil version, license and website
         self.logger.applyOptions(self.options)

--- a/fusil/config.py
+++ b/fusil/config.py
@@ -1,29 +1,5 @@
-import configparser
-import optparse
-import pathlib
-from configparser import NoOptionError, NoSectionError, RawConfigParser
-from io import StringIO
-from optparse import OptionGroup, OptionParser
 from os import getenv
-from os.path import exists as path_exists
 from os.path import join as path_join
-
-DEFAULTS = {
-    "fusil_max_memory": 500 * 1024 * 1024,
-    "fusil_success_score": 0.50,
-    "fusil_error_score": -0.50,
-    "fusil_success": 1,
-    "fusil_session": 0,
-    "fusil_normal_calm_load": 0.50,
-    "fusil_normal_calm_sleep": 0.5,
-    "process_max_memory": 2000 * 1024 * 1024,
-    "process_core_dump": True,
-    "process_max_user_process": 5000,
-    "process_user": "fusil",
-    "process_uid": None,
-    "process_group": "fusil",
-    "process_gid": None,
-}
 
 
 class ConfigError(Exception):
@@ -47,320 +23,33 @@ def createFilename(name=None, configdir=None):
 
 
 class FusilConfig:
-    def __init__(self, options=None, filename=None, configdir=None, read=False, write=False):
-        self._parser = ConfigParserWithHelp(allow_unnamed_section=True)
-        self.filename = createFilename(filename, configdir)
-        if read and path_exists(self.filename):
-            self._parser.read([self.filename])
+    """Fusil's non-CLI defaults: scoring thresholds, memory limits, and the subprocess
+    user/group used by the dedicated-``fusil``-user sandbox.
 
-        # Fusil application options
-        self.fusil_max_memory = self.getint("fusil", "max_memory", DEFAULTS["fusil_max_memory"])
-        self.fusil_success_score = self.getfloat(
-            "fusil", "success_score", DEFAULTS["fusil_success_score"]
-        )
-        self.fusil_error_score = self.getfloat(
-            "fusil", "error_score", DEFAULTS["fusil_error_score"]
-        )
-        self.fusil_success = self.getint("fusil", "success", DEFAULTS["fusil_success"])
-        self.fusil_session = self.getint("fusil", "session", DEFAULTS["fusil_session"])
-        self.fusil_normal_calm_load = self.getfloat(
-            "fusil", "normal_calm_load", DEFAULTS["fusil_normal_calm_load"]
-        )
-        self.fusil_normal_calm_sleep = self.getfloat(
-            "fusil", "normal_calm_sleep", DEFAULTS["fusil_normal_calm_sleep"]
-        )
-
-        # Process options
-        self.process_max_memory = self.getint(
-            "process", "max_memory", DEFAULTS["process_max_memory"]
-        )
-        self.process_core_dump = self.getbool("process", "core_dump", DEFAULTS["process_core_dump"])
-        self.process_max_user_process = self.getint(
-            "process", "max_user_process", DEFAULTS["process_max_user_process"]
-        )
-
-        # User used for subprocess
-        self.process_user = self.getstr("process", "user", DEFAULTS["process_user"])
-        self.process_uid = DEFAULTS["process_uid"]
-
-        # Group used for subprocess
-        self.process_group = self.getstr("process", "group", DEFAULTS["process_group"])
-        self.process_gid = DEFAULTS["process_gid"]
-
-        # Initialize attributes used in fusil-python-threaded
-        self.blacklist = ""
-        self.classes_number = 0
-        self.debug = False
-        self.filenames = ""
-        self.functions_number = 0
-        self.fuzz_exceptions = False
-        self.methods_number = 0
-        self.modules = "*"
-        self.no_async = False
-        self.no_numpy = False
-        self.no_site_packages = False
-        self.no_threads = False
-        self.no_tstrings = False
-        self.objects_number = 0
-        self.only_c = False
-        self.packages = "*"
-        self.python = ""
-        self.record_high_cpu = False
-        self.record_timeouts = False
-        self.show_stdout = False
-        self.skip_test = False
-        self.test_private = False
-        self.timeout = 0
-        self.verbose = False
-        self.exitcode_score = 0.0
-
-        # Options from command line
-        options: optparse.Values
-
-        if options:
-            for section, option_dict in options.option_groups.items():
-                for name, (value, help) in option_dict.items():
-                    if not self._parser.has_section(section):
-                        self._parser.add_section(section)
-                    elif self._parser.has_option(section, name):
-                        value = get_and_convert(self._parser, section, name)
-                        print(f"{section}: {name} = {value} {type(value)} (from config file)")
-
-                    self._parser.set(section, name, str(value), help)
-                    setattr(self, name, value)
-
-        self.version = getattr(options, "version", False)
-
-        if write:
-            print("Writing configuration file %s" % self.filename)
-            with pathlib.Path(self.filename).open("w") as config_file:
-                config_file.write("""# Fusil configuration file\n\n""")
-                self._parser.write(config_file)
-                config_file.close()
-                self._parser = None
-
-    def write_sample_config(self, write_file=True):
-        """Create a sample configuration file and optionally write it."""
-        output = StringIO()
-        self._parser = RawConfigParser(allow_unnamed_section=True)
-        filename = createFilename()
-        config_file = pathlib.Path(filename)
-        if write_file and config_file.exists():
-            raise ConfigError("Configuration file already exists: %s" % filename)
-
-        output.write("""# Fusil default configuration file\n\n""")
-        for session_and_key, value in DEFAULTS.items():
-            section, key = session_and_key.split("_", maxsplit=1)
-            if section not in self._parser:
-                self._parser.add_section(section)
-            self._parser.set(section, key, str(value))
-        self._parser.write(output)
-        self._parser = None
-
-        if write_file:
-            with config_file.open("w") as file:
-                file.write(output.getvalue())
-        return output
-
-    def _gettype(self, func, type_name, section, key, default_value):
-        try:
-            value = func(section, key)
-            if func == self._parser.get:
-                value = value.strip()
-            return value
-        except (NoSectionError, NoOptionError):
-            return default_value
-        except ValueError as err:
-            raise ConfigError(
-                "Value %s of section %s is not %s! %s" % (key, section, type_name, err)
-            ) from err
-
-    def getstr(self, section, key, default_value=None):
-        return self._gettype(self._parser.get, "a string", section, key, default_value)
-
-    def getbool(self, section, key, default_value):
-        return self._gettype(self._parser.getboolean, "a boolean", section, key, default_value)
-
-    def getint(self, section, key, default_value):
-        return self._gettype(self._parser.getint, "an integer", section, key, default_value)
-
-    def getfloat(self, section, key, default_value):
-        return self._gettype(self._parser.getfloat, "a float", section, key, default_value)
-
-
-def optparse_to_configparser(parser, output=None, defaults=False, options=None):
-    """Convert optparse options to a configparser."""
-    if defaults and options:
-        raise ConfigError("Cannot use both defaults and options")
-    elif not (defaults or options is not None):
-        raise ConfigError("Must use either defaults or options")
-
-    if output is None:
-        output = StringIO("# Fusil configuration file\n\n")
-    config_writer = ConfigParserWithHelp(allow_unnamed_section=True)
-
-    option: optparse.Option
-    for option in parser.option_list:
-        if option.dest is not None and option.dest != "version":
-            if not config_writer.has_section(configparser.UNNAMED_SECTION):
-                config_writer.add_section(configparser.UNNAMED_SECTION)
-            if defaults:
-                config_writer.set(
-                    configparser.UNNAMED_SECTION,
-                    option.dest,
-                    f"{option.default}",
-                    option.help,
-                )
-            else:
-                config_writer.set(
-                    configparser.UNNAMED_SECTION,
-                    option.dest,
-                    f"{getattr(options, option.dest)}",
-                    option.help,
-                )
-
-    for section in parser.option_groups:
-        for option in section.option_list:
-            if not config_writer.has_section(section.title.lower()):
-                config_writer.add_section(section.title.lower())
-            if defaults:
-                config_writer.set(
-                    section.title.lower(), option.dest, f"{option.default}", option.help
-                )
-            else:
-                config_writer.set(
-                    section.title.lower(),
-                    option.dest,
-                    f"{getattr(options, option.dest)}",
-                    option.help,
-                )
-
-    config_writer.write(output)
-    if isinstance(output, StringIO):
-        return output.getvalue()
-    output.close()
-    output = open(output.name)
-    return output.read()
-
-
-class OptionGroupWithSections(OptionGroup):
-    """
-    OptionGroup class with sections:
-    - add_option(*args, section=None, **kwargs)
+    Every ``--*`` command-line option lives on the parsed optparse ``Values`` object
+    (``application.options``); this class is the single home for the handful of settings
+    that have no CLI flag. It used to also read/write a ``fusil.conf`` file, but that
+    round-trip was never used in practice (and the file it read never reached the running
+    config), so it was removed in favour of these constants as the single source of truth.
     """
 
-    def __init__(self, parser, title, description=None):
-        super().__init__(parser, title, description)
-        self.option_sections = {}
+    def __init__(self):
+        self.filename = createFilename()
 
-    def add_option(self, *args, **kwargs):
-        super().add_option(*args, **kwargs)
-        section = self.title.lower()
-        if "dest" in kwargs:
-            self.option_sections[kwargs["dest"]] = section
-        elif args[0].startswith("--"):
-            self.option_sections[args[0][2:].replace("-", "_")] = section
-        else:
-            self.option_sections[args[1][2:].replace("-", "_")] = section
+        # Fusil application defaults
+        self.fusil_max_memory = 500 * 1024 * 1024
+        self.fusil_success_score = 0.50
+        self.fusil_error_score = -0.50
+        self.fusil_success = 1
+        self.fusil_session = 0
+        self.fusil_normal_calm_load = 0.50
+        self.fusil_normal_calm_sleep = 0.5
 
-
-class OptionParserWithSections(OptionParser):
-    """OptionParser class which records sections."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.option_sections = {}
-
-    def add_option_group(self, group, *args, **kwargs):
-        super().add_option_group(group, *args, **kwargs)
-        self.option_sections.update(group.option_sections)
-
-    def parse_args(self, args=None, values=None):
-        options, args = super().parse_args(args, values)
-        options.option_sections = self.option_sections
-        options.option_groups = {}
-        for section in self.option_groups:
-            options.option_groups[section.title.lower()] = {}
-            for option in section.option_list:
-                options.option_groups[section.title.lower()][option.dest] = (
-                    getattr(options, option.dest),
-                    option.help,
-                )
-
-        return options, args
-
-
-class ConfigParserWithHelp(configparser.ConfigParser):
-    """ConfigParser class which records and writes help messages."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.help = {}
-
-    def set(self, section, option, value=None, help=None):
-        super().set(section, option, value)
-        if help is not None:
-            if not self.has_section(section):
-                self.add_section(section)
-            elif section not in self.help:
-                self.help[section] = {}
-            if option in self.help[section]:
-                raise ConfigError(
-                    "Option %s of section %s already has a help message: %s"
-                    % (option, section, self.help[section][option])
-                )
-            self.help[section][option] = help
-
-    def add_section(self, section):
-        super().add_section(section)
-        self.help[section] = {}
-
-    def _write_section(self, fp, section_name, section_items, delimiter):
-        fp.write("\n[%s]\n" % section_name)
-        for key, value in section_items:
-            if key in self.help[section_name]:
-                fp.write("\n# %s\n" % self.help[section_name][key])
-
-            value = self._interpolation.before_write(self, section_name, key, value)
-            if value is not None or not self._allow_no_value:
-                value = delimiter + str(value).replace("\n", "\n\t")
-            else:
-                value = ""
-            fp.write("%s%s\n" % (key, value))
-        fp.write("#" + "-" * 40 + "\n")
-        fp.write("\n")
-
-
-BOOLEANS = {
-    "True": True,
-    "False": False,
-    "true": True,
-    "false": False,
-    "yes": True,
-    "no": False,
-    "y": True,
-    "n": False,
-}
-
-
-def get_and_convert(parser, section, key):
-    """Get a value from a parser and convert it to the appropriate type."""
-    value: str = parser.get(section, key)
-
-    if value in BOOLEANS:
-        return BOOLEANS[value]
-    elif value == "None":
-        return None
-
-    try:
-        return int(value, 0)
-    except ValueError:
-        pass
-
-    for num_type in (int, float, complex):
-        try:
-            return num_type(value)
-        except ValueError:
-            pass
-
-    return value
+        # Subprocess defaults
+        self.process_max_memory = 2000 * 1024 * 1024
+        self.process_core_dump = True
+        self.process_max_user_process = 5000
+        self.process_user = "fusil"
+        self.process_uid = None
+        self.process_group = "fusil"
+        self.process_gid = None

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import time
 import warnings
+from optparse import OptionGroup, OptionParser
 
 # python-ptrace (imported transitively below) emits deprecation warnings on
 # recent Python versions; hide them while importing the fusil runtime stack.
@@ -10,11 +11,6 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import fusil.python.tricky_weird  # noqa: F401  (imported here to suppress its import warnings)
     from fusil.application import Application
-    from fusil.config import (
-        OptionGroupWithSections,
-        OptionParserWithSections,
-        createFilename,
-    )
     from fusil.process.create import CreateProcess
     from fusil.process.stdout import WatchStdout
     from fusil.process.watch import WatchProcess
@@ -44,9 +40,9 @@ class Fuzzer(Application):
 
     NAME = "python"
 
-    def createFuzzerOptions(self, parser: OptionParserWithSections) -> None:
+    def createFuzzerOptions(self, parser: OptionParser) -> None:
         """Create command-line options for the fuzzer configuration."""
-        input_options = OptionGroupWithSections(parser, "Input")
+        input_options = OptionGroup(parser, "Input")
         input_options.add_option(
             "--modules",
             help="Tested Python module names separated by commas (default: test all modules)",
@@ -89,7 +85,7 @@ class Fuzzer(Application):
             action="store_true",
             default=False,
         )
-        running_options = OptionGroupWithSections(parser, "Running")
+        running_options = OptionGroup(parser, "Running")
         running_options.add_option(
             "--timeout",
             help="Timeout in seconds (default: %d)" % TIMEOUT,
@@ -140,7 +136,7 @@ class Fuzzer(Application):
             action="store_true",
             default=False,
         )
-        fuzzing_options = OptionGroupWithSections(parser, "Fuzzing")
+        fuzzing_options = OptionGroup(parser, "Fuzzing")
         fuzzing_options.add_option(
             "--functions-number",
             help="Number of function calls to generate per module (default: %d)" % DEFAULT_NB_CALL,
@@ -235,7 +231,7 @@ class Fuzzer(Application):
             default=True,
         )
 
-        oom_options = OptionGroupWithSections(parser, "OOM Fuzzing")
+        oom_options = OptionGroup(parser, "OOM Fuzzing")
         oom_options.add_option(
             "--oom-fuzz",
             help="Enable OOM (out-of-memory) injection: wrap calls in dense "
@@ -348,33 +344,11 @@ class Fuzzer(Application):
             default=120,
         )
 
-        config_options = OptionGroupWithSections(parser, "Configuration")
-        config_options.add_option(
-            "--write-config",
-            help="Write a sample configuration file if one doesn't exist (default: False)",
-            action="store_true",
-            default=False,
-        )
-        config_options.add_option(
-            "--config-file",
-            help="Name of the configuration file to be read or written (default: %s)"
-            % createFilename(),
-            type="str",
-            default=createFilename(),
-        )
-        config_options.add_option(
-            "--use-config",
-            help="Load settings from configuration file (default: False)",
-            action="store_true",
-            default=False,
-        )
-
         options = (
             input_options,
             running_options,
             fuzzing_options,
             oom_options,
-            config_options,
         )
         for option in options:
             parser.add_option_group(option)
@@ -383,7 +357,7 @@ class Fuzzer(Application):
         plugin_opts = self.plugin_manager.get_cli_options()
 
         if plugin_opts:
-            plugin_options_group = OptionGroupWithSections(parser, "Plugin Options")
+            plugin_options_group = OptionGroup(parser, "Plugin Options")
             for args, kwargs in plugin_opts:
                 plugin_options_group.add_option(*args, **kwargs)
             parser.add_option_group(plugin_options_group)

--- a/tests/python/_test_options.py
+++ b/tests/python/_test_options.py
@@ -11,9 +11,9 @@ name starts with an underscore).
 """
 
 from functools import lru_cache
+from optparse import OptionParser
 from types import SimpleNamespace
 
-from fusil.config import FusilConfig, OptionParserWithSections
 from fusil.python import Fuzzer
 
 
@@ -24,19 +24,16 @@ def _harvested_defaults():
     createFuzzerOptions only touches the parser plus ``self.plugin_manager.get_cli_options``,
     so a tiny stub is enough to drive it without constructing a full Application.
     """
-    parser = OptionParserWithSections()
+    parser = OptionParser()
     stub = SimpleNamespace(plugin_manager=SimpleNamespace(get_cli_options=lambda: []))
     Fuzzer.createFuzzerOptions(stub, parser)
     return vars(parser.get_default_values())
 
 
 def make_test_options(**overrides):
-    """Return a ``FusilConfig(read=False)`` populated with every real fuzzer-option
-    default, then any ``overrides``. Use this in test ``setUp`` instead of hand-listing
-    options."""
-    options = FusilConfig(read=False)
-    for name, value in _harvested_defaults().items():
-        setattr(options, name, value)
-    for name, value in overrides.items():
-        setattr(options, name, value)
-    return options
+    """Return an options object carrying every real fuzzer-option default, then any
+    ``overrides``. Use this in test ``setUp`` instead of hand-listing options.
+
+    Mirrors what ``application.parseOptions`` produces at runtime -- the parsed optparse
+    ``Values`` -- as a plain ``SimpleNamespace`` that tests can freely read and mutate."""
+    return SimpleNamespace(**{**_harvested_defaults(), **overrides})

--- a/tests/python/test_argument_generator.py
+++ b/tests/python/test_argument_generator.py
@@ -10,10 +10,11 @@ from unittest.mock import MagicMock, patch  # MagicMock for placeholders
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
 
+from python._test_options import make_test_options
+
 import fusil.python.argument_generator
 import fusil.python.tricky_weird
 import fusil.python.values
-from fusil.config import FusilConfig
 
 USE_NUMPY = True
 try:
@@ -31,7 +32,7 @@ class TestArgumentGenerator(unittest.TestCase):
         no_numpy_opt=False,
         no_tstrings_opt=False,
     ):
-        mock_options = FusilConfig(read=False)
+        mock_options = make_test_options()
         mock_options.no_numpy = no_numpy_opt
         mock_options.no_tstrings = no_tstrings_opt
         mock_options.functions_number = getattr(mock_options, "functions_number", 10)
@@ -836,7 +837,7 @@ class TestArgumentGeneratorCoverage(unittest.TestCase):
         """
         Set up a basic ArgumentGenerator instance for each test.
         """
-        self.config = FusilConfig(read=False)
+        self.config = make_test_options()
         # Mock the parent PythonSource object
         self.mock_python_source = MagicMock()
         self.mock_python_source.options = self.config


### PR DESCRIPTION
## What

Removes Fusil's `fusil.conf` config-file round-trip (complexity roadmap §3.5). The
feature was dead weight and subtly broken:

- The file it read (`--use-config`) never reached the running configuration —
  `application.config` is always a `FusilConfig()` built from defaults (never from the
  file); the file path only populated a *separate* `application.options` object.
- `config.py` hard-coded ~30 option defaults that **duplicated** the optparse defaults —
  two sources of truth for the same settings.

Command-line options are now the single source of truth.

## Changes

- **config.py** (~360 → ~55 LOC): drop `ConfigParserWithHelp`, `OptionParserWithSections`,
  `OptionGroupWithSections`, `optparse_to_configparser()`, `write_sample_config()`,
  `get_and_convert()`, the `DEFAULTS` dict, and `FusilConfig`'s parser/read/write/options
  round-trip. `FusilConfig` is now a small holder of the handful of settings with **no CLI
  flag** (session scoring thresholds, memory limit, dedicated-`fusil`-user subprocess
  user/group).
- **application.py**: build the parser with plain `optparse.OptionParser`/`OptionGroup`;
  `parseOptions` no longer wraps options in a `FusilConfig` (`self.options` is the parsed
  `Values`), and drops the `--use-config`/`--write-config` handling and the configparser
  verbose dump (replaced by a plain option listing).
- **python/__init__.py**: remove the `--write-config`/`--config-file`/`--use-config` option
  group; use plain `optparse.OptionGroup`.
- **tests**: `make_test_options()` now returns a `SimpleNamespace` harvested from the real
  optparse defaults (mirrors what `parseOptions` produces at runtime);
  `test_argument_generator` uses it instead of `FusilConfig(read=False)`.
- **docs**: rewrite `configuration.rst` to document CLI-based configuration and note the
  removed `fusil.conf`.

Net: **−502 / +77** lines.

## Verification

- Core suite **280 OK**, golden output **byte-identical**, `ruff check` + `ruff format --check` clean.
- Fuzzer smoke: `--version`, `--help` (no Configuration group), `--verbose` (new options
  dump), and an `--only-generate --modules json` run all work; `--write-config` is now
  correctly rejected as an unknown option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)