### PR TITLE
fix(fuzzer): skip missing target modules + keep bombs out of set/dict keys

### DIFF
--- a/fusil/python/argument_generator.py
+++ b/fusil/python/argument_generator.py
@@ -157,11 +157,15 @@ class ArgumentGenerator:
 
         self.hashable_argument_generators = safe_hashable_generators
         if allow_external_references:
-            # The 'errback' name is hashable but is an external reference. Bombs are hashable
-            # too (HashBomb/EqBomb/SuperBomb arm __hash__/__eq__) -- as dict keys / set members
-            # they hit the container insert & lookup error paths.
+            # The 'errback' name is hashable but is an external reference.
             self.hashable_argument_generators += (self.genErrback,)
-            self.hashable_argument_generators += (self.genBombObject,) * BOMB_WEIGHT
+            # NOTE: bombs are deliberately NOT added to the hashable pool. A bomb in a
+            # set-member / dict-key position is hashed when the container *literal* is built by
+            # the harness -- which frequently happens at module scope, outside the per-call
+            # try/except. A raising __hash__ (SuperBomb, or a HashBomb that drew delay 0) then
+            # detonates during harness construction, killing the whole script (exit 1) before
+            # any target call is reached, rather than exercising the target's C code. Bombs
+            # still reach the target as direct arguments and as list/tuple/dict-*value* elements.
 
         # Build the final lists based on the flag
         self.simple_argument_generators = safe_simple_generators

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -284,7 +284,22 @@ class WritePythonCode(WriteCode):
             self.write(0, "from string.templatelib import Interpolation, Template")
 
         self.write_print_to_stderr(0, f'"Importing target module: {self.module_name}"')
-        self.write(0, f"import {self.module_name}")
+        # The parent discovers importable modules in ITS interpreter; the target interpreter
+        # may not have them (e.g. pexpect/ptyprocess are importable in the parent env but absent
+        # in the target build). A missing target module is an environment mismatch, not a crash,
+        # so exit cleanly (0) -- otherwise the bare import raises ModuleNotFoundError, the script
+        # dies with a non-zero code, and --exitcode-score scores it as a spurious finding.
+        self.write(0, "try:")
+        with self.indented():
+            self.write(0, f"import {self.module_name}")
+        self.write(0, "except ImportError as _fusil_import_error:")
+        with self.indented():
+            self.write_print_to_stderr(
+                0,
+                f'"FUSIL: target module {self.module_name} not importable (skipping):",'
+                " repr(_fusil_import_error)",
+            )
+            self.write(0, "raise SystemExit(0)")
         self.emptyLine()
 
         self.write(

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -17,7 +17,11 @@ import asyncio
 seed(946466063)
 
 print("Importing target module: fakemod", file=stderr)
-import fakemod
+try:
+    import fakemod
+except ImportError as _fusil_import_error:
+    print("FUSIL: target module fakemod not importable (skipping):", repr(_fusil_import_error), file=stderr)
+    raise SystemExit(0)
 
 TRIVIAL_TYPES = {int, str, float, bool, bytes, tuple, list, dict, set, type(None),}
 def skip_trivial_type(obj_instance_or_class):

--- a/tests/python/test_argument_generator.py
+++ b/tests/python/test_argument_generator.py
@@ -370,6 +370,33 @@ class TestArgumentGenerator(unittest.TestCase):
             self._check_if_generator_in_tuple("genTrickyTemplate", "complex_argument_generators")
         )
 
