### PR TITLE
fix(python): blacklist _pyrepl._module_completer (auto-imports arbitrary modules)

### DIFF
--- a/fusil/python/blacklists.py
+++ b/fusil/python/blacklists.py
@@ -38,6 +38,12 @@ MODULE_BLACKLIST = {
     "xxlimited_35",
     "xxsubtype",
     "tkinter",
+    # The REPL's module-name completer imports arbitrary modules (via importlib) to offer
+    # completions; fuzzing it reaches _get_import_completion_action's unguarded
+    # importlib.import_module(), which bypasses the completer's own AUTO_IMPORT_DENYLIST and
+    # imports side-effect modules -- e.g. antigravity (opens a browser to xkcd/353). Like
+    # pydoc, it's an arbitrary-module importer, not a useful fuzz target.
+    "_pyrepl._module_completer",
 }
 CTYPES = {
     "PyObj_FromPtr",

--- a/tests/python/test_blacklists.py
+++ b/tests/python/test_blacklists.py
@@ -49,6 +49,11 @@ class TestKnownEntriesPresent(unittest.TestCase):
     def test_builtins_pow_round(self):
         self.assertEqual(bl.BUILTINS, {"pow", "round"})
 
+    def test_module_completer_blacklisted(self):
+        # It auto-imports arbitrary modules for REPL completion (side effects: antigravity
+        # opens a browser); must not be fuzzed. See blacklists.py comment.
+        self.assertIn("_pyrepl._module_completer", bl.MODULE_BLACKLIST)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Symptom
Fuzzing occasionally opened a browser to `https://xkcd.com/353/` — the side effect of
`import antigravity` — ~twice in many thousand sessions.

## Root cause (traced, not guessed)
Discovery does **not** import `antigravity` (it's correctly blacklisted; verified empirically).
Only two target-stdlib files reference `antigravity`, and one is live:
**`_pyrepl/_module_completer.py`** — the REPL's module-name tab-completer. It `importlib.import_module()`s
modules to offer completions, and keeps its own `AUTO_IMPORT_DENYLIST`:
```python
AUTO_IMPORT_DENYLIST = { re.compile(r"antigravity"),  # Calls webbrowser.open
                         re.compile(r"idlelib\..+"), re.compile(r"test\..+"),
                         re.compile(r"this"), re.compile(r"_ios_support"),
                         re.compile(r".+\.__main__") }
```
`_maybe_import_module` honours that denylist — but `_get_import_completion_action`'s `_do_import`
closure calls `importlib.import_module(path)` **without** re-checking it (it's the interactive
"press again to import" action). fusil fuzzing the completer reaches that unguarded import and
rarely imports a side-effect module → antigravity opens a browser. (Rare because it needs the
`antigravity` completion path.)

## Fix
Like `pydoc` (already blacklisted), `_pyrepl._module_completer` is an arbitrary-module importer
with no useful fuzz surface — blacklist it. A full discovery no longer yields it; other
`_pyrepl` submodules stay fuzzable.

Not caused by the recent `--oom-foreign`/bomb work — a pre-existing side-effect source the fleet
happened to hit. (Its `AUTO_IMPORT_DENYLIST` is a handy cross-check: `idlelib.*`/`this`/`test.*`/
`*.__main__` are already handled by fusil; `_ios_support` — spawns a subprocess — is a candidate
for a future blacklist add.)

## Verification
358 tests OK (+ `test_module_completer_blacklisted`), `ruff` clean, and a real discovery
confirms `_pyrepl._module_completer` is excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)