### PR TITLE
test(mas): pre-refactor safety net for the session lifecycle

### DIFF
--- a/doc/complexity-reduction-report.md
+++ b/doc/complexity-reduction-report.md
@@ -253,11 +253,26 @@ two fixes, which *restore* intended behavior).
 7. Collapse `AggressivityAgent` to a scalar (§3.2) and resolve the `SystemCalm` path (§3.3).
 
 **Phase 3 — only if maintenance pain justifies it (high risk):**
-8. Config round-trip removal (§3.5), single-source-of-truth defaults.
+8. Config round-trip removal (§3.5), single-source-of-truth defaults. **DONE (PR #158).**
 9. MAS → direct-pipeline rewrite (§3.1) — document the event graph first; treat as its own
    project with new tests for the keep/drop crash-dir logic before touching it.
 
+**Pre-refactor safety net for item 9 — now in place** (so the MAS→pipeline rewrite has a
+behavioural spec to preserve):
+- `tests/test_session_directory.py::TestCheckKeepDirectory` — every branch of the keep/drop
+  crash-dir decision (empty-drop-even-on-success, success/policy keep+relabel+prune, fusil-error,
+  keep_sessions, keep_generated_files).
+- `tests/test_session_lifecycle.py` — score aggregation (`computeScore`/`isSuccess`), the
+  stop-trigger threshold (`Session.live`/`on_session_stop`), and the per-session loop control
+  (`Project.on_session_done`/`on_project_session_destroy`/stop path). Its module docstring holds
+  the one-page event graph the refactor must reproduce.
+- `tests/test_mas.py` — Agent lifecycle (`activate`/`deactivate`), the `Univers` step loop
+  (`executeAgent`/`execute`), and the new **`MTA.trace`** instrumentation.
+- **`MTA.trace`** (fusil/mas/mta.py): set it to a list to record the full `(event, args)`
+  sequence flowing through the bus, in send order (the single `deliver()` choke point). Use it to
+  capture the event trace of a real run before the rewrite and assert the new pipeline reproduces
+  it. `None` by default (zero cost when off).
+
 The golden-output test (`tests/python/test_golden_output.py`) and the OOM/feat/h5py
 before-after harnesses guard the *generation* path; none of the above touches generation
-except the h5py plugin move (which the h5py harness covers). The MAS/lifecycle work would need
-new tests around session keep/drop *before* starting — that coverage gap is itself a finding.
+except the h5py plugin move (which the h5py harness covers).

--- a/fusil/mas/mta.py
+++ b/fusil/mas/mta.py
@@ -16,6 +16,13 @@ class MTA(ApplicationAgent):
         self.setupMTA(self, application.logger)
         self.mailing_list = {}
         self.queue = []
+        # Optional event trace: refactor-safety instrumentation. When set to a list,
+        # every delivered message is recorded as (event, arguments) in send order. This
+        # is the single choke point all Agent.send() calls flow through, so it captures
+        # the full event sequence -- letting a test (or a before/after comparison of a
+        # MAS -> direct-pipeline rewrite) assert the control flow is preserved. `None`
+        # (the default) disables recording with a single is-not-None check per deliver.
+        self.trace = None
 
     def hasMessage(self):
         return bool(self.queue)
@@ -38,6 +45,8 @@ class MTA(ApplicationAgent):
         self.mailing_list[event].remove(mailbox)
 
     def deliver(self, message):
+        if self.trace is not None:
+            self.trace.append((message.event, message.arguments))
         self.queue.append(message)
 
     def live(self):

--- a/tests/test_mas.py
+++ b/tests/test_mas.py
@@ -7,11 +7,13 @@ subclasses stand in for real agents.
 
 import gc
 import unittest
+from types import SimpleNamespace
 
 from fusil.mas.agent import Agent, AgentError
 from fusil.mas.agent_id import AgentID
 from fusil.mas.message import Message
 from fusil.mas.mta import MTA
+from fusil.mas.univers import Univers
 
 
 class _StubLogger:
@@ -149,6 +151,136 @@ class TestDelivery(unittest.TestCase):
         sender.send("ping")
         mta.live()  # encounters the dead weakref and prunes it
         self.assertEqual(len(mta.mailing_list["ping"]), 1)
+
+
+class Lifecycle(Agent):
+    """Records init/deinit so activate/deactivate transitions can be asserted."""
+
+    def __init__(self, name, mta):
+        super().__init__(name, mta)
+        self.events = []
+
+    def init(self):
+        self.events.append("init")
+
+    def deinit(self):
+        self.events.append("deinit")
+
+
+class TestAgentLifecycle(unittest.TestCase):
+    def test_activate_calls_init_and_sets_active(self):
+        mta, _app = _make_mta()
+        a = Lifecycle("a", mta)
+        self.assertFalse(a.is_active)
+        a.activate()
+        self.assertTrue(a.is_active)
+        self.assertEqual(a.events, ["init"])
+
+    def test_double_activate_raises(self):
+        mta, _app = _make_mta()
+        a = Lifecycle("a", mta)
+        a.activate()
+        with self.assertRaises(AgentError):
+            a.activate()
+
+    def test_deactivate_calls_deinit_and_clears_active(self):
+        mta, _app = _make_mta()
+        a = Lifecycle("a", mta)
+        a.activate()
+        a.events.clear()
+        a.deactivate()
+        self.assertFalse(a.is_active)
+        self.assertEqual(a.events, ["deinit"])
+
+    def test_deactivate_when_inactive_is_noop(self):
+        mta, _app = _make_mta()
+        a = Lifecycle("a", mta)
+        a.deactivate()  # never activated
+        self.assertEqual(a.events, [])
+
+
+class StepAgent(Agent):
+    """Records the order of readMailbox/live calls a univers step makes."""
+
+    def __init__(self, name, mta):
+        super().__init__(name, mta)
+        self.steps = []
+
+    def readMailbox(self):
+        self.steps.append("read")
+        return 0
+
+    def live(self):
+        self.steps.append("live")
+
+
+class TestUnivers(unittest.TestCase):
+    def test_execute_agent_skips_inactive(self):
+        mta, app = _make_mta()
+        u = Univers(app, mta, 0)
+        a = StepAgent("a", mta)  # not activated
+        u.executeAgent(a)
+        self.assertEqual(a.steps, [])
+
+    def test_execute_agent_reads_then_lives(self):
+        mta, app = _make_mta()
+        u = Univers(app, mta, 0)
+        a = StepAgent("a", mta)
+        a.activate()
+        u.executeAgent(a)
+        self.assertEqual(a.steps, ["read", "live"])
+
+    def test_execute_stops_when_is_done(self):
+        # A step loop that never sets is_done would hang; Stopper.live sets it on the
+        # first pass, so execute() must run one step and return.
+        mta, app = _make_mta()
+        u = Univers(app, mta, 0)
+
+        class Stopper(Agent):
+            def live(self):
+                u.is_done = True
+
+        s = Stopper("s", mta)
+        s.activate()
+        project = SimpleNamespace(agents=[s])
+        u.execute(project)  # must return, not hang
+        self.assertTrue(u.is_done)
+
+
+class TestEventTrace(unittest.TestCase):
+    """The opt-in MTA.trace instrumentation (refactor-safety aid): records the full
+    (event, args) sequence flowing through the bus, in send order."""
+
+    def test_trace_is_off_by_default(self):
+        mta, _app = _make_mta()
+        self.assertIsNone(mta.trace)
+        sender = Recorder("s", mta)
+        sender.activate()
+        sender.send("ping", 1)  # must not raise / must not record
+        self.assertIsNone(mta.trace)
+
+    def test_trace_records_events_in_send_order(self):
+        mta, _app = _make_mta()
+        mta.trace = []
+        sender = Recorder("s", mta)
+        sender.activate()
+        sender.send("ping", 1)
+        sender.send("ping", 2, 3)
+        sender.send("pong")
+        self.assertEqual(
+            mta.trace,
+            [("ping", (1,)), ("ping", (2, 3)), ("pong", ())],
+        )
+
+    def test_trace_records_even_without_subscribers(self):
+        # deliver() is the choke point: an event with no subscriber is still recorded
+        # (it is queued and then dropped by live()), so the trace reflects intent to send.
+        mta, _app = _make_mta()
+        mta.trace = []
+        sender = Recorder("s", mta)
+        sender.activate()
+        sender.send("no_subscriber_event", 42)
+        self.assertEqual(mta.trace, [("no_subscriber_event", (42,))])
 
 
 if __name__ == "__main__":

--- a/tests/test_session_directory.py
+++ b/tests/test_session_directory.py
@@ -7,6 +7,7 @@ no filesystem). Runtime-free.
 """
 
 import unittest
+from types import SimpleNamespace
 
 from fusil.session_directory import PART_MAXLEN, SessionDirectory
 
@@ -53,6 +54,100 @@ class TestOnSessionRename(unittest.TestCase):
         for part in ("module", "segmentation_fault", "OOM-0004"):
             sd.on_session_rename(part)
         self.assertEqual(sd.rename_parts, ["module", "segmentation_fault", "OOM-0004"])
+
+
+def _keep_dir(
+    *,
+    empty,
+    empty_ignore_generated=None,
+    success,
+    exitcode=0,
+    keep_sessions=False,
+    keep_generated=False,
+    policy="absent",
+):
+    """A bare SessionDirectory wired for checkKeepDirectory().
+
+    ``empty`` is isEmpty(False) (truly empty); ``empty_ignore_generated`` is isEmpty(True)
+    (empty once registered generated files are ignored). A truly empty dir is also empty
+    ignoring generated files, so that defaults to ``empty`` when not given.
+    """
+    if empty_ignore_generated is None:
+        empty_ignore_generated = empty
+    sd = SessionDirectory.__new__(SessionDirectory)
+    sd.directory = "/fake/session-1"
+    sd.rename_parts = []
+    sd.rename_set = set()
+    sd.info = lambda *a, **k: None
+    sd.warning = lambda *a, **k: None
+
+    def isEmpty(ignore_generated=False):
+        return empty_ignore_generated if ignore_generated else empty
+
+    sd.isEmpty = isEmpty
+    sd.session = lambda: SimpleNamespace(isSuccess=lambda: success)
+    options = SimpleNamespace(keep_sessions=keep_sessions, keep_generated_files=keep_generated)
+    application = SimpleNamespace(exitcode=exitcode, options=options)
+    if policy != "absent":
+        application.session_keep_policy = policy
+    sd.application = lambda: application
+    return sd
+
+
+class TestCheckKeepDirectory(unittest.TestCase):
+    """The keep/drop decision that produces (or discards) crash dirs. The MAS rewrite
+    routes session teardown through this, so pin every branch."""
+
+    def test_empty_dir_dropped_even_on_success(self):
+        # The success/exitcode/keep_sessions block is guarded by `if not isEmpty(False)`,
+        # so a *successful* session with an empty directory is still dropped.
+        sd = _keep_dir(empty=True, success=True)
+        self.assertFalse(sd.checkKeepDirectory())
+
+    def test_nonempty_success_no_policy_kept(self):
+        sd = _keep_dir(empty=False, success=True)
+        self.assertTrue(sd.checkKeepDirectory())
+
+    def test_nonempty_success_policy_keep_relabels(self):
+        sd = _keep_dir(empty=False, success=True, policy=lambda s: (True, "OOM-0001"))
+        self.assertTrue(sd.checkKeepDirectory())
+        self.assertEqual(sd.rename_parts, ["OOM-0001"])
+
+    def test_nonempty_success_policy_prune_drops_and_relabels(self):
+        sd = _keep_dir(empty=False, success=True, policy=lambda s: (False, "OOM-0001"))
+        self.assertFalse(sd.checkKeepDirectory())
+        self.assertEqual(sd.rename_parts, ["OOM-0001"])
+
+    def test_nonempty_success_policy_keep_without_label(self):
+        sd = _keep_dir(empty=False, success=True, policy=lambda s: (True, None))
+        self.assertTrue(sd.checkKeepDirectory())
+        self.assertEqual(sd.rename_parts, [])
+
+    def test_nonempty_fusil_error_kept(self):
+        sd = _keep_dir(empty=False, success=False, exitcode=1)
+        self.assertTrue(sd.checkKeepDirectory())
+
+    def test_nonempty_keep_sessions_kept(self):
+        sd = _keep_dir(empty=False, success=False, keep_sessions=True)
+        self.assertTrue(sd.checkKeepDirectory())
+
+    def test_nonempty_no_flags_dropped(self):
+        sd = _keep_dir(empty=False, success=False)
+        self.assertFalse(sd.checkKeepDirectory())
+
+    def test_keep_generated_with_nongenerated_files_kept(self):
+        # keep_generated_files keeps the dir when isEmpty(ignore_generated=True) is False,
+        # i.e. there are files beyond the registered generated ones.
+        sd = _keep_dir(
+            empty=False, empty_ignore_generated=False, success=False, keep_generated=True
+        )
+        self.assertTrue(sd.checkKeepDirectory())
+
+    def test_keep_generated_only_generated_files_dropped(self):
+        # A dir holding only registered generated files: isEmpty(True) is True, so the
+        # keep_generated branch does NOT fire and the dir is dropped.
+        sd = _keep_dir(empty=False, empty_ignore_generated=True, success=False, keep_generated=True)
+        self.assertFalse(sd.checkKeepDirectory())
 
 
 if __name__ == "__main__":

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,274 @@
+"""Safety-net tests for the session lifecycle + scoring control flow.
+
+This is the coverage the complexity report (doc/complexity-reduction-report.md §3.1) says
+must exist *before* a MAS -> direct-pipeline rewrite: the session keep/drop crash-dir
+decision, the score aggregation, the stop-trigger threshold, and the per-session loop
+control. They pin the *observable behaviour* so a rewrite that preserves it stays green
+and one that breaks it fails.
+
+The event graph these tests pin (one edge per test), happy path:
+
+    Project.init -> createSession() ----------------------------> send "session_start"
+    (each univers step) Session.live() -- score crosses band --> send "session_stop"
+    Session.on_session_stop() -- computeScore(verbose) --------> send "session_done"(score)
+    Project.on_session_done(score) ---------------------------> send "project_session_destroy"(score)
+    Project.on_project_session_destroy(score):
+        session.score = score
+        destroySession()
+        success?  -> nb_success++  -> max_success hit? -> send "univers_stop" (STOP)
+        max_session hit?                                -> send "univers_stop" (STOP)
+        otherwise                                       -> createSession()      (LOOP)
+
+    Stop path:  Project.on_project_stop -> send "univers_stop"
+                Project.on_univers_stop -> destroySession()
+
+The crash dir is produced out-of-band by SessionDirectory.deinit ->
+checkKeepDirectory() -> keepDirectory()/rmtree(), tested in test_session_directory.py.
+
+Runtime-free: bare instances (``__new__``) with the collaborators each method touches
+stubbed out -- no MTA loop, no python-ptrace, no filesystem.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from fusil.project import Project
+from fusil.project_agent import ProjectAgent
+from fusil.session import Session
+
+
+class _ScoreAgent(ProjectAgent):
+    """A ProjectAgent whose getScore() is fixed. Bypasses Agent.__init__ (no MTA needed);
+    computeScore only reads __class__, is_active and getScore()."""
+
+    def __init__(self, score, active=True):
+        self._score = score
+        self.is_active = active
+
+    def getScore(self):
+        return self._score
+
+
+class _AppAgent:
+    """A non-ProjectAgent (stands in for an application agent like MTA/logger): must be
+    skipped by computeScore even though it exposes a getScore()."""
+
+    is_active = True
+
+    def getScore(self):
+        return 1.0
+
+
+def _session(agents, success_score=0.5, error_score=-0.5):
+    s = Session.__new__(Session)
+    s.project = lambda: SimpleNamespace(
+        agents=agents, success_score=success_score, error_score=error_score
+    )
+    s.score = None
+    s.info = lambda *a, **k: None
+    return s
+
+
+class TestComputeScore(unittest.TestCase):
+    def test_sums_active_project_agents(self):
+        s = _session([_ScoreAgent(0.3), _ScoreAgent(0.2)])
+        self.assertAlmostEqual(s.computeScore(), 0.5)
+
+    def test_skips_inactive_agents(self):
+        s = _session([_ScoreAgent(0.3), _ScoreAgent(1.0, active=False)])
+        self.assertAlmostEqual(s.computeScore(), 0.3)
+
+    def test_skips_none_scores(self):
+        s = _session([_ScoreAgent(0.4), _ScoreAgent(None)])
+        self.assertAlmostEqual(s.computeScore(), 0.4)
+
+    def test_skips_non_project_agents(self):
+        # _AppAgent.getScore() == 1.0 but it is not a ProjectAgent, so it must not count.
+        s = _session([_ScoreAgent(0.25), _AppAgent()])
+        self.assertAlmostEqual(s.computeScore(), 0.25)
+
+    def test_normalizes_each_score_before_summing(self):
+        # 2.0 clamps to 1.0, -3.0 clamps to -1.0 -> net 0.0 (per-agent clamp, then sum).
+        s = _session([_ScoreAgent(2.0), _ScoreAgent(-3.0)])
+        self.assertAlmostEqual(s.computeScore(), 0.0)
+
+    def test_rounds_each_score_to_two_dp(self):
+        s = _session([_ScoreAgent(0.333)])
+        self.assertAlmostEqual(s.computeScore(), 0.33)
+
+    def test_no_agents_scores_zero(self):
+        self.assertEqual(_session([]).computeScore(), 0)
+
+
+class TestIsSuccess(unittest.TestCase):
+    def test_none_score_is_not_success(self):
+        s = _session([])
+        s.score = None
+        self.assertFalse(s.isSuccess())
+
+    def test_score_at_threshold_is_success(self):
+        s = _session([], success_score=0.5)
+        s.score = 0.5
+        self.assertTrue(s.isSuccess())
+
+    def test_score_below_threshold_is_not_success(self):
+        s = _session([], success_score=0.5)
+        s.score = 0.49
+        self.assertFalse(s.isSuccess())
+
+
+def _live_session(score, *, stopped=False, success=0.5, error=-0.5):
+    s = Session.__new__(Session)
+    s.project = lambda: SimpleNamespace(success_score=success, error_score=error)
+    s.stopped = stopped
+    s.info = lambda *a, **k: None
+    s.sent = []
+    s.send = lambda event, *args: s.sent.append((event, args))
+    s.computeScore = lambda verbose=False: score
+    return s
+
+
+class TestSessionLiveStopTrigger(unittest.TestCase):
+    def test_neutral_score_does_not_stop(self):
+        s = _live_session(0.0)
+        s.live()
+        self.assertEqual(s.sent, [])
+
+    def test_success_threshold_triggers_stop(self):
+        s = _live_session(0.6)
+        s.live()
+        self.assertEqual(s.sent, [("session_stop", ())])
+
+    def test_error_threshold_triggers_stop(self):
+        s = _live_session(-0.6)
+        s.live()
+        self.assertEqual(s.sent, [("session_stop", ())])
+
+    def test_exact_success_threshold_triggers_stop(self):
+        s = _live_session(0.5)
+        s.live()
+        self.assertEqual(s.sent, [("session_stop", ())])
+
+    def test_already_stopped_is_noop(self):
+        s = _live_session(0.9, stopped=True)
+        s.live()
+        self.assertEqual(s.sent, [])
+
+
+class TestSessionOnStop(unittest.TestCase):
+    def test_emits_session_done_with_score_and_sets_stopped(self):
+        s = _live_session(0.0)  # live() not used here
+        s.computeScore = lambda verbose=False: 0.7
+        s.on_session_stop()
+        self.assertTrue(s.stopped)
+        self.assertEqual(s.sent, [("session_done", (0.7,))])
+
+    def test_second_call_is_noop(self):
+        s = _live_session(0.0)
+        s.computeScore = lambda verbose=False: 0.7
+        s.on_session_stop()
+        s.sent.clear()
+        s.on_session_stop()
+        self.assertEqual(s.sent, [])
+
+
+def _project(*, nb_success=0, max_success=0, max_session=0, session_index=1, success_score=0.5):
+    p = Project.__new__(Project)
+    # Quiet Agent.__del__/Project.destroy at GC time on this bare stub (they touch name,
+    # is_active and _destroyed; without these, __del__ prints ignored-exception noise).
+    p.name = "test-project"
+    p.is_active = False
+    p.mailbox = None
+    p._destroyed = True
+    p.success_score = success_score
+    p.error_score = -0.5
+    p.nb_success = nb_success
+    p.max_success = max_success
+    p.max_session = max_session
+    p.session_index = session_index
+    p.session = SimpleNamespace(score=None)
+    p.session_start = 0.0  # on_project_session_destroy only uses this for a log line
+    p.error = lambda *a, **k: None
+    p.warning = lambda *a, **k: None
+    p.calls = []
+    p.send = lambda event, *args: p.calls.append(("send", event, args))
+    p.createSession = lambda: p.calls.append(("createSession",))
+    p.destroySession = lambda: p.calls.append(("destroySession",))
+    return p
+
+
+def _events(p):
+    return [c[1] for c in p.calls if c[0] == "send"]
+
+
+class TestOnSessionDone(unittest.TestCase):
+    def test_forwards_score_to_project_session_destroy(self):
+        p = _project()
+        p.on_session_done(0.42)
+        self.assertEqual(p.calls, [("send", "project_session_destroy", (0.42,))])
+
+
+class TestSessionLoopControl(unittest.TestCase):
+    """Project.on_project_session_destroy: the per-session loop decision."""
+
+    def test_records_score_and_always_destroys_session(self):
+        p = _project()
+        p.on_project_session_destroy(0.1)
+        self.assertEqual(p.session.score, 0.1)
+        self.assertIn(("destroySession",), p.calls)
+
+    def test_success_increments_and_loops_when_unlimited(self):
+        p = _project(max_success=0, max_session=0)
+        p.on_project_session_destroy(0.6)
+        self.assertEqual(p.nb_success, 1)
+        self.assertIn(("createSession",), p.calls)
+        self.assertNotIn("univers_stop", _events(p))
+
+    def test_non_success_does_not_increment_but_loops(self):
+        p = _project()
+        p.on_project_session_destroy(0.1)
+        self.assertEqual(p.nb_success, 0)
+        self.assertIn(("createSession",), p.calls)
+
+    def test_max_success_reached_stops(self):
+        p = _project(max_success=1)
+        p.on_project_session_destroy(0.6)
+        self.assertEqual(p.nb_success, 1)
+        self.assertIn("univers_stop", _events(p))
+        self.assertNotIn(("createSession",), p.calls)
+
+    def test_max_session_reached_stops(self):
+        p = _project(max_session=1, session_index=1)
+        p.on_project_session_destroy(0.1)  # not a success
+        self.assertIn("univers_stop", _events(p))
+        self.assertNotIn(("createSession",), p.calls)
+
+    def test_success_under_cap_then_max_session_stops(self):
+        # success (nb 1 < max_success 2, no stop) but session cap hit -> stop, no loop.
+        p = _project(max_success=2, max_session=1, session_index=1)
+        p.on_project_session_destroy(0.6)
+        self.assertEqual(p.nb_success, 1)
+        self.assertIn("univers_stop", _events(p))
+        self.assertNotIn(("createSession",), p.calls)
+
+
+class TestStopPath(unittest.TestCase):
+    def test_project_stop_requests_univers_stop(self):
+        p = _project()
+        p.on_project_stop()
+        self.assertEqual(_events(p), ["univers_stop"])
+
+    def test_univers_stop_destroys_active_session(self):
+        p = _project()
+        p.on_univers_stop()
+        self.assertIn(("destroySession",), p.calls)
+
+    def test_univers_stop_without_session_is_noop(self):
+        p = _project()
+        p.session = None
+        p.on_univers_stop()
+        self.assertEqual(p.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Builds the behavioural safety net the complexity report (§3.1) says must exist **before**
a MAS → direct-pipeline rewrite. This area (session lifecycle, scoring, keep/drop) was
undertested, which is exactly what could turn that rewrite into a silent regression. All
tests are runtime-free (bare instances + stubs; no MTA loop, no python-ptrace, no filesystem).

## Tests

- **`test_session_directory.py::TestCheckKeepDirectory`** — every branch of the keep/drop
  crash-dir decision (the one the report explicitly flags):
  - empty dir dropped **even on success** (the success branch is guarded by `not isEmpty(False)`),
  - non-empty success kept; keep-policy hook keep/relabel/prune (the OOM-dedup path),
  - fusil-error kept, `--keep-sessions` kept, `--keep-generated-files` (both sub-cases).
- **`test_session_lifecycle.py`** (new) — score aggregation (`computeScore`/`isSuccess`),
  the stop-trigger threshold (`Session.live`/`on_session_stop`), and the per-session loop
  control (`Project.on_session_done`/`on_project_session_destroy` + the stop path). Its
  module docstring is the **one-page event graph** the rewrite must reproduce.
- **`test_mas.py`** — Agent lifecycle (`activate`/`deactivate`, double-activate, inactive
  no-op) and the `Univers` step loop (`executeAgent` skip-inactive / read-then-live,
  `execute` stops on `is_done`).

## Instrumentation

- **`MTA.trace`** (opt-in): set it to a list to record the full `(event, args)` sequence
  flowing through the bus in send order — the single `deliver()` choke point every
  `Agent.send()` passes through. Capture the event trace of a real run before the rewrite
  and assert the new pipeline reproduces it. `None` by default (one is-not-None check per
  deliver when off).

## Verification

- Suite **280 → 327** tests, all green.
- Golden output **byte-identical**; `ruff check` + `ruff format --check` clean.

Also documents the safety net + `MTA.trace` in the complexity report's Phase-3 section, and
marks the config round-trip removal (item 8) done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)