### PR TITLE
fix(oom): bomb random alias + world-readable shim cache

### DIFF
--- a/fusil/python/foreign_oom.py
+++ b/fusil/python/foreign_oom.py
@@ -16,6 +16,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -24,8 +25,24 @@ _SHIM_SOURCE = Path(__file__).with_name("fusil_malloc_shim.c")
 
 
 def _cache_dir() -> Path:
-    base = os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")
-    return Path(base) / "fusil"
+    # A world-readable shared dir, NOT ~/.cache: the parent compiles the shim (typically as
+    # root), but the fuzzed child runs as the dropped-privilege ``fusil`` user and must be able
+    # to traverse the dir and open the .so to LD_PRELOAD it. ~/.cache is 0700 (root's home is
+    # untraversable by the child), which made ld.so report "cannot be preloaded".
+    return Path(tempfile.gettempdir()) / "fusil-shim"
+
+
+def _make_child_readable(cache_dir: Path, so_path: Path) -> None:
+    """Best-effort: let the dropped-privilege child traverse the cache dir and read the .so.
+
+    The parent (often root) builds the shim; the child (``fusil`` user) LD_PRELOADs it, so both
+    the directory (needs +x to traverse) and the .so (needs +r) must be world-accessible.
+    """
+    for path, mode in ((cache_dir, 0o755), (so_path, 0o644)):
+        try:
+            os.chmod(path, mode)
+        except OSError:  # pragma: no cover - perms are best-effort (e.g. not owner)
+            pass
 
 
 class ForeignOOMError(Exception):
@@ -47,6 +64,7 @@ def get_shim_path() -> str:
     cache_dir = _cache_dir()
     so_path = cache_dir / ("fusil_malloc_shim_%s.so" % digest)
     if so_path.exists():
+        _make_child_readable(cache_dir, so_path)
         return str(so_path)
 
     compiler = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
@@ -64,4 +82,5 @@ def get_shim_path() -> str:
     except subprocess.CalledProcessError as err:
         raise ForeignOOMError("failed to build malloc shim: %s" % (err.stderr or err)) from err
     os.replace(tmp_so, so_path)  # atomic publish
+    _make_child_readable(cache_dir, so_path)
     return str(so_path)

--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -19,7 +19,10 @@ This module is embedded verbatim into generated fuzzing scripts, so it must stay
 self-contained (only ``random`` + builtins) and import-safe.
 """
 
-import random
+# Import the random *module* under a private alias. The generated script's boilerplate does
+# ``from random import ..., random``, which rebinds the bare name ``random`` to the random()
+# *function*; a private alias keeps this embedded code reaching the module's randint/choice.
+import random as _bomb_random
 
 # Weighted toward MemoryError (the unguarded-PyErr_Clear / swallowed-error bug class) but
 # spanning the exceptions C code is most likely to mishandle when a slot raises unexpectedly.
@@ -41,7 +44,7 @@ _BOMB_EXCEPTIONS = (
 
 
 def _bomb_exc(exc=None):
-    return exc if exc is not None else random.choice(_BOMB_EXCEPTIONS)
+    return exc if exc is not None else _bomb_random.choice(_BOMB_EXCEPTIONS)
 
 
 class _BombBase:
@@ -49,7 +52,7 @@ class _BombBase:
 
     def __init__(self, max_delay=3, exc=MemoryError):
         self._calls = 0
-        self._delay = random.randint(0, max_delay)
+        self._delay = _bomb_random.randint(0, max_delay)
         self._exc = exc
 
     def _fire(self):
@@ -143,7 +146,7 @@ class FailingIterator:
 
     def __init__(self, max_items=4, exc=None):
         self._i = 0
-        self._n = random.randint(0, max_items)
+        self._n = _bomb_random.randint(0, max_items)
         self._exc = exc
 
     def __iter__(self):
@@ -255,7 +258,7 @@ class SuperBomb(metaclass=_SuperBombMeta):
         # object.__setattr__: __setattr__ itself is not armed, but keep construction robust
         # regardless of what a subclass/metaclass does.
         object.__setattr__(self, "_bomb_calls", {})
-        object.__setattr__(self, "_bomb_delay", random.randint(0, max_delay))
+        object.__setattr__(self, "_bomb_delay", _bomb_random.randint(0, max_delay))
 
 
 # --- File-like bombs (target the common "try fd, else .read()" C pattern) ----------------
@@ -366,7 +369,7 @@ class _StatefulHashMeta(type):
     def __new__(mcls, name, bases, namespace):
         cls = super().__new__(mcls, name, bases, namespace)
         # list cell so __hash__ can mutate without triggering __setattr__ machinery
-        cls._bomb_hash_state = [0, random.randint(0, 3)]
+        cls._bomb_hash_state = [0, _bomb_random.randint(0, 3)]
         return cls
 
     def __hash__(cls):

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -390,7 +390,10 @@ This module is embedded verbatim into generated fuzzing scripts, so it must stay
 self-contained (only ``random`` + builtins) and import-safe.
 """
 