+    def test_bombs_excluded_from_hashable_pool(self):
+        """Regression: bombs must NOT be in the set-member/dict-key (hashable) pool. A bomb there
+        is hashed when the harness builds the container *literal* -- frequently at module scope,
+        outside the per-call try/except -- so a raising __hash__ (SuperBomb, or a HashBomb that
+        drew delay 0) detonates during construction, killing the whole script (exit 1) before any
+        target call. Bombs must stay in the simple/complex pools so they still reach target C."""
+        self.assertFalse(
+            self._check_if_generator_in_tuple("genBombObject", "hashable_argument_generators")
+        )
+        # coverage preserved: bombs still reach the target as ordinary and complex arguments
+        self.assertTrue(
+            self._check_if_generator_in_tuple("genBombObject", "simple_argument_generators")
+        )
+        self.assertTrue(
+            self._check_if_generator_in_tuple("genBombObject", "complex_argument_generators")
+        )
+        # and no bomb ever surfaces through an actual hashable (set/dict-key) draw
+        from fusil.python.samples import bomb_objects as bombs
+
+        bomb_names = set(bombs.BOMB_CLASS_NAMES) | set(bombs.BOMB_TYPE_NAMES)
+        for _ in range(2000):
+            expr = "".join(self.arg_gen.create_hashable_argument())
+            self.assertFalse(
+                any(name in expr for name in bomb_names),
+                f"bomb leaked into a hashable (set/dict-key) position: {expr!r}",
+            )
+
     def test_create_simple_argument_variety(self):
         """Try to detect if create_simple_argument uses different sub-generators."""
         self._setup_arg_gen(

--- a/tests/python/test_write_python_code.py
+++ b/tests/python/test_write_python_code.py
@@ -441,6 +441,22 @@ class TestWritePythonCode(unittest.TestCase):
         # Check that at least one function call was generated
         self.assertIn('callFunc("f1",', full_script)
 
+    def test_target_import_guarded_for_missing_module(self):
+        """Regression: the target import is wrapped so a module absent from the CHILD interpreter
+        (e.g. pexpect/ptyprocess discovered in the parent env but not installed in the target
+        build) exits cleanly (SystemExit 0) instead of dying with ModuleNotFoundError -- which
+        --exitcode-score would otherwise score as a spurious finding."""
+        output_stream = StringIO()
+        self.writer.output = output_stream
+        self.writer._write_script_header_and_imports()
+        header = output_stream.getvalue()
+
+        ast.parse(header)  # syntactically valid
+        self.assertIn("try:", header)
+        self.assertIn(f"import {self.writer.module_name}", header)
+        self.assertIn("except ImportError as", header)
+        self.assertIn("raise SystemExit(0)", header)
+
     # --- Wiring and Call Order Tests ---
 
     def test_generate_fuzzing_script_call_order(self):


### PR DESCRIPTION
Two fleet-noise fixes surfaced by triaging the first `fusil-fleet3` (`--oom-foreign`) run. Neither is a target bug; both were inflating the crash signal.

## 1. Guard the target import (parent/child env mismatch)

Module discovery runs `pkgutil.walk_packages` in the **parent** interpreter, which can have modules the **target** build lacks (in fleet3, `pexpect`/`ptyprocess` were importable in the parent env but not installed in the target). The generated script's bare `import <module>` then died with `ModuleNotFoundError` → non-zero exit → **scored as a spurious finding under `--exitcode-score`** (25 noise dirs).

Fix: emit the target import wrapped so a module absent from the child is a clean skip, not a crash:

```python
try:
    import <module>
except ImportError as _fusil_import_error:
    print("FUSIL: target module <module> not importable (skipping):", repr(_fusil_import_error), file=stderr)
    raise SystemExit(0)
```

`SystemExit(0)` = exit 0 → not scored, session discarded. (A missing module can't mask a real memory-safety bug — those are signals/aborts, not `ImportError`.)

## 2. Keep exception bombs out of set/dict-key positions

Bombs were in `hashable_argument_generators`, so a bomb could land as a **set member / dict key** in a container *literal* the harness builds — frequently at module scope, outside the per-call `try/except`. A raising `__hash__` (`SuperBomb`, or a `HashBomb` that drew delay 0) then detonated during **harness construction**, killing the whole script (exit 1) before any target call — the bomb never reached the target's C code anyway.

Fix: remove `genBombObject` from `hashable_argument_generators`. Bombs still reach the target as direct arguments and as list/tuple/dict-**value** elements (verified), so no useful coverage is lost.

## Verification

- Regenerated the golden snapshot (import wrapping; the fakemod golden path doesn't use external-reference bombs, so the pool change is correctly a no-op there).
- New regression tests: the target import is guarded (`test_write_python_code`), and bombs never surface in a hashable draw while remaining in the simple/complex pools (`test_argument_generator`).
- Full suite **362 OK**; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)