### PR TITLE
feat(python): file-like + metaclass/descriptor bombs (reproducer techniques C, D)

### DIFF
--- a/doc/reproducer-techniques-for-fusil.md
+++ b/doc/reproducer-techniques-for-fusil.md
@@ -180,6 +180,10 @@ harness). Pairs especially well with class-instantiation fuzzing and the bomb ob
 
 ### C. Mischievous file-like objects (Techniques 5b / 21)
 
+> **STATUS: IMPLEMENTED.** `ReadBomb` (read/readline succeed a random few times then raise),
+> `WrongTypeFile` (read returns an int), `FilenoBomb` (fileno raises, read works) in
+> `bomb_objects.py`, injected via `genBombObject`.
+
 A small set of file-like bombs — `read()` returning the wrong type, `read()` succeeding once
 then raising (delayed failure, the most productive), `fileno()` raising while the object stays
 callable — targets the very common "try fd, fall back to `.read()`" C pattern and mid-parse
@@ -190,6 +194,12 @@ target functions take file-like args; pairs with a heuristic that prefers it for
 `file`/`fp`/`path`/`fileobj`). **Risk: LOW.**
 
 ### D. Metaclass / descriptor attribute bombs (Techniques 1, 4, 19)
+
+> **STATUS: IMPLEMENTED.** `HiddenNameType` (T1, metaclass hides `__name__`/`__qualname__`/
+> `__module__`), `DescriptorBomb` (T4, raising data-descriptors on commonly-probed attrs),
+> `StatefulHashType` (T19, metaclass hash arms after a random delay) in `bomb_objects.py`.
+> The type bombs (`HiddenNameType`, `StatefulHashType`) are passed as the class object itself
+> via `genBombObject` / `BOMB_TYPE_NAMES`.
 
 - **Attribute-hiding metaclass** (T1): a class whose metaclass `__getattribute__` raises on
   `__name__`/`__module__`/`__qualname__` — targets unchecked `PyObject_GetAttrString(Py_TYPE

--- a/fusil/python/argument_generator.py
+++ b/fusil/python/argument_generator.py
@@ -350,12 +350,16 @@ class ArgumentGenerator:
         return [tricky_name]
 
     def genBombObject(self) -> list[str]:
-        """Generate a freshly-constructed exception-bomb object (see samples/bomb_objects.py).
+        """Generate an exception-bomb argument (see samples/bomb_objects.py).
 
-        A new instance per call (bombs are stateful and self-randomise their delay/exception),
-        so each fuzzed argument gets an independently-armed landmine."""
-        bomb_class = choice(fusil.python.tricky_weird.bomb_object_names)
-        return [f"{bomb_class}()"]
+        Instance bombs are freshly constructed per call (``Name()``) -- they are stateful and
+        self-randomise their delay/exception, so each argument is an independently-armed
+        landmine. Type bombs are passed as the class object itself (``Name``), where a
+        metaclass makes attribute/hash access on the class the landmine."""
+        instance_names = fusil.python.tricky_weird.bomb_object_names
+        type_names = fusil.python.tricky_weird.bomb_type_names
+        name = choice(instance_names + type_names)
+        return [name if name in type_names else f"{name}()"]
 
     def genTrickyNumpy(self) -> list[str]:
         """Generate a name of a 'tricky' predefined NumPy object from tricky_weird."""

--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -258,6 +258,129 @@ class SuperBomb(metaclass=_SuperBombMeta):
         object.__setattr__(self, "_bomb_delay", random.randint(0, max_delay))
 
 
+# --- File-like bombs (target the common "try fd, else .read()" C pattern) ----------------
+
+
+class ReadBomb(_BombBase):
+    """A file-like whose read()/readline() succeed a random few times, then raise -- the
+    delayed mid-parse failure that surfaces partial-read error handling."""
+
+    def read(self, *args, **kwargs):
+        self._fire()
+        return b""
+
+    def readline(self, *args, **kwargs):
+        self._fire()
+        return b""
+
+    def readlines(self, *args, **kwargs):
+        self._fire()
+        return []
+
+    def __iter__(self):
+        return iter((b"line\n",))
+
+    def seek(self, *args, **kwargs):
+        return 0
+
+    def tell(self):
+        return 0
+
+    def close(self):
+        pass
+
+
+class WrongTypeFile:
+    """read() returns the wrong type (int, not bytes/str) -- targets C code that assumes the
+    return of read() is a buffer."""
+
+    def read(self, *args, **kwargs):
+        return 123456
+
+    def readline(self, *args, **kwargs):
+        return 123456
+
+    def close(self):
+        pass
+
+
+class FilenoBomb:
+    """fileno() raises (looks like a bad/again fd) while read() keeps working -- targets the
+    'try obj.fileno(), fall back to obj.read()' branch and its error handling."""
+
+    def fileno(self):
+        raise _bomb_exc()("fusil fileno bomb")
+
+    def read(self, *args, **kwargs):
+        return b""
+
+    def readable(self):
+        return True
+
+    def close(self):
+        pass
+
+
+# --- Metaclass / descriptor bombs (target attribute-access C paths) ----------------------
+
+
+class _HiddenNameMeta(type):
+    """Metaclass whose attribute access raises for the identity names C code reads unchecked
+    (``Py_TYPE(obj)->tp_name`` analogues via ``PyObject_GetAttrString(cls, "__name__")``)."""
+
+    def __getattribute__(cls, name):
+        if name in ("__name__", "__qualname__", "__module__"):
+            raise _bomb_exc()("fusil hidden name: %s" % name)
+        return super().__getattribute__(name)
+
+
+class HiddenNameType(metaclass=_HiddenNameMeta):
+    """A *class* (pass it, don't instantiate) whose __name__/__qualname__/__module__ raise."""
+
+
+class _RaisingGet:
+    """A data descriptor whose __get__/__set__ raise -- hits unguarded PyErr_Clear in getattr
+    fallbacks when installed on a commonly-probed attribute name."""
+
+    def __get__(self, obj, objtype=None):
+        raise _bomb_exc()("fusil descriptor get")
+
+    def __set__(self, obj, value):
+        raise _bomb_exc()("fusil descriptor set")
+
+
+class DescriptorBomb:
+    """An instance whose class carries raising data-descriptors on attribute names C code
+    commonly probes."""
+
+    value = _RaisingGet()
+    name = _RaisingGet()
+    read = _RaisingGet()
+    __wrapped__ = _RaisingGet()
+
+
+class _StatefulHashMeta(type):
+    """Metaclass hash that succeeds at first (registration) then raises after a random delay --
+    targets type-keyed registries (``PyDict_GetItem`` on a class key that changes hashability)."""
+
+    def __new__(mcls, name, bases, namespace):
+        cls = super().__new__(mcls, name, bases, namespace)
+        # list cell so __hash__ can mutate without triggering __setattr__ machinery
+        cls._bomb_hash_state = [0, random.randint(0, 3)]
+        return cls
+
+    def __hash__(cls):
+        state = super().__getattribute__("_bomb_hash_state")
+        state[0] += 1
+        if state[0] > state[1]:
+            raise _bomb_exc()("fusil stateful hash")
+        return 0
+
+
+class StatefulHashType(metaclass=_StatefulHashMeta):
+    """A *class* (pass it, don't instantiate) whose hash works, then arms and starts raising."""
+
+
 # Names the argument generator instantiates (as ``Name()``); every class constructs with no
 # required arguments and self-randomises its delay/exception.
 BOMB_CLASS_NAMES = [
@@ -269,4 +392,15 @@ BOMB_CLASS_NAMES = [
     "ReprBomb",
     "FailingIterator",
     "SuperBomb",
+    "ReadBomb",
+    "WrongTypeFile",
+    "FilenoBomb",
+    "DescriptorBomb",
+]
+
+# Names the argument generator passes *as the class object itself* (not instantiated) -- the
+# bomb is the type: a metaclass turns attribute/hash access on the class into a landmine.
+BOMB_TYPE_NAMES = [
+    "HiddenNameType",
+    "StatefulHashType",
 ]

--- a/fusil/python/tricky_weird.py
+++ b/fusil/python/tricky_weird.py
@@ -34,6 +34,7 @@ tricky_numpy_names = (
 )
 
 bomb_object_names = list(bomb_objects.BOMB_CLASS_NAMES)
+bomb_type_names = list(bomb_objects.BOMB_TYPE_NAMES)
 
 weird_classes = pathlib.Path(weird_classes.__file__).read_text()
 tricky_typing = pathlib.Path(tricky_typing.__file__).read_text()

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -629,6 +629,129 @@ class SuperBomb(metaclass=_SuperBombMeta):
         object.__setattr__(self, "_bomb_delay", random.randint(0, max_delay))
 
 
+# --- File-like bombs (target the common "try fd, else .read()" C pattern) ----------------
+
+
+class ReadBomb(_BombBase):
+    """A file-like whose read()/readline() succeed a random few times, then raise -- the
+    delayed mid-parse failure that surfaces partial-read error handling."""
+
+    def read(self, *args, **kwargs):
+        self._fire()
+        return b""
+
+    def readline(self, *args, **kwargs):
+        self._fire()
+        return b""
+
+    def readlines(self, *args, **kwargs):
+        self._fire()
+        return []
+
+    def __iter__(self):
+        return iter((b"line\n",))
+
+    def seek(self, *args, **kwargs):
+        return 0
+
+    def tell(self):
+        return 0
+
+    def close(self):
+        pass
+
+
+class WrongTypeFile:
+    """read() returns the wrong type (int, not bytes/str) -- targets C code that assumes the
+    return of read() is a buffer."""
+
+    def read(self, *args, **kwargs):
+        return 123456
+
+    def readline(self, *args, **kwargs):
+        return 123456
+
+    def close(self):
+        pass
+
+
+class FilenoBomb:
+    """fileno() raises (looks like a bad/again fd) while read() keeps working -- targets the
+    'try obj.fileno(), fall back to obj.read()' branch and its error handling."""
+
+    def fileno(self):
+        raise _bomb_exc()("fusil fileno bomb")
+
+    def read(self, *args, **kwargs):
+        return b""
+
+    def readable(self):
+        return True
+
+    def close(self):
+        pass
+
+
+# --- Metaclass / descriptor bombs (target attribute-access C paths) ----------------------
+
+
+class _HiddenNameMeta(type):
+    """Metaclass whose attribute access raises for the identity names C code reads unchecked
+    (``Py_TYPE(obj)->tp_name`` analogues via ``PyObject_GetAttrString(cls, "__name__")``)."""
+
+    def __getattribute__(cls, name):
+        if name in ("__name__", "__qualname__", "__module__"):
+            raise _bomb_exc()("fusil hidden name: %s" % name)
+        return super().__getattribute__(name)
+
+
+class HiddenNameType(metaclass=_HiddenNameMeta):
+    """A *class* (pass it, don't instantiate) whose __name__/__qualname__/__module__ raise."""
+
+
+class _RaisingGet:
+    """A data descriptor whose __get__/__set__ raise -- hits unguarded PyErr_Clear in getattr
+    fallbacks when installed on a commonly-probed attribute name."""
+
+    def __get__(self, obj, objtype=None):
+        raise _bomb_exc()("fusil descriptor get")
+
+    def __set__(self, obj, value):
+        raise _bomb_exc()("fusil descriptor set")
+
+
+class DescriptorBomb:
+    """An instance whose class carries raising data-descriptors on attribute names C code
+    commonly probes."""
+
+    value = _RaisingGet()
+    name = _RaisingGet()
+    read = _RaisingGet()
+    __wrapped__ = _RaisingGet()
+
+
+class _StatefulHashMeta(type):
+    """Metaclass hash that succeeds at first (registration) then raises after a random delay --
+    targets type-keyed registries (``PyDict_GetItem`` on a class key that changes hashability)."""
+
+    def __new__(mcls, name, bases, namespace):
+        cls = super().__new__(mcls, name, bases, namespace)
+        # list cell so __hash__ can mutate without triggering __setattr__ machinery
+        cls._bomb_hash_state = [0, random.randint(0, 3)]
+        return cls
+
+    def __hash__(cls):
+        state = super().__getattribute__("_bomb_hash_state")
+        state[0] += 1
+        if state[0] > state[1]:
+            raise _bomb_exc()("fusil stateful hash")
+        return 0
+
+
+class StatefulHashType(metaclass=_StatefulHashMeta):
+    """A *class* (pass it, don't instantiate) whose hash works, then arms and starts raising."""
+
+
 # Names the argument generator instantiates (as ``Name()``); every class constructs with no
 # required arguments and self-randomises its delay/exception.
 BOMB_CLASS_NAMES = [
@@ -640,6 +763,17 @@ BOMB_CLASS_NAMES = [
     "ReprBomb",
     "FailingIterator",
     "SuperBomb",
+    "ReadBomb",
+    "WrongTypeFile",
+    "FilenoBomb",
+    "DescriptorBomb",
+]
+
+# Names the argument generator passes *as the class object itself* (not instantiated) -- the
+# bomb is the type: a metaclass turns attribute/hash access on the class into a landmine.
+BOMB_TYPE_NAMES = [
+    "HiddenNameType",
+    "StatefulHashType",
 ]
 
 

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -90,10 +90,55 @@ class TestSuperBomb(unittest.TestCase):
             sb.__hash__()  # call 3 > delay 2
 
 
+class TestFileBombs(unittest.TestCase):
+    def test_read_bomb_delays_then_raises(self):
+        rb = B.ReadBomb()
+        rb._delay, rb._calls = 1, 0
+        self.assertEqual(rb.read(), b"")  # call 1
+        with self.assertRaises(MemoryError):
+            rb.read()  # call 2 > delay 1
+
+    def test_wrong_type_file_returns_non_buffer(self):
+        self.assertNotIsInstance(B.WrongTypeFile().read(), (bytes, str))
+
+    def test_fileno_bomb_raises_but_read_works(self):
+        fb = B.FilenoBomb()
+        self.assertEqual(fb.read(), b"")
+        with self.assertRaises(BaseException):
+            fb.fileno()
+
+
+class TestMetaclassBombs(unittest.TestCase):
+    def test_hidden_name_type_hides_identity_attrs(self):
+        self.assertIsInstance(B.HiddenNameType, type)  # it is a class, passed as-is
+        for attr in ("__name__", "__qualname__", "__module__"):
+            with self.assertRaises(BaseException, msg=attr):
+                getattr(B.HiddenNameType, attr)
+
+    def test_descriptor_bomb_get_raises(self):
+        db = B.DescriptorBomb()
+        for attr in ("value", "name", "read", "__wrapped__"):
+            with self.assertRaises(BaseException, msg=attr):
+                getattr(db, attr)
+
+    def test_stateful_hash_type_arms_after_use(self):
+        # A fresh subclass so its hash state is independent of other tests / the shared class.
+        T = B._StatefulHashMeta("T", (), {})
+        T._bomb_hash_state = [0, 2]  # succeed twice, then raise
+        self.assertEqual(hash(T), 0)
+        self.assertEqual(hash(T), 0)
+        with self.assertRaises(BaseException):
+            hash(T)
+
+
 class TestGeneratorWiring(unittest.TestCase):
     def test_all_class_names_construct_with_no_args(self):
         for name in B.BOMB_CLASS_NAMES:
             getattr(B, name)()  # must construct; generator emits `Name()`
+
+    def test_type_bombs_are_types(self):
+        for name in B.BOMB_TYPE_NAMES:
+            self.assertIsInstance(getattr(B, name), type)
 
     def test_tricky_weird_exposes_names_and_source(self):
         self.assertEqual(tricky_weird.bomb_object_names, B.BOMB_CLASS_NAMES)
@@ -107,17 +152,23 @@ class TestGeneratorWiring(unittest.TestCase):
         for marker in ("oom_call", "set_nomemory", "_OOM_AVAILABLE", "remove_mem_hooks"):
             self.assertNotIn(marker, tricky_weird.bomb_objects)
 
-    def test_gen_bomb_object_emits_valid_constructor(self):
+    def test_gen_bomb_object_emits_instances_and_types(self):
         from python._test_options import make_test_options
 
         from fusil.python.argument_generator import ArgumentGenerator
 
         arg_gen = ArgumentGenerator(make_test_options(no_numpy=True, no_tstrings=True), [""])
-        for _ in range(30):
+        saw_instance = saw_type = False
+        for _ in range(200):
             (expr,) = arg_gen.genBombObject()
-            self.assertTrue(expr.endswith("()"))
-            self.assertIn(expr[:-2], B.BOMB_CLASS_NAMES)
             ast.parse(expr)  # valid Python expression
+            if expr.endswith("()"):
+                self.assertIn(expr[:-2], B.BOMB_CLASS_NAMES)  # instance bomb: Name()
+                saw_instance = True
+            else:
+                self.assertIn(expr, B.BOMB_TYPE_NAMES)  # type bomb: bare Name
+                saw_type = True
+        self.assertTrue(saw_instance and saw_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends the exception-bomb arsenal (#162) with two more protocol surfaces.

## File-like bombs (technique C)
Target the very common "try `fd`, fall back to `.read()`" C pattern and mid-parse error handling.
- **`ReadBomb`** — `read()`/`readline()` succeed a random few times, then raise (delayed mid-parse failure).
- **`WrongTypeFile`** — `read()` returns an `int` (C assuming a buffer from `read()`).
- **`FilenoBomb`** — `fileno()` raises while `read()` works (the fd-then-read fallback branch).

## Metaclass / descriptor bombs (technique D)
Target attribute-access C paths.
- **`HiddenNameType`** (T1) — metaclass `__getattribute__` raises for `__name__`/`__qualname__`/`__module__`
  — unchecked `PyObject_GetAttrString(cls, "__name__")` flowing into `strcmp`/`PyUnicode_AsUTF8`.
- **`DescriptorBomb`** (T4) — raising data-descriptors on commonly-probed attrs (`value`/`name`/`read`/`__wrapped__`)
  — unguarded `PyErr_Clear` in getattr fallbacks.
- **`StatefulHashType`** (T19) — metaclass `__hash__` succeeds, then arms after a random delay — type-keyed
  registries (`PyDict_GetItem` on a class key that changes hashability).

## Wiring
The two **type bombs** (`HiddenNameType`, `StatefulHashType`) are the class object itself, so they're
passed *bare* (not instantiated) via a new `BOMB_TYPE_NAMES` list — `genBombObject` emits `Name` for those
and `Name()` for the instance bombs.

## Verification
- **350 tests OK** (7 new in `test_bomb_objects.py` covering the file/metaclass/type bombs + the
  instance-vs-type emission). Golden regenerated.
- `ruff` clean; generated scripts `ast.parse`; a real `--modules json` run executes them cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)