-import random
+# Import the random *module* under a private alias. The generated script's boilerplate does
+# ``from random import ..., random``, which rebinds the bare name ``random`` to the random()
+# *function*; a private alias keeps this embedded code reaching the module's randint/choice.
+import random as _bomb_random
 
 # Weighted toward MemoryError (the unguarded-PyErr_Clear / swallowed-error bug class) but
 # spanning the exceptions C code is most likely to mishandle when a slot raises unexpectedly.
@@ -412,7 +415,7 @@ _BOMB_EXCEPTIONS = (
 
 
 def _bomb_exc(exc=None):
-    return exc if exc is not None else random.choice(_BOMB_EXCEPTIONS)
+    return exc if exc is not None else _bomb_random.choice(_BOMB_EXCEPTIONS)
 
 
 class _BombBase:
@@ -420,7 +423,7 @@ class _BombBase:
 
     def __init__(self, max_delay=3, exc=MemoryError):
         self._calls = 0
-        self._delay = random.randint(0, max_delay)
+        self._delay = _bomb_random.randint(0, max_delay)
         self._exc = exc
 
     def _fire(self):
@@ -514,7 +517,7 @@ class FailingIterator:
 
     def __init__(self, max_items=4, exc=None):
         self._i = 0
-        self._n = random.randint(0, max_items)
+        self._n = _bomb_random.randint(0, max_items)
         self._exc = exc
 
     def __iter__(self):
@@ -626,7 +629,7 @@ class SuperBomb(metaclass=_SuperBombMeta):
         # object.__setattr__: __setattr__ itself is not armed, but keep construction robust
         # regardless of what a subclass/metaclass does.
         object.__setattr__(self, "_bomb_calls", {})
-        object.__setattr__(self, "_bomb_delay", random.randint(0, max_delay))
+        object.__setattr__(self, "_bomb_delay", _bomb_random.randint(0, max_delay))
 
 
 # --- File-like bombs (target the common "try fd, else .read()" C pattern) ----------------
@@ -737,7 +740,7 @@ class _StatefulHashMeta(type):
     def __new__(mcls, name, bases, namespace):
         cls = super().__new__(mcls, name, bases, namespace)
         # list cell so __hash__ can mutate without triggering __setattr__ machinery
-        cls._bomb_hash_state = [0, random.randint(0, 3)]
+        cls._bomb_hash_state = [0, _bomb_random.randint(0, 3)]
         return cls
 
     def __hash__(cls):

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -131,6 +131,30 @@ class TestMetaclassBombs(unittest.TestCase):
             hash(T)
 
 
+class TestRandomShadowing(unittest.TestCase):
+    """Regression for the fleet bug (2026-07-02): the generated script's boilerplate emits
+    ``from random import choice, randint, random``, which rebinds the bare name ``random`` to
+    the random() *function*, shadowing the module. The embedded bomb source must reach
+    randint/choice via its private ``_bomb_random`` alias -- otherwise ``IndexBomb()`` etc.
+    die with ``AttributeError: 'builtin_function_or_method' object has no attribute 'randint'``.
+    """
+
+    def test_bombs_construct_with_random_name_shadowed(self):
+        # Mirror the generated boilerplate: `random` is now the function, not the module.
+        from random import choice, randint, random
+
+        ns = {"choice": choice, "randint": randint, "random": random}
+        # Precondition that made the old code fail: the shadowing `random` has no randint.
+        self.assertFalse(hasattr(ns["random"], "randint"))
+        # exec the source exactly as embedded into generated scripts. This also defines the
+        # type bombs, whose metaclasses call _bomb_random.randint at class-creation time.
+        exec(tricky_weird.bomb_objects, ns)
+        for name in B.BOMB_CLASS_NAMES:
+            ns[name]()  # must construct despite the shadow (regression: AttributeError)
+        for name in B.BOMB_TYPE_NAMES:
+            self.assertIsInstance(ns[name], type)
+
+
 class TestGeneratorWiring(unittest.TestCase):
     def test_all_class_names_construct_with_no_args(self):
         for name in B.BOMB_CLASS_NAMES:

--- a/tests/python/test_foreign_oom.py
+++ b/tests/python/test_foreign_oom.py
@@ -6,6 +6,7 @@ injects malloc failures deterministically (the drop-in set_nomemory semantics) a
 
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import textwrap
@@ -14,7 +15,7 @@ import unittest
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
 
-from fusil.python.foreign_oom import get_shim_path
+from fusil.python.foreign_oom import _cache_dir, get_shim_path
 
 _HAVE_CC = bool(shutil.which("cc") or shutil.which("gcc") or shutil.which("clang"))
 
@@ -26,6 +27,19 @@ class TestForeignOOMShim(unittest.TestCase):
         self.assertTrue(os.path.exists(path))
         self.assertTrue(path.endswith(".so"))
         self.assertEqual(get_shim_path(), path)  # second call hits the cache
+
+    def test_shim_and_cache_dir_are_child_readable(self):
+        # Regression (2026-07-02): the parent builds the shim (often as root), but the fuzzed
+        # child runs as the dropped-privilege `fusil` user and LD_PRELOADs it. When the shim
+        # lived in root's 0700 ~/.cache, ld.so reported "cannot be preloaded". The cache dir
+        # must be world-traversable (+x) and the .so world-readable (+r).
+        path = get_shim_path()
+        so_mode = os.stat(path).st_mode
+        self.assertTrue(so_mode & stat.S_IROTH, f"shim .so not world-readable: {oct(so_mode)}")
+        dir_mode = os.stat(_cache_dir()).st_mode
+        self.assertTrue(
+            dir_mode & stat.S_IXOTH, f"cache dir not world-traversable: {oct(dir_mode)}"
+        )
 
     def test_shim_injects_and_recovers(self):
         shim = get_shim_path()


### PR DESCRIPTION
Two fleet-surfaced fixes for the recent bomb / `--oom-foreign` features (both discovered running the fleet under `--oom-foreign --gc-aggressive`).

## Bug 1 — bomb objects crash on `random.randint`

Fleet stdout showed:

```
AttributeError: 'builtin_function_or_method' object has no attribute 'randint'
```

at `IndexBomb()` → `self._delay = random.randint(...)`. Root cause: the generated script's boilerplate emits `from random import choice, randint, random`, which rebinds the bare name `random` to the `random()` **function**, shadowing the module before the embedded bomb source runs.

Fix: `bomb_objects.py` imports the module under a private alias (`import random as _bomb_random`) and reaches `randint`/`choice` through it, so the embedded code is immune to the shadowing. The golden snapshot is regenerated (the bomb source is embedded verbatim into generated scripts).

## Bug 2 — `--oom-foreign` shim fails to preload

Fleet stdout showed:

```
ERROR: ld.so: object '/root/.cache/fusil/fusil_malloc_shim_*.so' from LD_PRELOAD
cannot be preloaded (cannot open shared object file): ignored.
--oom-foreign requested but fusil_malloc_shim not preloaded ... running without injection
```

Root cause: the parent compiles the shim as root and caches it in root's `~/.cache` (0700); the fuzzed child runs as the dropped-privilege `fusil` user and cannot traverse root's home to open the `.so`.

Fix: move the cache to a world-readable shared dir (`<tmpdir>/fusil-shim`) and best-effort `chmod` the dir (+x) and the `.so` (+r) so the child can `LD_PRELOAD` it — applied on both the build path and the cache-hit path.

## Tests

- `test_bomb_objects.py`: bombs construct with `random` shadowed by the function (reproduces Bug 1).
- `test_foreign_oom.py`: the shim `.so` is world-readable and its cache dir world-traversable (reproduces Bug 2).

Full suite **360 OK**; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)