### PR TITLE
fix: robust agent teardown + clearer --keep-generated-files help

### DIFF
--- a/fusil/application.py
+++ b/fusil/application.py
@@ -119,7 +119,8 @@ class Application(ApplicationAgent):
         )
         fuzzer.add_option(
             "--keep-generated-files",
-            help="Keep a session directory if it contains generated files",
+            help="Keep a session directory if the fuzzed program left files in it "
+            "(files other than Fusil's own generated source/logs)",
             action="store_true",
             default=False,
         )

--- a/fusil/mas/agent.py
+++ b/fusil/mas/agent.py
@@ -168,12 +168,15 @@ class Agent(object):
         self._log("error", message)
 
     def __repr__(self):
+        # Defensive: __del__'s error handler stringifies self and is documented never to
+        # let an error escape, so these must not raise on a partially-constructed agent
+        # (missing agent_id/name/is_active, e.g. if __init__ failed part-way).
         return "<%s id=%s, name=%r is_active=%s>" % (
             self.__class__.__name__,
-            self.agent_id,
-            self.name,
-            self.is_active,
+            getattr(self, "agent_id", "?"),
+            getattr(self, "name", "?"),
+            getattr(self, "is_active", "?"),
         )
 
     def __str__(self):
-        return "<%s %r>" % (self.__class__.__name__, self.name)
+        return "<%s %r>" % (self.__class__.__name__, getattr(self, "name", "?"))

--- a/fusil/project.py
+++ b/fusil/project.py
@@ -111,7 +111,9 @@ class Project(ProjectAgent):
             self.summarize()
 
     def destroy(self):
-        if self._destroyed:
+        # getattr guard: destroy() runs from Agent.__del__, which may fire on a Project
+        # whose __init__ did not finish (so _destroyed was never set).
+        if getattr(self, "_destroyed", False):
             return
         self._destroyed = True
 

--- a/fusil/session_directory.py
+++ b/fusil/session_directory.py
@@ -85,7 +85,9 @@ class SessionDirectory(SessionAgent, Directory):
                 return True
 
         if application.options.keep_generated_files and not self.isEmpty(True):
-            # Project generated some extra files: keep the directory
+            # The fuzzed program left files behind (isEmpty(ignore_generated=True) ignores
+            # Fusil's own registered source/logs, so a False here means a *non*-Fusil file
+            # exists). Those are interesting artifacts, so keep the directory.
             self.warning("Keep the non-empty directory %s" % self.directory)
             return True
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -174,11 +174,9 @@ class TestSessionOnStop(unittest.TestCase):
 
 def _project(*, nb_success=0, max_success=0, max_session=0, session_index=1, success_score=0.5):
     p = Project.__new__(Project)
-    # Quiet Agent.__del__/Project.destroy at GC time on this bare stub (they touch name,
-    # is_active and _destroyed; without these, __del__ prints ignored-exception noise).
-    p.name = "test-project"
-    p.is_active = False
-    p.mailbox = None
+    # This bare stub is never fully constructed; mark it already-destroyed so Project.destroy
+    # (called from Agent.__del__ at GC) short-circuits instead of running its full-init body.
+    # Agent.__str__/__repr__ are getattr-robust, so no name/is_active/mailbox are needed.
     p._destroyed = True
     p.success_score = success_score
     p.error_score = -0.5


### PR DESCRIPTION
Two items surfaced while writing the MAS safety net (#159).

## 1. Agent teardown robustness (real fix)

`Agent.__del__` is explicitly documented to *never let an error escape* — but its error
handler stringifies `self` (`print(self, ...)`), and `__str__`/`__repr__` raised
`AttributeError` on a partially-constructed agent (missing `name`/`agent_id`/`is_active` —
e.g. an agent whose `__init__` failed part-way, or GC of a bare test stub). That leaked as
`Exception ignored while calling deallocator` noise, defeating `__del__`'s own contract.

- `Agent.__str__`/`__repr__`: `getattr(..., "?")` fallbacks so they never raise.
- `Project.destroy`: guard the `_destroyed` check with `getattr` (destroy runs from
  `__del__` and may fire before `__init__` set `_destroyed`).
- The `test_session_lifecycle._project` stub no longer needs the
  `name`/`is_active`/`mailbox` workaround (down to a single legitimate `_destroyed = True`),
  which demonstrates the fix.

## 2. `--keep-generated-files` — not a bug, clarified

I flagged this as "reads inverted vs the flag name" while pinning behaviour. On
investigation it is **correct and original** (unchanged since the initial import):
`not isEmpty(ignore_generated=True)` is True exactly when a file exists that Fusil did *not*
register (`source.py`/logs are registered via `uniqueFilename`), i.e. **the fuzzed program
left artifacts behind**. That is the only non-redundant reading — Reading-A ("keep if Fusil
generated source") would just duplicate `--keep-sessions`. Only the flag help + the code
comment were ambiguous; both are clarified. **No behaviour change.**

## Verification

- Suite **327 OK** (the keep/drop + teardown tests from #159 still green).
- Golden byte-identical; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)