### PR TITLE
feat(python): exception-bomb object family + SuperBomb (reproducer technique A)

### DIFF
--- a/doc/reproducer-techniques-for-fusil.md
+++ b/doc/reproducer-techniques-for-fusil.md
@@ -79,6 +79,14 @@ the template the best new techniques below follow.
 
 ### A. The "exception-bomb object" family — biggest ROI, lowest effort
 
+> **STATUS: IMPLEMENTED.** `fusil/python/samples/bomb_objects.py` — the targeted family
+> (`HashBomb`, `EqBomb`, `IndexBomb`, `LenBomb`, `LyingLen`, `ReprBomb`, `FailingIterator`)
+> plus a metaclass-driven **`SuperBomb`** (every protocol slot raises a *random* exception on
+> first use or after a *random* delay — spray-and-pray). Delays and (for SuperBomb) exception
+> types are randomised per instance to walk a wide slice of program state. Wired into all three
+> argument pools via `ArgumentGenerator.genBombObject` (weight `BOMB_WEIGHT`); tested in
+> `tests/python/test_bomb_objects.py`.
+
 This is the direct analogue of the OOM success at the *protocol* level. `set_nomemory` makes
 **allocations** fail deterministically; an exception-bomb object makes a **dunder callback**
 fail deterministically — exercising the huge class of C code that calls a Python protocol slot

--- a/fusil/python/argument_generator.py
+++ b/fusil/python/argument_generator.py
@@ -67,6 +67,11 @@ except ImportError:
 
 ERRBACK_NAME_CONST = "errback"
 
+# How many copies of genBombObject to weight into each argument pool. Tunable: higher = more
+# exception bombs sprayed into calls (more protocol-slot error-path coverage) at the cost of
+# other input variety. Kept well below numpy's 50 so bombs are frequent but not dominant.
+BOMB_WEIGHT = 8
+
 try:
     from fusil.python.template_strings import TEMPLATES
 except ImportError:
@@ -135,7 +140,10 @@ class ArgumentGenerator:
 
         safe_simple_generators = safe_hashable_generators + (self.genBufferObject,)
 
-        # These generators produce references to names defined in boilerplate
+        # These generators produce references to names defined in boilerplate. Exception
+        # bombs (BOMB_WEIGHT copies) are the protocol-level analogue of --oom-fuzz: they make
+        # a dunder raise (randomly delayed) to hit unguarded-error-path bugs in C code. Weighted
+        # up so they are sampled regularly across the wide arg space, but well below numpy's 50.
         external_reference_generators = (
             self.genErrback,
             self.genWeirdType,
@@ -145,12 +153,15 @@ class ArgumentGenerator:
             self.genTricky,
             self.genInterestingValues,
             self.genTrickyObjects,
-        )
+        ) + (self.genBombObject,) * BOMB_WEIGHT
 
         self.hashable_argument_generators = safe_hashable_generators
         if allow_external_references:
-            # The 'errback' name is hashable but is an external reference
+            # The 'errback' name is hashable but is an external reference. Bombs are hashable
+            # too (HashBomb/EqBomb/SuperBomb arm __hash__/__eq__) -- as dict keys / set members
+            # they hit the container insert & lookup error paths.
             self.hashable_argument_generators += (self.genErrback,)
+            self.hashable_argument_generators += (self.genBombObject,) * BOMB_WEIGHT
 
         # Build the final lists based on the flag
         self.simple_argument_generators = safe_simple_generators
@@ -168,7 +179,7 @@ class ArgumentGenerator:
                 self.genWeirdType,
                 self.genWeirdUnion,
                 self.genTrickyObjects,
-            )
+            ) + (self.genBombObject,) * BOMB_WEIGHT
 
         # NumPy tricky arrays -- gated on numpy alone, NOT on h5py. (Previously this whole
         # block required H5PyArgumentGenerator, so numpy support silently did nothing unless
@@ -337,6 +348,14 @@ class ArgumentGenerator:
         """Generate a name of a 'tricky' predefined object from tricky_weird."""
         tricky_name = choice(fusil.python.tricky_weird.tricky_objects_names)
         return [tricky_name]
