### PR TITLE
feat(oom): --oom-foreign — C-layer malloc failure injection via LD_PRELOAD shim (technique F)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe [options]
 #   --oom-dedup-catalog F    in-loop crash dedupe/labeling vs known_sites.tsv; add
 #                            --oom-dedup-prune to drop dups, --oom-dedup-resolve-segv
 #                            to resolve segvs via gdb so they dedupe too
+#   --oom-foreign            inject failures at the C malloc() layer via an LD_PRELOAD shim
+#                            (fusil_malloc_shim.c, compiled on demand) instead of set_nomemory,
+#                            reaching FOREIGN C-lib allocs (HDF5/zstd/...); implies --oom-fuzz;
+#                            --oom-foreign-pythonmalloc also routes CPython allocs through it
 ```
 
 `jit_config.py` is a standalone helper (not part of the fuzzer) that rewrites CPython

--- a/doc/reproducer-techniques-for-fusil.md
+++ b/doc/reproducer-techniques-for-fusil.md
@@ -227,6 +227,18 @@ what incidental fuzzing already finds.
 
 ### F. System-malloc fault injection via libfiu / LD_PRELOAD (Techniques 23 / 27 / 31)
 
+> **STATUS: IMPLEMENTED (own shim, not libfiu).** `--oom-foreign` LD_PRELOADs a small custom
+> shim (`fusil/python/fusil_malloc_shim.c`, compiled+cached by `foreign_oom.py`) that
+> interposes `malloc`/`calloc`/`realloc`/... and exports `fusil_malloc_arm(start, stop)` — a
+> drop-in for `_testcapi.set_nomemory`, armed from the harness via `ctypes.CDLL(None)`. Chosen
+> over libfiu because libfiu is rarely installed and its probabilistic mode isn't replayable,
+> whereas the shim mirrors `set_nomemory`'s deterministic windowed semantics exactly (so
+> foreign-allocator crashes stay replayable/dedup-able). Composes with `--oom-fuzz` (reuses the
+> whole sweep); `--oom-foreign-pythonmalloc` additionally sets `PYTHONMALLOC=malloc`. The child
+> env (incl. `LD_PRELOAD`) is captured into the replay script. Caveat: don't combine with an
+> ASan-instrumented target (ASan owns the allocator). Tests: `test_foreign_oom.py`,
+> `test_oom_fuzz.py::TestForeignOOMGeneration`.
+
 This is the strategic, higher-effort complement to `set_nomemory`. `set_nomemory` only hooks
 CPython's allocator domains; it **cannot** reach `malloc`/`calloc`/`realloc` inside foreign C
 libraries an extension links (HDF5, libzstd, libxml2, …). libfiu (`LD_PRELOAD` +

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -351,6 +351,23 @@ class Fuzzer(Application):
             type="int",
             default=120,
         )
+        oom_options.add_option(
+            "--oom-foreign",
+            help="Inject allocation failures at the C malloc() layer via an LD_PRELOAD shim "
+            "(instead of _testcapi.set_nomemory), reaching FOREIGN C-library allocations "
+            "(HDF5, zstd, libxml2, ...) that set_nomemory can't. Composes with --oom-fuzz "
+            "(reuses the same sweep); needs a C compiler. Default: False",
+            action="store_true",
+            default=False,
+        )
+        oom_options.add_option(
+            "--oom-foreign-pythonmalloc",
+            help="With --oom-foreign, also set PYTHONMALLOC=malloc so CPython's own "
+            "allocations route through the shim too (superset of set_nomemory + foreign; "
+            "noisier). Default: False (leave pymalloc on, target foreign/large allocs)",
+            action="store_true",
+            default=False,
+        )
 
         options = (
             input_options,
@@ -372,6 +389,11 @@ class Fuzzer(Application):
 
     def setupProject(self) -> None:
         """Initialize the fuzzing project with process monitoring and output analysis."""
+        # --oom-foreign reuses the whole OOM harness (oom_call/oom_run sweep), just with the
+        # LD_PRELOAD malloc shim as the arming backend instead of _testcapi.set_nomemory.
+        if self.options.oom_foreign:
+            self.options.oom_fuzz = True
+
         project = self.project
         if not self.project:
             project = self.project = Project(self)
@@ -391,6 +413,20 @@ class Fuzzer(Application):
             timeout=self.options.timeout,
         )
         process.max_memory = 4000 * 1024 * 1024 * 1024 * 1024
+
+        # Foreign-allocator OOM: preload the malloc-failure shim so the generated harness can
+        # inject failures at the C malloc() layer (reaching foreign C libraries). Fail fast if
+        # requested but unbuildable -- the user asked for it and needs a working compiler.
+        if self.options.oom_foreign:
+            from fusil.python.foreign_oom import get_shim_path
+
+            shim = get_shim_path()
+            process.env.set("LD_PRELOAD", shim)
+            self.error("Foreign-OOM: LD_PRELOAD=%s" % shim)
+            if self.options.oom_foreign_pythonmalloc:
+                process.env.set("PYTHONMALLOC", "malloc")
+                self.error("Foreign-OOM: PYTHONMALLOC=malloc (CPython allocs route through shim)")
+
         options = {"exitcode_score": self.options.exitcode_score}
         if not self.options.record_timeouts:
             options["timeout_score"] = 0

--- a/fusil/python/foreign_oom.py
+++ b/fusil/python/foreign_oom.py
@@ -1,0 +1,67 @@
+"""Foreign-allocator OOM: compile + locate the LD_PRELOAD malloc-failure shim.
+
+The shim (``fusil_malloc_shim.c``) interposes ``malloc``/``calloc``/``realloc``/... so
+allocation failures can be injected at the C ``malloc`` layer, reaching foreign C-library
+allocations (HDF5, zstd, libxml2, openssl, ...) that ``_testcapi.set_nomemory`` -- which only
+hooks CPython's PyMem allocators -- structurally cannot. It exports
+``fusil_malloc_arm(start, stop)`` (a drop-in for ``set_nomemory``) callable from the generated
+harness via ``ctypes.CDLL(None)``. See ``doc/python-fuzzer.md`` (OOM section).
+
+This module compiles the shim once (cached, keyed by the source hash) and returns the ``.so``
+path for the launcher to put in the child's ``LD_PRELOAD``.
+"""
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SHIM_SOURCE = Path(__file__).with_name("fusil_malloc_shim.c")
+
+
+def _cache_dir() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")
+    return Path(base) / "fusil"
+
+
+class ForeignOOMError(Exception):
+    """Raised when the foreign-OOM shim cannot be built (no compiler / compile failure)."""
+
+
+def get_shim_path() -> str:
+    """Return the path to the compiled malloc-failure shim, building it (cached) if needed.
+
+    The cache key is the shim source hash, so a changed shim rebuilds automatically and stale
+    copies are never reused. Raises ForeignOOMError if no C compiler is available or the
+    compile fails -- the caller (``--oom-foreign`` setup) surfaces that to the user.
+    """
+    if not _SHIM_SOURCE.exists():  # pragma: no cover - shipped with the package
+        raise ForeignOOMError("shim source missing: %s" % _SHIM_SOURCE)
+
+    source = _SHIM_SOURCE.read_bytes()
+    digest = hashlib.sha256(source).hexdigest()[:16]
+    cache_dir = _cache_dir()
+    so_path = cache_dir / ("fusil_malloc_shim_%s.so" % digest)
+    if so_path.exists():
+        return str(so_path)
+
+    compiler = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
+    if not compiler:
+        raise ForeignOOMError(
+            "--oom-foreign needs a C compiler (cc/gcc/clang) to build the malloc shim; none found"
+        )
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tmp_so = cache_dir / ("fusil_malloc_shim_%s.so.tmp%d" % (digest, os.getpid()))
+    cmd = [compiler, "-shared", "-fPIC", "-O2", "-o", str(tmp_so), str(_SHIM_SOURCE), "-ldl"]
+    logger.info("Building foreign-OOM malloc shim: %s", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as err:
+        raise ForeignOOMError("failed to build malloc shim: %s" % (err.stderr or err)) from err
+    os.replace(tmp_so, so_path)  # atomic publish
+    return str(so_path)

--- a/fusil/python/fusil_malloc_shim.c
+++ b/fusil/python/fusil_malloc_shim.c
@@ -1,0 +1,194 @@
+/* fusil_malloc_shim.c -- LD_PRELOAD allocation-failure injector.
+ *
+ * The protocol-level analogue of _testcapi.set_nomemory, but at the C malloc() layer, so it
+ * reaches FOREIGN C-library allocations (HDF5, zstd, libxml2, openssl, ...) that set_nomemory
+ * (which only hooks CPython's PyMem allocators) structurally cannot.
+ *
+ * Control API (call from Python via ctypes.CDLL(None)). Signature is a drop-in for
+ * _testcapi.set_nomemory(start, stop):
+ *   void fusil_malloc_arm(long start, long stop);
+ *       Reset the allocation counter and fail allocations numbered [start, stop).
+ *       stop <= 0 means "fail forever from start" (the legacy single-call semantics).
+ *   void fusil_malloc_disarm(void);
+ *       Stop failing allocations.
+ *   long fusil_malloc_count(void);
+ *       Allocations seen since the last arm (diagnostics).
+ *
+ * Deterministic + windowed, exactly like set_nomemory, so crashes stay replayable/dedup-able.
+ *
+ * Build: cc -shared -fPIC -O2 -o fusil_malloc_shim.so fusil_malloc_shim.c -ldl
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <stddef.h>
+#include <string.h>
+
+/* Real allocator pointers, resolved lazily from the next object in the link chain. */
+static void *(*real_malloc)(size_t);
+static void *(*real_calloc)(size_t, size_t);
+static void *(*real_realloc)(void *, size_t);
+static void (*real_free)(void *);
+static int (*real_posix_memalign)(void **, size_t, size_t);
+static void *(*real_aligned_alloc)(size_t, size_t);
+
+/* Failure-injection state. armed is release/acquire-synchronised so the window params and the
+ * counter reset are visible to other threads once they observe armed == 1. */
+static atomic_int armed = 0;
+static atomic_long alloc_counter = 0;
+static long fail_start = 0;
+static long fail_end = 0; /* [fail_start, fail_end) fails; LONG_MAX == fail forever */
+
+/* Bootstrap arena for allocations made by dlsym() itself during initialisation (glibc's
+ * dlsym may call calloc). Served before real_* are resolved; never freed (tiny, bounded). */
+static char boot_buf[65536];
+static size_t boot_off = 0;
+static int initializing = 0;
+
+static void *boot_alloc(size_t size)
+{
+    size = (size + 15u) & ~(size_t)15u; /* 16-byte align */
+    if (boot_off + size > sizeof(boot_buf))
+        return NULL;
+    void *p = boot_buf + boot_off;
+    boot_off += size;
+    return p;
+}
+
+static int is_boot_ptr(const void *p)
+{
+    return (const char *)p >= boot_buf && (const char *)p < boot_buf + sizeof(boot_buf);
+}
+
+static void init_reals(void)
+{
+    initializing = 1;
+    real_malloc = dlsym(RTLD_NEXT, "malloc");
+    real_calloc = dlsym(RTLD_NEXT, "calloc");
+    real_realloc = dlsym(RTLD_NEXT, "realloc");
+    real_free = dlsym(RTLD_NEXT, "free");
+    real_posix_memalign = dlsym(RTLD_NEXT, "posix_memalign");
+    real_aligned_alloc = dlsym(RTLD_NEXT, "aligned_alloc");
+    initializing = 0;
+}
+
+/* Return 1 if the current allocation should be failed. Counts only while armed. */
+static int should_fail(void)
+{
+    if (!atomic_load_explicit(&armed, memory_order_acquire))
+        return 0;
+    long n = atomic_fetch_add_explicit(&alloc_counter, 1, memory_order_relaxed);
+    return n >= fail_start && n < fail_end;
+}
+
+/* --- Control API (exported) --- */
+void fusil_malloc_arm(long start, long stop)
+{
+    fail_start = start;
+    fail_end = (stop > 0) ? stop : LONG_MAX; /* set_nomemory(start, stop): stop is absolute */
+    atomic_store_explicit(&alloc_counter, 0, memory_order_relaxed);
+    atomic_store_explicit(&armed, 1, memory_order_release);
+}
+
+void fusil_malloc_disarm(void)
+{
+    atomic_store_explicit(&armed, 0, memory_order_release);
+}
+
+long fusil_malloc_count(void)
+{
+    return atomic_load_explicit(&alloc_counter, memory_order_relaxed);
+}
+
+/* --- Interposed allocators --- */
+void *malloc(size_t size)
+{
+    if (!real_malloc) {
+        if (initializing)
+            return boot_alloc(size);
+        init_reals();
+    }
+    if (should_fail()) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_malloc(size);
+}
+
+void *calloc(size_t nmemb, size_t size)
+{
+    if (!real_calloc) {
+        if (initializing) {
+            void *p = boot_alloc(nmemb * size);
+            if (p)
+                memset(p, 0, nmemb * size);
+            return p;
+        }
+        init_reals();
+    }
+    if (should_fail()) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_calloc(nmemb, size);
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    if (!real_realloc) {
+        if (initializing)
+            return boot_alloc(size);
+        init_reals();
+    }
+    if (is_boot_ptr(ptr)) {
+        /* Was served from the bootstrap arena: migrate to a real allocation. */
+        if (should_fail()) {
+            errno = ENOMEM;
+            return NULL;
+        }
+        void *p = real_malloc(size);
+        if (p && ptr) {
+            size_t avail = (size_t)((boot_buf + boot_off) - (char *)ptr);
+            memcpy(p, ptr, size < avail ? size : avail);
+        }
+        return p;
+    }
+    if (should_fail()) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_realloc(ptr, size);
+}
+
+void free(void *ptr)
+{
+    if (is_boot_ptr(ptr))
+        return; /* bootstrap arena is never freed */
+    if (!real_free)
+        init_reals();
+    if (real_free)
+        real_free(ptr);
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size)
+{
+    if (!real_posix_memalign)
+        init_reals();
+    if (should_fail())
+        return ENOMEM;
+    return real_posix_memalign(memptr, alignment, size);
+}
+
+void *aligned_alloc(size_t alignment, size_t size)
+{
+    if (!real_aligned_alloc)
+        init_reals();
+    if (should_fail()) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return real_aligned_alloc(alignment, size);
+}

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -299,7 +299,32 @@ class WritePythonCode(WriteCode):
         )
         self.emptyLine()
 
-        if self.options.oom_fuzz:
+        if self.options.oom_fuzz and self.options.oom_foreign:
+            # Foreign-allocator OOM: arm the LD_PRELOAD malloc shim (via ctypes) instead of
+            # _testcapi.set_nomemory. `fusil_malloc_arm(start, stop)` is a drop-in for
+            # set_nomemory, so oom_call/oom_run below use `_set_nomemory` unchanged. The shim
+            # is static LD_PRELOAD interposition -- no allocator swap -- so the one-time
+            # install dance the _testcapi path needs does not apply here.
+            self.write_block(
+                0,
+                """
+                import faulthandler
+                faulthandler.enable()
+                import ctypes
+                try:
+                    _set_nomemory = ctypes.CDLL(None).fusil_malloc_arm
+                    _set_nomemory.argtypes = (ctypes.c_long, ctypes.c_long)
+                    _OOM_AVAILABLE = True
+                except (OSError, AttributeError):
+                    _OOM_AVAILABLE = False
+                    print("--oom-foreign requested but fusil_malloc_shim not preloaded (LD_PRELOAD); running without injection", file=stderr)
+                _OOM_DISABLE = 2_000_000_000
+                if _OOM_AVAILABLE:
+                    _set_nomemory(_OOM_DISABLE, 0)
+            """,
+            )
+            self.emptyLine()
+        elif self.options.oom_fuzz:
             self.write_block(
                 0,
                 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ where = ["."]
 include = ["fusil*"]
 namespaces = false
 
+# Ship the LD_PRELOAD malloc-failure shim source (compiled on demand by --oom-foreign).
+[tool.setuptools.package-data]
+"fusil.python" = ["*.c"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py313"

--- a/tests/python/test_foreign_oom.py
+++ b/tests/python/test_foreign_oom.py
@@ -1,0 +1,74 @@
+"""Tests for the foreign-allocator OOM shim (fusil/python/fusil_malloc_shim.c + foreign_oom.py).
+
+Verifies the shim compiles/caches and that, once LD_PRELOADed, ``fusil_malloc_arm(start, stop)``
+injects malloc failures deterministically (the drop-in set_nomemory semantics) and recovers.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
+
+from fusil.python.foreign_oom import get_shim_path
+
+_HAVE_CC = bool(shutil.which("cc") or shutil.which("gcc") or shutil.which("clang"))
+
+
+@unittest.skipUnless(_HAVE_CC, "needs a C compiler to build the malloc shim")
+class TestForeignOOMShim(unittest.TestCase):
+    def test_get_shim_path_compiles_and_caches(self):
+        path = get_shim_path()
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(path.endswith(".so"))
+        self.assertEqual(get_shim_path(), path)  # second call hits the cache
+
+    def test_shim_injects_and_recovers(self):
+        shim = get_shim_path()
+        # Under LD_PRELOAD, malloc resolved via CDLL(None) is the interposed shim malloc.
+        # arm a window covering ctypes call overhead, then a malloc must return NULL; after
+        # disarm it must succeed again. Windowed => deterministic (set_nomemory semantics).
+        snippet = textwrap.dedent(
+            """
+            import ctypes
+            me = ctypes.CDLL(None)
+            me.malloc.restype = ctypes.c_void_p
+            me.malloc.argtypes = [ctypes.c_size_t]
+            me.free.argtypes = [ctypes.c_void_p]
+            arm = me.fusil_malloc_arm
+            arm.argtypes = [ctypes.c_long, ctypes.c_long]
+            disarm = me.fusil_malloc_disarm
+
+            arm(0, 200)              # fail allocations [0, 200)
+            p = me.malloc(4096)
+            disarm()
+            armed_failed = not p
+            if p:
+                me.free(p)
+
+            q = me.malloc(4096)      # disarmed: succeeds
+            disarmed_ok = bool(q)
+            if q:
+                me.free(q)
+
+            print("PASS" if (armed_failed and disarmed_ok) else "FAIL")
+            """
+        )
+        env = dict(os.environ, LD_PRELOAD=shim)
+        proc = subprocess.run(
+            [sys.executable, "-c", snippet],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip().splitlines()[-1], "PASS", proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_golden_output.py
+++ b/tests/python/test_golden_output.py
@@ -61,6 +61,8 @@ class _Options:
     oom_seq = False
     oom_seq_len = 3
     oom_window = 1
+    oom_foreign = False
+    oom_foreign_pythonmalloc = False
 
 
 class _Parent:

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -42,6 +42,8 @@ def _make_options(oom_fuzz, oom_verbose=False):
     # General generation knobs
     o.fuzz_exceptions = False
     o.gc_aggressive = False
+    o.oom_foreign = False
+    o.oom_foreign_pythonmalloc = False
     o.test_private = False
     o.no_numpy = True
     o.no_tstrings = True
@@ -77,6 +79,7 @@ def _generate(
     oom_seq_len=3,
     oom_window=1,
     oom_seq_randomize=False,
+    oom_foreign=False,
 ):
     """Generate a fuzzing script against ``module`` and return its source."""
     parent = MagicMock()
@@ -88,6 +91,7 @@ def _generate(
     options.oom_seq_len = oom_seq_len
     options.oom_window = oom_window
     options.oom_seq_randomize = oom_seq_randomize
+    options.oom_foreign = oom_foreign
     parent.options = options
     parent.filenames = ["/bin/sh"]
     fd, path = tempfile.mkstemp(suffix="_oom_test.py")
@@ -300,6 +304,27 @@ class TestOOMSeqGeneration(unittest.TestCase):
         src = _generate(oom_fuzz=True, oom_seq=False)
         for marker in ("oom_run", "_OOM_WINDOW", "[OOM-SEQ]", "_oom_seq_"):
             self.assertNotIn(marker, src, f"unexpected seq artifact {marker!r} without --oom-seq")
+
+
+class TestForeignOOMGeneration(unittest.TestCase):
+    """--oom-foreign arms the LD_PRELOAD malloc shim (via ctypes) instead of set_nomemory."""
+
+    def test_foreign_mode_arms_shim_via_ctypes(self):
+        src = _generate(oom_fuzz=True, oom_foreign=True)
+        ast.parse(src)
+        # arms the shim's fusil_malloc_arm, resolved from the preloaded lib
+        self.assertIn("fusil_malloc_arm", src)
+        self.assertIn("ctypes.CDLL(None)", src)
+        # does NOT use the _testcapi backend in foreign mode
+        self.assertNotIn("from _testcapi import set_nomemory", src)
+        # but still emits the shared OOM harness (aliased to _set_nomemory)
+        self.assertIn("oom_call", src)
+        self.assertIn("_set_nomemory", src)
+
+    def test_default_mode_uses_testcapi_not_shim(self):
+        src = _generate(oom_fuzz=True, oom_foreign=False)
+        self.assertIn("from _testcapi import set_nomemory", src)
+        self.assertNotIn("fusil_malloc_arm", src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements **reproducer technique F** — "OOM mode part 2". `set_nomemory` only hooks CPython's
PyMem allocators; it **cannot** reach `malloc`/`calloc`/`realloc` inside foreign C libraries an
extension links (HDF5, zstd, libxml2, openssl, …). `--oom-foreign` closes that gap.

## Design: our own shim, not libfiu

`libfiu` isn't installed here (and rarely is), and its natural mode is *probabilistic*
(not replayable). Instead, a small custom `LD_PRELOAD` shim mirrors `set_nomemory`'s
**deterministic, windowed** semantics exactly — so foreign-allocator crashes stay
replayable/dedup-able, and it drops straight into the existing OOM harness. (Confirmed both
choices with you first.)

- **`fusil/python/fusil_malloc_shim.c`** — interposes `malloc`/`calloc`/`realloc`/`free`/
  `posix_memalign`/`aligned_alloc` via `dlsym(RTLD_NEXT)` (+ a bootstrap arena for the
  dlsym-time allocation), atomic counter. Exports **`fusil_malloc_arm(start, stop)`** — a
  *drop-in* for `_testcapi.set_nomemory` (same `[start, stop)` window semantics) — plus
  `fusil_malloc_disarm`/`fusil_malloc_count`.
- **`fusil/python/foreign_oom.py`** — compiles the shim once (cached by source hash under
  `XDG_CACHE_HOME`), returns the `.so`; `ForeignOOMError` if no compiler.
- **Launcher** — `--oom-foreign` implies `--oom-fuzz`, compiles the shim, sets `LD_PRELOAD`
  (+ `PYTHONMALLOC=malloc` under `--oom-foreign-pythonmalloc`) on the child env.
- **Harness** — in foreign mode the OOM header arms the shim via
  `ctypes.CDLL(None).fusil_malloc_arm` aliased to `_set_nomemory`, so `oom_call`/`oom_run`
  sweep it **unchanged**; the `_testcapi` backend is used otherwise.
- **Replay** already embeds the child env → `LD_PRELOAD` carries into `replay.py` (verified).
- `pyproject` ships the `.c` as package data.

Caveat: not for ASan-instrumented targets (ASan owns the allocator).

## Verification

- Standalone POC: a **separately-compiled** library's internal `malloc` fails on cue; windowed
  `arm(2,5)` → `..XXX.`; fail-forever `arm(1,0)` → `.XXX` (exact `set_nomemory` semantics).
- **354 tests OK** — `test_foreign_oom.py` compiles the shim and LD_PRELOAD-arms a subprocess;
  `test_oom_fuzz.py::TestForeignOOMGeneration` checks the harness arms via ctypes (not `_testcapi`).
  Golden **unchanged**; `ruff` clean.
- A real `--oom-fuzz --oom-foreign --modules zlib` run preloads the shim (`Foreign-OOM:
  LD_PRELOAD=…`), fuzzes cleanly, and the kept `replay.py` embeds the `LD_PRELOAD` + `source.py`
  arms `fusil_malloc_arm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)