### PR TITLE
feat(python): add --gc-aggressive (reproducer technique B)

### DIFF
--- a/doc/reproducer-techniques-for-fusil.md
+++ b/doc/reproducer-techniques-for-fusil.md
@@ -165,6 +165,10 @@ set, or behind a flag). This is the recommended first implementation.
 
 ### B. Cyclic-GC threshold coercion — a cheap global knob like `set_nomemory` (Technique 26)
 
+> **STATUS: IMPLEMENTED.** `--gc-aggressive` emits `import gc; gc.set_threshold(1, 1, 1)` at
+> the top of the generated script (next to the OOM harness). Off by default; tested in
+> `tests/python/test_gc_aggressive.py`.
+
 `gc.set_threshold(1, 1, 1)` forces a gen-0 collection on essentially every tracked allocation,
 turning rare "GC fires while an object is tracked but half-initialized" races (`tp_traverse`
 reading a NULL field) into deterministic crashes. This is the same *shape* as the OOM win — a

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -176,6 +176,14 @@ class Fuzzer(Application):
             default=False,
         )
         fuzzing_options.add_option(
+            "--gc-aggressive",
+            help="Emit gc.set_threshold(1, 1, 1) at the top of the generated script, forcing a "
+            "gen-0 collection on ~every allocation (surfaces GC-during-partial-init crashes); "
+            "off by default",
+            action="store_true",
+            default=False,
+        )
+        fuzzing_options.add_option(
             "--no-async",
             help="Don't run code asynchronously (default: False)",
             action="store_true",

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -327,6 +327,20 @@ class WritePythonCode(WriteCode):
             )
             self.emptyLine()
 
+        if self.options.gc_aggressive:
+            # gc.set_threshold(1, 1, 1) forces a gen-0 collection on ~every tracked allocation,
+            # turning rare "GC fires while an object is tracked but half-initialised"
+            # races (tp_traverse reading a NULL field) into deterministic crashes. A cheap
+            # global coercion like the OOM hook; composes with the bombs + class fuzzing.
+            self.write_block(
+                0,
+                """
+                import gc
+                gc.set_threshold(1, 1, 1)
+                """,
+            )
+            self.emptyLine()
+
     def _write_tricky_definitions(self) -> None:
         """Writes definitions for 'tricky' classes and objects."""
         self.write(0, fusil.python.tricky_weird.weird_classes)

--- a/tests/python/test_gc_aggressive.py
+++ b/tests/python/test_gc_aggressive.py
@@ -1,0 +1,60 @@
+"""Tests for --gc-aggressive: emit gc.set_threshold(1, 1, 1) at the top of the script."""
+
+import ast
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))  # repo root
+sys.path.insert(0, os.path.join(SCRIPT_DIR, ".."))  # tests/ -> python._test_options
+
+import json as _target
+
+from python._test_options import make_test_options
+
+from fusil.python.write_python_code import WritePythonCode
+
+
+class _Parent:
+    def __init__(self, options):
+        self.options = options
+        self.filenames = ["/bin/sh"]
+
+    def warning(self, *a, **k):
+        pass
+
+
+def _generate(gc_aggressive):
+    options = make_test_options(
+        no_numpy=True, no_tstrings=True, gc_aggressive=gc_aggressive, functions_number=2
+    )
+    fd, path = tempfile.mkstemp(suffix="_gc.py")
+    os.close(fd)
+    try:
+        writer = WritePythonCode(
+            _Parent(options), path, _target, "json", threads=False, _async=False
+        )
+        writer.generate_fuzzing_script()
+        with open(path) as fh:
+            return fh.read()
+    finally:
+        os.unlink(path)
+
+
+class TestGcAggressive(unittest.TestCase):
+    def test_emitted_when_on(self):
+        src = _generate(gc_aggressive=True)
+        ast.parse(src)
+        self.assertIn("gc.set_threshold(1, 1, 1)", src)
+        self.assertIn("import gc", src)
+
+    def test_absent_when_off(self):
+        src = _generate(gc_aggressive=False)
+        ast.parse(src)
+        self.assertNotIn("gc.set_threshold(1, 1, 1)", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_golden_output.py
+++ b/tests/python/test_golden_output.py
@@ -46,6 +46,7 @@ class _Options:
     objects_number = 0
     methods_number = 2
     deep_dive = False
+    gc_aggressive = False
     fuzz_exceptions = False
     test_private = False
     no_numpy = True

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -41,6 +41,7 @@ def _make_options(oom_fuzz, oom_verbose=False):
     o.oom_verbose = oom_verbose
     # General generation knobs
     o.fuzz_exceptions = False
+    o.gc_aggressive = False
     o.test_private = False
     o.no_numpy = True
     o.no_tstrings = True


### PR DESCRIPTION
Implements **reproducer technique B** — a cheap global coercion in the same shape as the OOM
allocator hook. `gc.set_threshold(1, 1, 1)` forces a gen-0 collection on ~every tracked
allocation, turning rare "GC fires while an object is tracked but half-initialised" races
(`tp_traverse` reading a NULL field) into deterministic crashes. Composes with the exception
bombs (#162) and class-instantiation fuzzing.

- **`--gc-aggressive`** (Fuzzing option group), off by default.
- `write_python_code` emits `import gc; gc.set_threshold(1, 1, 1)` at the top of the generated
  script, right after the OOM harness.

## Verification
- Golden output **unchanged** (flag off by default).
- **343 tests OK** (2 new in `tests/python/test_gc_aggressive.py`), `ruff` clean, a real
  `--gc-aggressive --modules json` run executes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)