+
+    def genBombObject(self) -> list[str]:
+        """Generate a freshly-constructed exception-bomb object (see samples/bomb_objects.py).
+
+        A new instance per call (bombs are stateful and self-randomise their delay/exception),
+        so each fuzzed argument gets an independently-armed landmine."""
+        bomb_class = choice(fusil.python.tricky_weird.bomb_object_names)
+        return [f"{bomb_class}()"]
 
     def genTrickyNumpy(self) -> list[str]:
         """Generate a name of a 'tricky' predefined NumPy object from tricky_weird."""

--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -1,0 +1,272 @@
+"""Exception-bomb objects: the protocol-level analogue of the OOM (allocation-failure) mode.
+
+The OOM allocator hook makes *allocations* fail deterministically; a bomb object makes a
+*dunder callback* fail -- exercising the large class of C code that calls a Python protocol
+slot (``__hash__``, ``__eq__``, ``__index__``, ``__len__``, ``__iter__``, ``__repr__``, ...)
+and then does an unguarded ``PyErr_Clear()`` or assumes the slot succeeded.
+
+Two knobs, both randomised at construction so repeated use across a run walks a wide slice of
+program state (the windowed-failure insight of the OOM sequence mode applied to protocol slots):
+
+* **delay** — succeed a random number of times, *then* raise. Delay 0 means "raise on first
+  use"; delay N means "corrupt/observe state for N calls, then fail" (the cross-call
+  "succeeded during insert, fails during lookup" shape that surfaces swallowed exceptions).
+* **exception** — the targeted bombs raise ``MemoryError`` (the highest-value target for the
+  unguarded-error-path bug class), while ``SuperBomb`` raises a *random* exception from a wide
+  set: spray-and-pray coverage of every protocol slot at once.
+
+This module is embedded verbatim into generated fuzzing scripts, so it must stay
+self-contained (only ``random`` + builtins) and import-safe.
+"""
+
+import random
+
+# Weighted toward MemoryError (the unguarded-PyErr_Clear / swallowed-error bug class) but
+# spanning the exceptions C code is most likely to mishandle when a slot raises unexpectedly.
+_BOMB_EXCEPTIONS = (
+    MemoryError,
+    MemoryError,
+    MemoryError,
+    RecursionError,
+    OverflowError,
+    ValueError,
+    TypeError,
+    RuntimeError,
+    KeyError,
+    IndexError,
+    StopIteration,
+    SystemError,
+    KeyboardInterrupt,
+)
+
+
+def _bomb_exc(exc=None):
+    return exc if exc is not None else random.choice(_BOMB_EXCEPTIONS)
+
+
+class _BombBase:
+    """Succeed a random ``delay`` (0..max_delay) times, then raise ``exc`` from armed slots."""
+
+    def __init__(self, max_delay=3, exc=MemoryError):
+        self._calls = 0
+        self._delay = random.randint(0, max_delay)
+        self._exc = exc
+
+    def _fire(self):
+        self._calls += 1
+        if self._calls > self._delay:
+            raise _bomb_exc(self._exc)("fusil bomb")
+
+
+class HashBomb(_BombBase):
+    """__hash__ raises after the delay -- hits dict/set insert & lookup error paths."""
+
+    def __hash__(self):
+        self._fire()
+        return 42
+
+    def __eq__(self, other):
+        return self is other
+
+
+class EqBomb(_BombBase):
+    """Comparison raises; stays hashable and looks sequence-ish to pass pre-checks."""
+
+    def __eq__(self, other):
+        self._fire()
+        return NotImplemented
+
+    def __ne__(self, other):
+        self._fire()
+        return NotImplemented
+
+    def __hash__(self):
+        return 0
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 0
+
+
+class IndexBomb(_BombBase):
+    """Numeric coercion raises -- hits sequence-index / int-conversion error paths."""
+
+    def __index__(self):
+        self._fire()
+        return 1
+
+    def __int__(self):
+        self._fire()
+        return 1
+
+    def __float__(self):
+        self._fire()
+        return 1.0
+
+
+class LenBomb(_BombBase):
+    """__len__ raises but __iter__ works -- length-then-iterate mismatch."""
+
+    def __len__(self):
+        self._fire()
+        return 3
+
+    def __iter__(self):
+        return iter([1, 2, 3])
+
+
+class LyingLen:
+    """__len__ reports a huge size (over-allocation) but yields few items."""
+
+    def __len__(self):
+        return 1_000_000
+
+    def __iter__(self):
+        return iter([1, 2, 3])
+
+
+class ReprBomb(_BombBase):
+    """__repr__/__str__ raise -- hits error-formatting and logging paths in C."""
+
+    def __repr__(self):
+        self._fire()
+        return "<ReprBomb>"
+
+    __str__ = __repr__
+
+
+class FailingIterator:
+    """Yields a random few items, then raises mid-iteration (partial-mutation on
+    extend/update/list()/dict-from-pairs)."""
+
+    def __init__(self, max_items=4, exc=None):
+        self._i = 0
+        self._n = random.randint(0, max_items)
+        self._exc = exc
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._i >= self._n:
+            raise _bomb_exc(self._exc)("fusil iter bomb")
+        self._i += 1
+        return self._i
+
+
+# --- SuperBomb: every protocol slot is a landmine ----------------------------------------
+#
+# Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
+# raises a random exception, either on first use or after a per-instance random delay. The
+# attribute/lifecycle dunders (__init__/__new__/__getattribute__/__setattr__/__del__/...) are
+# deliberately left working so the object can be constructed and passed around to reach deep
+# call sites before it detonates.
+
+_SUPERBOMB_DUNDERS = (
+    "__hash__",
+    "__eq__",
+    "__ne__",
+    "__lt__",
+    "__le__",
+    "__gt__",
+    "__ge__",
+    "__call__",
+    "__len__",
+    "__length_hint__",
+    "__bool__",
+    "__contains__",
+    "__int__",
+    "__float__",
+    "__index__",
+    "__complex__",
+    "__round__",
+    "__trunc__",
+    "__repr__",
+    "__str__",
+    "__format__",
+    "__bytes__",
+    "__fspath__",
+    "__iter__",
+    "__next__",
+    "__reversed__",
+    "__getitem__",
+    "__setitem__",
+    "__delitem__",
+    "__missing__",
+    "__add__",
+    "__radd__",
+    "__iadd__",
+    "__sub__",
+    "__rsub__",
+    "__mul__",
+    "__rmul__",
+    "__mod__",
+    "__divmod__",
+    "__pow__",
+    "__truediv__",
+    "__floordiv__",
+    "__matmul__",
+    "__neg__",
+    "__pos__",
+    "__abs__",
+    "__invert__",
+    "__and__",
+    "__or__",
+    "__xor__",
+    "__lshift__",
+    "__rshift__",
+    "__enter__",
+    "__exit__",
+    "__get__",
+    "__set__",
+    "__delete__",
+    "__aiter__",
+    "__anext__",
+    "__await__",
+    "__ceil__",
+    "__floor__",
+)
+
+
+def _make_superbomb_slot(name):
+    def _slot(self, *args, **kwargs):
+        counts = self._bomb_calls
+        counts[name] = counts.get(name, 0) + 1
+        if counts[name] > self._bomb_delay:
+            raise _bomb_exc()("fusil superbomb via %s" % name)
+
+    _slot.__name__ = name
+    return _slot
+
+
+class _SuperBombMeta(type):
+    def __new__(mcls, cname, bases, namespace):
+        for _name in _SUPERBOMB_DUNDERS:
+            namespace.setdefault(_name, _make_superbomb_slot(_name))
+        return super().__new__(mcls, cname, bases, namespace)
+
+
+class SuperBomb(metaclass=_SuperBombMeta):
+    """Every protocol dunder raises a random exception on first use or after a random delay."""
+
+    def __init__(self, max_delay=3):
+        # object.__setattr__: __setattr__ itself is not armed, but keep construction robust
+        # regardless of what a subclass/metaclass does.
+        object.__setattr__(self, "_bomb_calls", {})
+        object.__setattr__(self, "_bomb_delay", random.randint(0, max_delay))
+
+
+# Names the argument generator instantiates (as ``Name()``); every class constructs with no
+# required arguments and self-randomises its delay/exception.
+BOMB_CLASS_NAMES = [
+    "HashBomb",
+    "EqBomb",
+    "IndexBomb",
+    "LenBomb",
+    "LyingLen",
+    "ReprBomb",
+    "FailingIterator",
+    "SuperBomb",
+]

