### PR TITLE
fix(fuzzer): generic/deep-dive method fuzzing uses METHOD_BLACKLIST, not hardcoded names

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -299,6 +299,17 @@ class WritePythonCode(WriteCode):
         )
         self.emptyLine()
 
+        # Emit the method denylist so the generated script's generic / deep-dive method fuzzing
+        # can skip the same hang-prone / false-positive methods the static generation already
+        # filters (locks' acquire, queues' get, sleep, ...). This runtime path previously
+        # hardcoded only ('wait', '_rehash') -- a tiny subset -- instead of reusing METHOD_BLACKLIST.
+        self.write(
+            0,
+            "_FUSIL_METHOD_BLACKLIST = frozenset({%s})"
+            % ", ".join(repr(name) for name in sorted(METHOD_BLACKLIST)),
+        )
+        self.emptyLine()
+
         if self.options.oom_fuzz and self.options.oom_foreign:
             # Foreign-allocator OOM: arm the LD_PRELOAD malloc shim (via ctypes) instead of
             # _testcapi.set_nomemory. `fusil_malloc_arm(start, stop)` is a drop-in for
@@ -963,7 +974,7 @@ class WritePythonCode(WriteCode):
                         )
                         self.write(
                             0,
-                            f"if callable({current_prefix}_attr_val) and not {current_prefix}_attr_val.__name__ in ('wait', '_rehash'): {current_prefix}_methods.append(({current_prefix}_attr_name, {current_prefix}_attr_val))",
+                            f"if callable({current_prefix}_attr_val) and {current_prefix}_attr_name not in _FUSIL_METHOD_BLACKLIST: {current_prefix}_methods.append(({current_prefix}_attr_name, {current_prefix}_attr_val))",
                         )
                     self.write(0, "except Exception: pass")
             self.write(
@@ -993,7 +1004,7 @@ class WritePythonCode(WriteCode):
                     self.write(0, "# Conceptual call to generic method fuzzer")
                     self.write(
                         0,
-                        f"if {current_prefix}_method_name_to_call not in ('wait', '_rehash'): callMethod(f'{current_prefix}_gen{{_i_{current_prefix}}}', {target_obj_expr_str}, {current_prefix}_method_name_to_call)",
+                        f"if {current_prefix}_method_name_to_call not in _FUSIL_METHOD_BLACKLIST: callMethod(f'{current_prefix}_gen{{_i_{current_prefix}}}', {target_obj_expr_str}, {current_prefix}_method_name_to_call)",
                     )  # Example simplified call
         self.emptyLine()
 

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -26,6 +26,8 @@ def skip_trivial_type(obj_instance_or_class):
     return False
 
 
+_FUSIL_METHOD_BLACKLIST = frozenset({'__class__', '__enter__', '__imul__', '__ipow__', '__mul__', '__pow__', '__rmul__', '_acquire_lock', '_acquire_restore', '_handle_request_noblock', '_randbelow', '_randbelow_with_getrandbits', '_read', '_rehash', '_run_once', '_serve', '_shutdown', 'accept', 'acquire', 'acquire_lock', 'cmdloop', 'copyfileobj', 'get', 'get_request', 'handle_request', 'handle_request_noblock', 'prefix', 'raise_signal', 'repeat', 'run_forever', 'select', 'serve_forever', 'shutdown', 'sleep', 'test', 'tri', 'tril_indices', 'wait', 'zfill'})
+
 import sys
 from _collections import OrderedDict, deque
 from abc import ABCMeta
@@ -917,7 +919,7 @@ if instance_c1_widget is not None:
                 if c1_widget_ops_generic_attr_name.startswith('_'): continue
                 try:
                     c1_widget_ops_generic_attr_val = getattr(instance_c1_widget, c1_widget_ops_generic_attr_name)
-                    if callable(c1_widget_ops_generic_attr_val) and not c1_widget_ops_generic_attr_val.__name__ in ('wait', '_rehash'): c1_widget_ops_generic_methods.append((c1_widget_ops_generic_attr_name, c1_widget_ops_generic_attr_val))
+                    if callable(c1_widget_ops_generic_attr_val) and c1_widget_ops_generic_attr_name not in _FUSIL_METHOD_BLACKLIST: c1_widget_ops_generic_methods.append((c1_widget_ops_generic_attr_name, c1_widget_ops_generic_attr_val))
                 except Exception: pass
         except Exception: c1_widget_ops_generic_methods = [] # Failed to get methods
         if c1_widget_ops_generic_methods:
@@ -925,7 +927,7 @@ if instance_c1_widget is not None:
             for _i_c1_widget_ops_generic in range(min(len(c1_widget_ops_generic_methods), 2)):
                 c1_widget_ops_generic_method_name_to_call, c1_widget_ops_generic_method_obj_to_call = choice(c1_widget_ops_generic_methods)
                 # Conceptual call to generic method fuzzer
-                if c1_widget_ops_generic_method_name_to_call not in ('wait', '_rehash'): callMethod(f'c1_widget_ops_generic_gen{_i_c1_widget_ops_generic}', instance_c1_widget, c1_widget_ops_generic_method_name_to_call)
+                if c1_widget_ops_generic_method_name_to_call not in _FUSIL_METHOD_BLACKLIST: callMethod(f'c1_widget_ops_generic_gen{_i_c1_widget_ops_generic}', instance_c1_widget, c1_widget_ops_generic_method_name_to_call)
 
 if instance_c1_widget is not None and instance_c1_widget is not SENTINEL_VALUE:
     print(f"--- Fuzzing instance: instance_c1_widget (type hint: Widget, prefix: c1m) ---", file=stderr)

--- a/tests/python/test_write_python_code.py
+++ b/tests/python/test_write_python_code.py
@@ -441,6 +441,33 @@ class TestWritePythonCode(unittest.TestCase):
         # Check that at least one function call was generated
         self.assertIn('callFunc("f1",', full_script)
 
+    def test_generic_method_fuzzing_uses_method_blacklist(self):
+        """Regression: the generic / deep-dive method-fuzzing path must filter runtime method
+        names through the emitted METHOD_BLACKLIST, not a hardcoded ('wait', '_rehash') subset."""
+        from fusil.python.blacklists import METHOD_BLACKLIST
+
+        # 1. the denylist is emitted into the script as a runtime constant == METHOD_BLACKLIST
+        header_stream = StringIO()
+        self.writer.output = header_stream
+        self.writer._write_script_header_and_imports()
+        header = header_stream.getvalue()
+        self.assertIn("_FUSIL_METHOD_BLACKLIST = frozenset({", header)
+        ns: dict = {}
+        for line in header.splitlines():
+            if line.startswith("_FUSIL_METHOD_BLACKLIST"):
+                exec(line, ns)
+                break
+        self.assertEqual(set(ns["_FUSIL_METHOD_BLACKLIST"]), set(METHOD_BLACKLIST))
+
+        # 2. the full generated script filters through it, with no hardcoded name tuple left
+        full_stream = StringIO()
+        with patch.object(self.writer, "createFile"), patch.object(self.writer, "close"):
+            self.writer.output = full_stream
+            self.writer.generate_fuzzing_script()
+        script = full_stream.getvalue()
+        self.assertNotIn("('wait', '_rehash')", script)
+        self.assertIn("not in _FUSIL_METHOD_BLACKLIST", script)
+
     # --- Wiring and Call Order Tests ---
 
     def test_generate_fuzzing_script_call_order(self):


### PR DESCRIPTION
## The hardcoding

The generic-object / deep-dive method-fuzzing path (`_fuzz_generic_object_methods` in `write_python_code.py`) hardcoded `('wait', '_rehash')` as the *only* method names to skip — in **both** the collection filter and the call guard — instead of reusing the project's `METHOD_BLACKLIST`:

```python
# before (emitted into the generated script):
if callable(v) and not v.__name__ in ('wait', '_rehash'): methods.append(...)
...
if name not in ('wait', '_rehash'): callMethod(..., name)
```

That two-name subset left the deep-dive path calling the hang-prone / false-positive methods the static generation path already filters via `METHOD_BLACKLIST` — e.g. locks' `acquire`, queues' `get`, `sleep`, `shutdown`, `serve_forever`, `accept`. So a deep-dived object could hang the session or trip a spurious signal.

## The fix

Emit the full `METHOD_BLACKLIST` into the generated script as a runtime constant (`_FUSIL_METHOD_BLACKLIST`, next to `TRIVIAL_TYPES`) and filter through it in both places:

```python
_FUSIL_METHOD_BLACKLIST = frozenset({'__class__', ..., 'acquire', 'get', 'sleep', 'wait', '_rehash', ...})
...
if callable(v) and name not in _FUSIL_METHOD_BLACKLIST: methods.append(...)
if name not in _FUSIL_METHOD_BLACKLIST: callMethod(..., name)
```

The generated script's generic/deep-dive method fuzzing now honours the same denylist as the rest of the generator — no hardcoded names.

## Verification

- Regenerated the golden snapshot (the emitted constant + the two filter sites).
- Regression test (`test_generic_method_fuzzing_uses_method_blacklist`): the emitted `_FUSIL_METHOD_BLACKLIST` equals `METHOD_BLACKLIST`, and the full generated script contains no `('wait', '_rehash')` tuple while using `not in _FUSIL_METHOD_BLACKLIST`.
- Full suite **361 OK**; `ruff check` + `ruff format --check` clean.

Independent of #169 (branched off `main`); both touch `write_python_code.py` + the golden, so whichever merges second will want a quick golden regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)