--- a/fusil/python/tricky_weird.py
+++ b/fusil/python/tricky_weird.py
@@ -10,7 +10,7 @@ undesirable behavior in Python code and C extensions.
 import logging
 import pathlib
 
-from fusil.python.samples import tricky_objects, tricky_typing, weird_classes
+from fusil.python.samples import bomb_objects, tricky_objects, tricky_typing, weird_classes
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +33,12 @@ tricky_numpy_names = (
     [name for name in dir(tricky_numpy) if name.startswith("numpy_")] if tricky_numpy else []
 )
 
+bomb_object_names = list(bomb_objects.BOMB_CLASS_NAMES)
+
 weird_classes = pathlib.Path(weird_classes.__file__).read_text()
 tricky_typing = pathlib.Path(tricky_typing.__file__).read_text()
 tricky_objects = pathlib.Path(tricky_objects.__file__).read_text()
+bomb_objects = pathlib.Path(bomb_objects.__file__).read_text()
 if tricky_numpy:
     tricky_numpy = pathlib.Path(tricky_numpy.__file__).read_text()
 

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -335,6 +335,8 @@ class WritePythonCode(WriteCode):
         self.emptyLine()
         self.write(0, fusil.python.tricky_weird.tricky_objects)
         self.emptyLine()
+        self.write(0, fusil.python.tricky_weird.bomb_objects)
+        self.emptyLine()
         if not self.options.no_numpy and _ARG_GEN_USE_NUMPY:
             self.write(0, "import numpy")
             self.write(0, fusil.python.tricky_weird.tricky_numpy)

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -369,6 +369,280 @@ if tricky_list_with_cycle[0] and tricky_list_with_cycle[0][0] is tricky_list_wit
     tricky_list_with_cycle[0][0].append(tricky_list_with_cycle)
 
 
+"""Exception-bomb objects: the protocol-level analogue of the OOM (allocation-failure) mode.
+
+The OOM allocator hook makes *allocations* fail deterministically; a bomb object makes a
+*dunder callback* fail -- exercising the large class of C code that calls a Python protocol
+slot (``__hash__``, ``__eq__``, ``__index__``, ``__len__``, ``__iter__``, ``__repr__``, ...)
+and then does an unguarded ``PyErr_Clear()`` or assumes the slot succeeded.
+
+Two knobs, both randomised at construction so repeated use across a run walks a wide slice of
+program state (the windowed-failure insight of the OOM sequence mode applied to protocol slots):
+
+* **delay** — succeed a random number of times, *then* raise. Delay 0 means "raise on first
+  use"; delay N means "corrupt/observe state for N calls, then fail" (the cross-call
+  "succeeded during insert, fails during lookup" shape that surfaces swallowed exceptions).
+* **exception** — the targeted bombs raise ``MemoryError`` (the highest-value target for the
+  unguarded-error-path bug class), while ``SuperBomb`` raises a *random* exception from a wide
+  set: spray-and-pray coverage of every protocol slot at once.
+
+This module is embedded verbatim into generated fuzzing scripts, so it must stay
+self-contained (only ``random`` + builtins) and import-safe.
+"""
+
+import random
+
+# Weighted toward MemoryError (the unguarded-PyErr_Clear / swallowed-error bug class) but
+# spanning the exceptions C code is most likely to mishandle when a slot raises unexpectedly.
+_BOMB_EXCEPTIONS = (
+    MemoryError,
+    MemoryError,
+    MemoryError,
+    RecursionError,
+    OverflowError,
+    ValueError,
+    TypeError,
+    RuntimeError,
+    KeyError,
+    IndexError,
+    StopIteration,
+    SystemError,
+    KeyboardInterrupt,
+)
+
+
+def _bomb_exc(exc=None):
+    return exc if exc is not None else random.choice(_BOMB_EXCEPTIONS)
+
+
+class _BombBase:
+    """Succeed a random ``delay`` (0..max_delay) times, then raise ``exc`` from armed slots."""
+
+    def __init__(self, max_delay=3, exc=MemoryError):
+        self._calls = 0
+        self._delay = random.randint(0, max_delay)
+        self._exc = exc
+
+    def _fire(self):
+        self._calls += 1
+        if self._calls > self._delay:
+            raise _bomb_exc(self._exc)("fusil bomb")
+
+
+class HashBomb(_BombBase):
+    """__hash__ raises after the delay -- hits dict/set insert & lookup error paths."""
+
+    def __hash__(self):
+        self._fire()
+        return 42
+
+    def __eq__(self, other):
+        return self is other
+
+
+class EqBomb(_BombBase):
+    """Comparison raises; stays hashable and looks sequence-ish to pass pre-checks."""
+
+    def __eq__(self, other):
+        self._fire()
+        return NotImplemented
+
+    def __ne__(self, other):
+        self._fire()
+        return NotImplemented
+
+    def __hash__(self):
+        return 0
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 0
+
+
+class IndexBomb(_BombBase):
+    """Numeric coercion raises -- hits sequence-index / int-conversion error paths."""
+
+    def __index__(self):
+        self._fire()
+        return 1
+
+    def __int__(self):
+        self._fire()
+        return 1
+
+    def __float__(self):
+        self._fire()
+        return 1.0
+
+
+class LenBomb(_BombBase):
+    """__len__ raises but __iter__ works -- length-then-iterate mismatch."""
+
+    def __len__(self):
+        self._fire()
+        return 3
+
+    def __iter__(self):
+        return iter([1, 2, 3])
+
+
+class LyingLen:
+    """__len__ reports a huge size (over-allocation) but yields few items."""
+
+    def __len__(self):
+        return 1_000_000
+
+    def __iter__(self):
+        return iter([1, 2, 3])
+
+
+class ReprBomb(_BombBase):
+    """__repr__/__str__ raise -- hits error-formatting and logging paths in C."""
+
+    def __repr__(self):
+        self._fire()
+        return "<ReprBomb>"
+
+    __str__ = __repr__
+
+
+class FailingIterator:
+    """Yields a random few items, then raises mid-iteration (partial-mutation on
+    extend/update/list()/dict-from-pairs)."""
+
+    def __init__(self, max_items=4, exc=None):
+        self._i = 0
+        self._n = random.randint(0, max_items)
+        self._exc = exc
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._i >= self._n:
+            raise _bomb_exc(self._exc)("fusil iter bomb")
+        self._i += 1
+        return self._i
+
+
+# --- SuperBomb: every protocol slot is a landmine ----------------------------------------
+#
+# Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
+# raises a random exception, either on first use or after a per-instance random delay. The
+# attribute/lifecycle dunders (__init__/__new__/__getattribute__/__setattr__/__del__/...) are
+# deliberately left working so the object can be constructed and passed around to reach deep
+# call sites before it detonates.
+
+_SUPERBOMB_DUNDERS = (
+    "__hash__",
+    "__eq__",
+    "__ne__",
+    "__lt__",
+    "__le__",
+    "__gt__",
+    "__ge__",
+    "__call__",
+    "__len__",
+    "__length_hint__",
+    "__bool__",
+    "__contains__",
+    "__int__",
+    "__float__",
+    "__index__",
+    "__complex__",
+    "__round__",
+    "__trunc__",
+    "__repr__",
+    "__str__",
+    "__format__",
+    "__bytes__",
+    "__fspath__",
+    "__iter__",
+    "__next__",
+    "__reversed__",
+    "__getitem__",
+    "__setitem__",
+    "__delitem__",
+    "__missing__",
+    "__add__",
+    "__radd__",
+    "__iadd__",
+    "__sub__",
+    "__rsub__",
+    "__mul__",
+    "__rmul__",
+    "__mod__",
+    "__divmod__",
+    "__pow__",
+    "__truediv__",
+    "__floordiv__",
+    "__matmul__",
+    "__neg__",
+    "__pos__",
+    "__abs__",
+    "__invert__",
+    "__and__",
+    "__or__",
+    "__xor__",
+    "__lshift__",
+    "__rshift__",
+    "__enter__",
+    "__exit__",
+    "__get__",
+    "__set__",
+    "__delete__",
+    "__aiter__",
+    "__anext__",
+    "__await__",
+    "__ceil__",
+    "__floor__",
+)
+
+
+def _make_superbomb_slot(name):
+    def _slot(self, *args, **kwargs):
+        counts = self._bomb_calls
+        counts[name] = counts.get(name, 0) + 1
+        if counts[name] > self._bomb_delay:
+            raise _bomb_exc()("fusil superbomb via %s" % name)
+
+    _slot.__name__ = name
+    return _slot
+
+
+class _SuperBombMeta(type):
+    def __new__(mcls, cname, bases, namespace):
+        for _name in _SUPERBOMB_DUNDERS:
+            namespace.setdefault(_name, _make_superbomb_slot(_name))
+        return super().__new__(mcls, cname, bases, namespace)
+
+
+class SuperBomb(metaclass=_SuperBombMeta):
+    """Every protocol dunder raises a random exception on first use or after a random delay."""
+
+    def __init__(self, max_delay=3):
+        # object.__setattr__: __setattr__ itself is not armed, but keep construction robust
+        # regardless of what a subclass/metaclass does.
+        object.__setattr__(self, "_bomb_calls", {})
+        object.__setattr__(self, "_bomb_delay", random.randint(0, max_delay))
+
+
+# Names the argument generator instantiates (as ``Name()``); every class constructs with no
+# required arguments and self-randomises its delay/exception.
+BOMB_CLASS_NAMES = [
+    "HashBomb",
+    "EqBomb",
+    "IndexBomb",
+    "LenBomb",
+    "LyingLen",
+    "ReprBomb",
+    "FailingIterator",
+    "SuperBomb",
+]
+
+
 def errback(*args, **kw):
     raise ValueError('errback called')
 

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -1,0 +1,124 @@
+"""Tests for the exception-bomb object family (fusil/python/samples/bomb_objects.py).
+
+Bombs are the protocol-level analogue of --oom-fuzz: a dunder that raises (randomly delayed)
+to hit unguarded-error-path bugs in C code. These pin the delay/raise semantics, the
+SuperBomb "every dunder is a landmine" contract, and the generator wiring.
+"""
+
+import ast
+import os
+import sys
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))  # repo root -> import fusil.*
+sys.path.insert(0, os.path.join(SCRIPT_DIR, ".."))  # tests/ -> import python._test_options
+
+import fusil.python.tricky_weird as tricky_weird
+from fusil.python.samples import bomb_objects as B
+
+
+class TestDelaySemantics(unittest.TestCase):
+    def test_fires_after_exact_delay(self):
+        # delay N: succeed N times, raise on call N+1.
+        b = B.HashBomb()
+        b._delay, b._calls = 2, 0
+        self.assertEqual(hash(b), 42)  # call 1
+        self.assertEqual(hash(b), 42)  # call 2
+        with self.assertRaises(MemoryError):
+            hash(b)  # call 3 > delay 2
+
+    def test_delay_zero_fires_on_first_use(self):
+        b = B.HashBomb(max_delay=0)  # randint(0, 0) == 0
+        with self.assertRaises(MemoryError):
+            hash(b)
+
+    def test_targeted_bombs_default_to_memoryerror(self):
+        # The targeted family raises MemoryError (the high-value unguarded-error-path target).
+        with self.assertRaises(MemoryError):
+            B.IndexBomb(max_delay=0).__index__()
+        with self.assertRaises(MemoryError):
+            B.LenBomb(max_delay=0).__len__()
+        with self.assertRaises(MemoryError):
+            B.ReprBomb(max_delay=0).__repr__()
+        with self.assertRaises(MemoryError):
+            B.EqBomb(max_delay=0).__eq__(object())
+
+
+class TestSpecialBombs(unittest.TestCase):
+    def test_eqbomb_is_hashable(self):
+        self.assertEqual(hash(B.EqBomb()), 0)  # hashable so it reaches dict/set eq checks
+
+    def test_lyinglen_over_reports(self):
+        ll = B.LyingLen()
+        self.assertEqual(len(ll), 1_000_000)
+        self.assertEqual(list(ll), [1, 2, 3])  # but yields few
+
+    def test_failing_iterator_raises_during_iteration(self):
+        with self.assertRaises(BaseException):
+            list(B.FailingIterator(max_items=2))
+
+
+class TestSuperBomb(unittest.TestCase):
+    def test_constructs_cleanly(self):
+        B.SuperBomb()  # __init__ must work despite every other slot being armed
+
+    def test_every_listed_dunder_raises(self):
+        for name in B._SUPERBOMB_DUNDERS:
+            sb = B.SuperBomb(max_delay=0)  # fire on first use
+            slot = getattr(type(sb), name)
+            with self.assertRaises(BaseException, msg=f"{name} did not raise"):
+                slot(sb)
+
+    def test_raises_varied_exceptions(self):
+        seen = set()
+        for _ in range(300):
+            sb = B.SuperBomb(max_delay=0)
+            try:
+                sb.__hash__()
+            except BaseException as exc:  # noqa: BLE001
+                seen.add(type(exc))
+        self.assertGreater(len(seen), 3, f"expected variety, saw {seen}")
+
+    def test_respects_delay(self):
+        sb = B.SuperBomb()
+        object.__setattr__(sb, "_bomb_delay", 2)
+        object.__setattr__(sb, "_bomb_calls", {})
+        sb.__hash__()  # call 1 (no raise)
+        sb.__hash__()  # call 2 (no raise)
+        with self.assertRaises(BaseException):
+            sb.__hash__()  # call 3 > delay 2
+
+
+class TestGeneratorWiring(unittest.TestCase):
+    def test_all_class_names_construct_with_no_args(self):
+        for name in B.BOMB_CLASS_NAMES:
+            getattr(B, name)()  # must construct; generator emits `Name()`
+
+    def test_tricky_weird_exposes_names_and_source(self):
+        self.assertEqual(tricky_weird.bomb_object_names, B.BOMB_CLASS_NAMES)
+        # source text embedded into generated scripts must define every advertised class
+        for name in B.BOMB_CLASS_NAMES:
+            self.assertIn(f"class {name}", tricky_weird.bomb_objects)
+
+    def test_source_has_no_oom_marker_tokens(self):
+        # bomb source is embedded verbatim; it must not trip the OOM-artifact assertions in
+        # non-OOM generated scripts (test_oom_fuzz).
+        for marker in ("oom_call", "set_nomemory", "_OOM_AVAILABLE", "remove_mem_hooks"):
+            self.assertNotIn(marker, tricky_weird.bomb_objects)
+
+    def test_gen_bomb_object_emits_valid_constructor(self):
+        from python._test_options import make_test_options
+
+        from fusil.python.argument_generator import ArgumentGenerator
+
+        arg_gen = ArgumentGenerator(make_test_options(no_numpy=True, no_tstrings=True), [""])
+        for _ in range(30):
+            (expr,) = arg_gen.genBombObject()
+            self.assertTrue(expr.endswith("()"))
+            self.assertIn(expr[:-2], B.BOMB_CLASS_NAMES)
+            ast.parse(expr)  # valid Python expression
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements **reproducer technique A** from `doc/reproducer-techniques-for-fusil.md` — the
protocol-level analogue of `--oom-fuzz`. Where the OOM mode makes *allocations* fail
deterministically, a bomb object makes a **dunder callback** fail — exercising the large
class of C code that calls a Python protocol slot (`__hash__`, `__eq__`, `__index__`,
`__len__`, `__iter__`, `__repr__`, …) and then does an unguarded `PyErr_Clear()` or assumes
the slot succeeded.

## `fusil/python/samples/bomb_objects.py` (new)

- **Targeted family** — `HashBomb`, `EqBomb`, `IndexBomb`, `LenBomb`, `LyingLen`, `ReprBomb`,
  `FailingIterator`. An armed dunder raises **`MemoryError`** (the high-value unguarded-error-path
  target) after a **random delay** — succeed N times, then raise. That cross-call
  "succeeded on insert, fails on lookup" shape is what surfaces swallowed exceptions.
- **`SuperBomb`** (the spray-and-pray addition) — a metaclass installs a raising slot for ~60
  protocol dunders; **every one raises a random exception on first use or after a per-instance
  random delay**. Maximal protocol-slot coverage to walk more program state. The
  attribute/lifecycle dunders (`__init__`/`__getattribute__`/`__setattr__`/`__del__`/…) are left
  working so the object constructs and reaches deep call sites before detonating.

Delays (all bombs) and exception types (SuperBomb) are randomised per instance, so the same
generated `SuperBomb()` behaves differently across runs/instances — larger state-space coverage.

## Wiring

- `tricky_weird` exposes `bomb_object_names` + the embedded source.
- `ArgumentGenerator.genBombObject` emits a fresh `Name()` per call (bombs are stateful, so a
  new armed instance each time), injected into the **simple / complex / hashable** pools at
  weight `BOMB_WEIGHT` (8 — frequent but well below numpy's 50).
- `write_python_code` embeds the bomb source into generated scripts.

Always on, like `weird_classes`/`tricky_objects`.

## Verification

- **341 tests OK** (14 new in `tests/python/test_bomb_objects.py` pinning delay/raise
  semantics, the SuperBomb "every dunder is a landmine" contract, exception variety, and the
  generator wiring). Golden snapshot regenerated (bombs now appear in output).
- `ruff` clean; generated scripts `ast.parse`; a real `--modules json` run executes
  bomb-laden scripts cleanly (bomb exceptions are caught by the call wrappers — a real C
  crash would be surfaced by the signal/text probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)