### PR TITLE
feat(fleet): per-session stats sidecar (StatsAgent) + `fleet report` observability

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -34,6 +34,8 @@ and capture their logs — no VMs or containers needed.
 ```bash
 sudo ./fleet up            # start (nproc-1) instances; or: sudo ./fleet up 8
 ./fleet status             # per-instance state + crashes kept + NEW candidates
+./fleet report             # rich observability: sessions, throughput, crash taxonomy, disk, health
+./fleet report 3           # ...for one instance;  add --watch for a live view, --json for scripts
 ./fleet finds              # list the oomNEW dirs across the whole fleet
 ./fleet tail 3             # follow instance 3's output live
 sudo ./fleet down          # stop everything

--- a/fleet/fleet
+++ b/fleet/fleet
@@ -6,6 +6,7 @@
 #   sudo ./fleet down        stop + disable all instances
 #   ./fleet status          per-instance state + crash/NEW-find counts
 #   ./fleet finds           list this fleet's oomNEW (new-bug candidate) dirs
+#   ./fleet report [N]      observability report: per-instance + campaign (--watch, --json, --no-systemd)
 #   ./fleet triage          dedupe oomNEW/oomSEGV candidates across instances (needs INGEST); extra args pass to ingest (e.g. --gdb)
 #   ./fleet tail [N]        follow instance N's log (default: 1)
 #   sudo ./fleet restart    restart all instances (e.g. to pick up a new catalog)
@@ -151,6 +152,15 @@ cmd_triage(){
     fi
 }
 
+cmd_report(){
+    # Observability report (per-instance + campaign). Pure-Python reader; put the repo on
+    # PYTHONPATH so RUNNER_PY can import fusil.python.fleet_report even when fusil isn't
+    # pip-installed in that venv. All args (N, --watch, --json, --no-systemd) pass through.
+    local repo; repo="$(dirname "$(dirname "$FUSIL_PY")")"
+    PYTHONPATH="$repo${PYTHONPATH:+:$PYTHONPATH}" \
+        "$RUNNER_PY" -m fusil.python.fleet_report --fleet-dir "$FLEET_DIR" "$@"
+}
+
 cmd_tail(){
     local i="${1:-1}" dir; dir="$(inst_dir "$i")"
     if [ "${LOG:-file}" = "none" ]; then
@@ -170,6 +180,7 @@ case "${1:-status}" in
     status)   cmd_status ;;
     finds)    cmd_finds ;;
     triage)   shift; cmd_triage "$@" ;;
+    report)   shift; cmd_report "$@" ;;
     tail)     shift; cmd_tail "$@" ;;
-    *)        sed -n '2,13p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
+    *)        sed -n '2,14p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
 esac

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -406,6 +406,12 @@ class Fuzzer(Application):
         self.source = PythonSource(
             project, self.options, source_output_path=self.options.source_output_path
         )
+        # Score-neutral observer: fold each finished session into the run dir's
+        # fusil_stats.json sidecar (read back by `fleet report`). Parent-side only; does not
+        # override getScore(), so it never affects scoring or the generated source.
+        from fusil.python.stats_agent import StatsAgent
+
+        StatsAgent(project, self.source)
         process = PythonProcess(
             project,
             self.options,

--- a/fusil/python/_report_format.py
+++ b/fusil/python/_report_format.py
@@ -1,0 +1,62 @@
+"""Small, dependency-free text-formatting helpers for the fleet reporter.
+
+Adapted from lafleur's observability layer (``lafleur/utils.py``, ``lafleur/report.py``) --
+copied rather than imported so fusil takes no dependency on lafleur. Pure stdlib.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def human_bytes(n: float | None) -> str:
+    """1536 -> '1.5K', 1234567890 -> '1.1G'. None/negative -> '-'."""
+    if n is None or n < 0:
+        return "-"
+    n = float(n)
+    for unit in ("B", "K", "M", "G", "T", "P"):
+        if n < 1024 or unit == "P":
+            if unit == "B":
+                return "%dB" % int(n)
+            return "%.1f%s" % (n, unit)
+        n /= 1024
+    return "%.1fP" % n
+
+
+def format_duration(seconds: float | None) -> str:
+    """90061 -> '1d 1h', 305 -> '5m 5s', None -> '-'. Two most-significant units."""
+    if seconds is None or seconds < 0:
+        return "-"
+    seconds = int(seconds)
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, secs = divmod(rem, 60)
+    parts = []
+    if days:
+        parts += ["%dd" % days, "%dh" % hours]
+    elif hours:
+        parts += ["%dh" % hours, "%dm" % minutes]
+    elif minutes:
+        parts += ["%dm" % minutes, "%ds" % secs]
+    else:
+        parts = ["%ds" % secs]
+    return " ".join(parts[:2])
+
+
+def format_rate(count: int, seconds: float | None) -> str:
+    """Per-minute rate, e.g. 3092 sessions over 2h -> '25.8/m'. '-' if no elapsed time."""
+    if not seconds or seconds <= 0:
+        return "-"
+    return "%.1f/m" % (count / (seconds / 60.0))
+
+
+def dir_size_bytes(path: str) -> int:
+    """Total size of a directory tree in bytes (best-effort; unreadable entries skipped)."""
+    total = 0
+    for root, _dirs, files in os.walk(path, onerror=lambda _e: None):
+        for name in files:
+            try:
+                total += os.lstat(os.path.join(root, name)).st_size
+            except OSError:
+                pass
+    return total

--- a/fusil/python/fleet_report.py
+++ b/fusil/python/fleet_report.py
@@ -1,0 +1,508 @@
+"""`fleet report` -- a text (and JSON) observability report for a fusil fuzzing fleet.
+
+Reads the per-run ``fusil_stats.json`` sidecars written by ``StatsAgent`` and enriches them
+with post-hoc data (kept-crash-dir taxonomy, disk usage, systemd state, current-run
+``fusil.out``) into a per-instance or whole-campaign report. Pure-Python + stdlib +
+best-effort ``systemctl``/``/proc`` -- no runtime stack, so the collection/aggregation logic
+unit-tests on a fixture directory.
+
+Usage::
+
+    python -m fusil.python.fleet_report --fleet-dir DIR            # campaign report
+    python -m fusil.python.fleet_report --fleet-dir DIR 1          # instance 1 only
+    python -m fusil.python.fleet_report --fleet-dir DIR --watch    # live-refresh
+    python -m fusil.python.fleet_report --fleet-dir DIR --json     # machine-readable
+
+Instance/campaign convention (borrowed from lafleur): a "campaign" is a directory whose
+immediate children are ``inst-NN`` instance dirs; a single instance is one ``inst-NN`` dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+from fusil.python._report_format import (
+    dir_size_bytes,
+    format_duration,
+    format_rate,
+    human_bytes,
+)
+from fusil.python.session_stats import SessionStats
+
+# Crash-dir label parsing. A kept crash dir is named "<module>-<kind>-<dedup-label>[-N]",
+# e.g. "_blake2-fatal_python_error-OOM-0043-2". We token-search rather than split so a
+# trailing "-N" collision suffix and multi-part kinds don't confuse attribution.
+_LABEL_RE = re.compile(r"(OOM-\d{3,}|oomNEW|oomSEGV|oomclean|oomimport)")
+_KIND_RE = re.compile(
+    r"(fatal_python_error|systemerror|assertion|sig[a-z]{2,}|exitcode\d+|cpu_load|timeout|bug)"
+)
+_IMPORT_FAIL_RE = re.compile(r"target module (\S+) not importable")
+
+STALE_HEARTBEAT_S = 180  # updated_at older than this on a running instance => "stuck?"
+CHURN_RESTARTS = 5  # this many run dirs (restarts) => flag possible churn
+MEM_CAP_FRACTION = 0.9  # MemoryPeak/MemoryMax above this => flag near-cap
+
+
+# --------------------------------------------------------------------------- collection
+
+
+def classify_crash_dir(name: str) -> tuple[str, str, str]:
+    """(module, kind, dedup_label) for a kept-crash-dir basename; 'other' where unknown."""
+    module = name.split("-", 1)[0]
+    kind = _KIND_RE.search(name)
+    label = _LABEL_RE.search(name)
+    return module, (kind.group(1) if kind else "other"), (label.group(1) if label else "other")
+
+
+def iter_crash_dirs(inst_dir: str) -> list[str]:
+    """Basenames of kept crash dirs (those holding a source.py) under inst-NN/python*/ ."""
+    out = []
+    for run in sorted(_run_dirs(inst_dir)):
+        try:
+            entries = list(os.scandir(run))
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_dir() and os.path.exists(os.path.join(entry.path, "source.py")):
+                out.append(entry.name)
+    return out
+
+
+def _run_dirs(inst_dir: str) -> list[str]:
+    """Absolute paths of the project run dirs (python, python-2, ...) = restart evidence."""
+    try:
+        return [
+            os.path.join(inst_dir, e.name)
+            for e in os.scandir(inst_dir)
+            if e.is_dir() and (e.name == "python" or e.name.startswith("python-"))
+        ]
+    except OSError:
+        return []
+
+
+def load_sidecars(inst_dir: str) -> tuple[dict, dict | None]:
+    """(merged across all run dirs, newest single run dict) from python*/fusil_stats.json."""
+    dicts = []
+    for run in _run_dirs(inst_dir):
+        path = os.path.join(run, "fusil_stats.json")
+        try:
+            dicts.append(SessionStats.load(path))
+        except (OSError, ValueError):
+            continue
+    if not dicts:
+        return SessionStats.merge([]), None
+    newest = max(dicts, key=lambda d: d.get("updated_at") or 0)
+    return SessionStats.merge(dicts), newest
+
+
+def systemd_info(instance_num: int, *, runner=None) -> dict:
+    """Best-effort `systemctl show fusil@N` snapshot; {} if systemd/unit unavailable."""
+    props = "ActiveState,SubState,NRestarts,MemoryCurrent,MemoryPeak,MemoryMax,ActiveEnterTimestamp"
+    runner = runner or (
+        lambda args: subprocess.run(args, capture_output=True, text=True, timeout=5)
+    )
+    try:
+        cp = runner(["systemctl", "show", "fusil@%d" % instance_num, "--property=%s" % props])
+    except Exception:
+        return {}
+    if getattr(cp, "returncode", 1) != 0 and not getattr(cp, "stdout", ""):
+        return {}
+    info = {}
+    for line in (cp.stdout or "").splitlines():
+        if "=" in line:
+            key, _, val = line.partition("=")
+            info[key] = val
+    return info
+
+
+def _proc_cmdline(pid: int | None) -> str | None:
+    if not pid:
+        return None
+    try:
+        with open("/proc/%d/cmdline" % pid, "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    return " ".join(p for p in raw.decode("utf-8", "replace").split("\0") if p) or None
+
+
+def parse_fusil_out(inst_dir: str) -> tuple[dict, str | None]:
+    """(failed-import module -> count, fleet-run header line) from the current-run fusil.out."""
+    path = os.path.join(inst_dir, "fusil.out")
+    failed: dict[str, int] = {}
+    header = None
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if header is None and line.startswith("# fleet-run "):
+                    header = line.rstrip("\n")
+                m = _IMPORT_FAIL_RE.search(line)
+                if m:
+                    failed[m.group(1)] = failed.get(m.group(1), 0) + 1
+    except OSError:
+        pass
+    return failed, header
+
+
+def instance_number(inst_dir: str) -> int:
+    m = re.search(r"(\d+)", os.path.basename(inst_dir))
+    return int(m.group(1)) if m else 0
+
+
+def collect_instance(inst_dir: str, *, now=None, systemd=True) -> dict:
+    """Assemble the full per-instance report dict (all metrics, pre-rendering)."""
+    now = now if now is not None else time.time()
+    num = instance_number(inst_dir)
+    merged, current = load_sidecars(inst_dir)
+    run_dirs = _run_dirs(inst_dir)
+
+    # crash taxonomy
+    by_label: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    by_module_crash: dict[str, int] = {}
+    crash_total = 0
+    for name in iter_crash_dirs(inst_dir):
+        crash_total += 1
+        module, kind, label = classify_crash_dir(name)
+        by_label[label] = by_label.get(label, 0) + 1
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+        by_module_crash[module] = by_module_crash.get(module, 0) + 1
+
+    sysd = systemd_info(num) if systemd else {}
+    failed_imports, header = parse_fusil_out(inst_dir)
+    pid = (current or {}).get("pid")
+    cmdline = _proc_cmdline(pid) or header
+
+    started = merged.get("started_at")
+    updated = (current or {}).get("updated_at")
+    elapsed = (now - started) if started else None
+    hb_age = (now - updated) if updated else None
+    active = sysd.get("ActiveState") == "active"
+    # "running" if systemd says active, else infer from a fresh heartbeat
+    running = active or (hb_age is not None and hb_age < STALE_HEARTBEAT_S)
+
+    return {
+        "instance": num,
+        "dir": inst_dir,
+        "gil_mode": (current or {}).get("gil_mode"),
+        "pid": pid,
+        "running": running,
+        "systemd_state": sysd.get("ActiveState") or "?",
+        "restarts": len(run_dirs),
+        "nrestarts_systemd": _int_or_none(sysd.get("NRestarts")),
+        "uptime_s": elapsed,
+        "heartbeat_age_s": hb_age,
+        "sessions": merged.get("sessions", 0),
+        "kept_crashes": crash_total,
+        "sidecar_crashes": merged.get("crashes", 0),
+        "timeouts": merged.get("timeouts", 0),
+        "cpu_load_kills": merged.get("cpu_load_kills", 0),
+        "oomnew": by_label.get("oomNEW", 0),
+        "by_label": by_label,
+        "by_kind": by_kind,
+        "by_module_crash": by_module_crash,
+        "modules": merged.get("modules", {}),
+        "failed_imports": failed_imports,
+        "mem_current": _int_or_none(sysd.get("MemoryCurrent")),
+        "mem_peak": _int_or_none(sysd.get("MemoryPeak")),
+        "mem_max": _int_or_none(sysd.get("MemoryMax")),
+        "disk_bytes": dir_size_bytes(inst_dir),
+        "cmdline": cmdline,
+    }
+
+
+def _int_or_none(val):
+    try:
+        n = int(val)
+    except (TypeError, ValueError):
+        return None
+    # systemd reports unset/unlimited as a huge sentinel or the literal "infinity"
+    if n < 0 or n >= 2**63 - 1:
+        return None
+    return n
+
+
+def discover_instances(fleet_dir: str) -> list[str]:
+    """Immediate inst-* subdirs; if fleet_dir is itself an inst-* dir, just that one."""
+    base = os.path.basename(fleet_dir.rstrip("/"))
+    if base.startswith("inst-"):
+        return [fleet_dir]
+    try:
+        subs = [
+            os.path.join(fleet_dir, e.name)
+            for e in os.scandir(fleet_dir)
+            if e.is_dir() and e.name.startswith("inst-")
+        ]
+    except OSError:
+        return []
+    return sorted(subs, key=instance_number)
+
+
+def aggregate_campaign(reports: list[dict], *, now=None) -> dict:
+    now = now if now is not None else time.time()
+    agg = {
+        "instances": len(reports),
+        "running": sum(1 for r in reports if r["running"]),
+        "sessions": sum(r["sessions"] for r in reports),
+        "kept_crashes": sum(r["kept_crashes"] for r in reports),
+        "timeouts": sum(r["timeouts"] for r in reports),
+        "oomnew": sum(r["oomnew"] for r in reports),
+        "disk_bytes": sum(r["disk_bytes"] for r in reports),
+        "by_label": {},
+        "by_kind": {},
+        "by_module_crash": {},
+        "started_at": None,
+    }
+    for r in reports:
+        for src, dst in (
+            (r["by_label"], agg["by_label"]),
+            (r["by_kind"], agg["by_kind"]),
+            (r["by_module_crash"], agg["by_module_crash"]),
+        ):
+            for key, val in src.items():
+                dst[key] = dst.get(key, 0) + val
+        started = r["uptime_s"]
+        if started is not None:
+            start_epoch = now - started
+            if agg["started_at"] is None or start_epoch < agg["started_at"]:
+                agg["started_at"] = start_epoch
+    agg["elapsed_s"] = (now - agg["started_at"]) if agg["started_at"] else None
+    return agg
+
+
+def anomalies(reports: list[dict]) -> list[tuple[int, str]]:
+    """(instance_num, reason) flags -- the health section."""
+    out = []
+    for r in reports:
+        if r["systemd_state"] not in ("active", "?"):
+            out.append((r["instance"], "systemd state=%s (down/failed)" % r["systemd_state"]))
+        elif r["heartbeat_age_s"] is not None and r["heartbeat_age_s"] > STALE_HEARTBEAT_S:
+            out.append(
+                (
+                    r["instance"],
+                    "stale heartbeat %s (stuck?)" % format_duration(r["heartbeat_age_s"]),
+                )
+            )
+        if r["restarts"] >= CHURN_RESTARTS:
+            out.append((r["instance"], "%d run dirs (churn/restarts?)" % r["restarts"]))
+        if r["mem_peak"] and r["mem_max"] and r["mem_peak"] / r["mem_max"] > MEM_CAP_FRACTION:
+            out.append(
+                (
+                    r["instance"],
+                    "memory %s near cap %s"
+                    % (human_bytes(r["mem_peak"]), human_bytes(r["mem_max"])),
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------- rendering
+
+
+def _top(counter: dict, n: int) -> list[tuple[str, int]]:
+    return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:n]
+
+
+def _taxo(counter: dict) -> str:
+    return ", ".join("%s=%d" % (k, v) for k, v in _top(counter, 12)) or "(none)"
+
+
+def render_instance(r: dict) -> str:
+    L = []
+    L.append("=" * 72)
+    L.append(
+        "fusil instance %-2d  [%s]  gil=%s  pid=%s"
+        % (
+            r["instance"],
+            "running" if r["running"] else "stopped",
+            r["gil_mode"] if r["gil_mode"] is not None else "?",
+            r["pid"] or "?",
+        )
+    )
+    L.append("=" * 72)
+    L.append(
+        "uptime %-10s  restarts %-3d  heartbeat %s ago"
+        % (format_duration(r["uptime_s"]), r["restarts"], format_duration(r["heartbeat_age_s"]))
+    )
+    to_pct = (100.0 * r["timeouts"] / r["sessions"]) if r["sessions"] else 0.0
+    find = (1000.0 * r["kept_crashes"] / r["sessions"]) if r["sessions"] else 0.0
+    L.append(
+        "sessions %-8d (%s)  crashes %-5d (%.1f/1k)  timeouts %d (%.1f%%)  cpu-kills %d"
+        % (
+            r["sessions"],
+            format_rate(r["sessions"], r["uptime_s"]),
+            r["kept_crashes"],
+            find,
+            r["timeouts"],
+            to_pct,
+            r["cpu_load_kills"],
+        )
+    )
+    L.append("-" * 72)
+    L.append("crashes by label: %s" % _taxo(r["by_label"]))
+    L.append("crashes by kind : %s" % _taxo(r["by_kind"]))
+    L.append("-" * 72)
+    hits = {m: b.get("hits", 0) for m, b in r["modules"].items()}
+    L.append(
+        "top modules (hits): %s"
+        % (", ".join("%s(%d)" % (m, h) for m, h in _top(hits, 8)) or "(none)")
+    )
+    L.append(
+        "crash-productive   : %s"
+        % (", ".join("%s(%d)" % (m, c) for m, c in _top(r["by_module_crash"], 8)) or "(none)")
+    )
+    if r["failed_imports"]:
+        L.append(
+            "failed imports     : %s"
+            % ", ".join("%s(%d)" % (m, c) for m, c in _top(r["failed_imports"], 8))
+        )
+    L.append("-" * 72)
+    L.append(
+        "memory %s (peak %s / cap %s)   disk %s"
+        % (
+            human_bytes(r["mem_current"]),
+            human_bytes(r["mem_peak"]),
+            human_bytes(r["mem_max"]),
+            human_bytes(r["disk_bytes"]),
+        )
+    )
+    if r["cmdline"]:
+        L.append("cmd: %s" % r["cmdline"])
+    return "\n".join(L)
+
+
+def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]) -> str:
+    L = []
+    L.append("=" * 84)
+    L.append(
+        "FUSIL FLEET  --  %d instances (%d running)  elapsed %s  disk %s"
+        % (
+            agg["instances"],
+            agg["running"],
+            format_duration(agg["elapsed_s"]),
+            human_bytes(agg["disk_bytes"]),
+        )
+    )
+    find = (1000.0 * agg["kept_crashes"] / agg["sessions"]) if agg["sessions"] else 0.0
+    L.append(
+        "sessions %-9d (%s)  crashes %-6d (%.1f/1k)  oomNEW %d  timeouts %d"
+        % (
+            agg["sessions"],
+            format_rate(agg["sessions"], agg["elapsed_s"]),
+            agg["kept_crashes"],
+            find,
+            agg["oomnew"],
+            agg["timeouts"],
+        )
+    )
+    L.append("=" * 84)
+    L.append(
+        "%-3s %-4s %-8s %-9s %9s %8s %6s %5s %5s %8s %7s"
+        % ("#", "gil", "state", "uptime", "sessions", "s/min", "crash", "NEW", "TO%", "mem", "disk")
+    )
+    L.append("-" * 84)
+    for r in reports:
+        to_pct = (100.0 * r["timeouts"] / r["sessions"]) if r["sessions"] else 0.0
+        L.append(
+            "%-3d %-4s %-8s %-9s %9d %8s %6d %5d %4.0f%% %8s %7s"
+            % (
+                r["instance"],
+                r["gil_mode"] if r["gil_mode"] is not None else "?",
+                "run" if r["running"] else "stop",
+                format_duration(r["uptime_s"]),
+                r["sessions"],
+                format_rate(r["sessions"], r["uptime_s"]).replace("/m", ""),
+                r["kept_crashes"],
+                r["oomnew"],
+                to_pct,
+                human_bytes(r["mem_current"]),
+                human_bytes(r["disk_bytes"]),
+            )
+        )
+    L.append("-" * 84)
+    L.append("fleet crashes by label: %s" % _taxo(agg["by_label"]))
+    L.append("fleet crashes by kind : %s" % _taxo(agg["by_kind"]))
+    L.append(
+        "most crash-productive : %s"
+        % (", ".join("%s(%d)" % (m, c) for m, c in _top(agg["by_module_crash"], 10)) or "(none)")
+    )
+    L.append("-" * 84)
+    if flags:
+        L.append("HEALTH: %d flag(s)" % len(flags))
+        for num, reason in flags:
+            L.append("  ! inst-%02d: %s" % (num, reason))
+    else:
+        L.append("HEALTH: all instances nominal")
+    return "\n".join(L)
+
+
+# --------------------------------------------------------------------------------- CLI
+
+
+def build_report(fleet_dir: str, instance: int | None, *, systemd=True, now=None) -> dict:
+    """Collect everything; returns {"instances": [...], "campaign": {...}, "anomalies": [...]}."""
+    inst_dirs = discover_instances(fleet_dir)
+    if instance is not None:
+        inst_dirs = [d for d in inst_dirs if instance_number(d) == instance]
+    reports = [collect_instance(d, now=now, systemd=systemd) for d in inst_dirs]
+    return {
+        "instances": reports,
+        "campaign": aggregate_campaign(reports, now=now),
+        "anomalies": anomalies(reports),
+    }
+
+
+def render(report: dict, instance: int | None) -> str:
+    reports = report["instances"]
+    if not reports:
+        return "no instances found"
+    if instance is not None:
+        return "\n".join(render_instance(r) for r in reports)
+    return render_campaign(reports, report["campaign"], report["anomalies"])
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="fleet_report", description="fusil fleet observability report"
+    )
+    ap.add_argument(
+        "--fleet-dir", required=True, help="campaign dir (parent of inst-*/) or one inst-* dir"
+    )
+    ap.add_argument("instance", nargs="?", type=int, help="report only this instance number")
+    ap.add_argument("--watch", action="store_true", help="live-refresh the report")
+    ap.add_argument(
+        "--interval", type=float, default=5.0, help="--watch refresh seconds (default 5)"
+    )
+    ap.add_argument(
+        "--json", action="store_true", help="emit machine-readable JSON instead of text"
+    )
+    ap.add_argument("--no-systemd", action="store_true", help="skip systemctl enrichment")
+    args = ap.parse_args(argv)
+
+    def once():
+        rep = build_report(args.fleet_dir, args.instance, systemd=not args.no_systemd)
+        if args.json:
+            return json.dumps(rep, default=str)
+        return render(rep, args.instance)
+
+    if not args.watch:
+        print(once())
+        return 0
+    try:
+        while True:
+            sys.stdout.write("\033[2J\033[H")  # clear + home
+            sys.stdout.write(once() + "\n")
+            sys.stdout.flush()
+            time.sleep(max(1.0, args.interval))
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/fusil/python/session_stats.py
+++ b/fusil/python/session_stats.py
@@ -1,0 +1,160 @@
+"""Per-run fuzzing statistics: a small, pure-Python accumulator + its JSON sidecar.
+
+This is the write side of fleet observability. ``StatsAgent`` (stats_agent.py) feeds a
+``SessionStats`` one call per finished session; the reporter (fleet_report.py) reads the
+emitted ``fusil_stats.json`` sidecars back and aggregates them across a fleet.
+
+Kept deliberately free of the ``python-ptrace`` runtime stack (only stdlib) so it unit-tests
+in isolation -- same split as ``oom_dedup.py``. The MAS wiring lives in ``stats_agent.py``.
+
+Sidecar schema (v1)::
+
+    {
+      "schema": 1,
+      "gil_mode": "0",            # PYTHON_GIL for this instance ("0"/"1"/None)
+      "pid": 12345,               # the fusil parent pid
+      "run_dir": "python-2",      # basename of the project run directory
+      "started_at": 1751450700.0, # epoch seconds, run start
+      "updated_at": 1751467000.0, # epoch seconds, last flush (heartbeat/liveness)
+      "sessions": 3092,           # sessions finished
+      "crashes": 112,             # sessions scored as a success/finding
+      "timeouts": 70,             # sessions the target-process timeout fired on
+      "cpu_load_kills": 5,        # sessions the CPU-load watcher killed
+      "modules": {                # per-target-module breakdown
+        "_blake2": {"hits": 15, "crashes": 3, "timeouts": 0},
+        ...
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Callable
+
+SCHEMA_VERSION = 1
+
+
+class SessionStats:
+    """In-memory per-run counters, serialisable to the ``fusil_stats.json`` sidecar.
+
+    ``clock`` is injectable so tests can pin ``updated_at`` deterministically.
+    """
+
+    def __init__(
+        self,
+        *,
+        gil_mode: str | None = None,
+        pid: int | None = None,
+        run_dir: str | None = None,
+        started_at: float | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._clock = clock
+        self.gil_mode = gil_mode
+        self.pid = pid
+        self.run_dir = run_dir
+        self.started_at = started_at if started_at is not None else clock()
+        self.updated_at = self.started_at
+        self.sessions = 0
+        self.crashes = 0
+        self.timeouts = 0
+        self.cpu_load_kills = 0
+        # module name -> {"hits": int, "crashes": int, "timeouts": int}
+        self.modules: dict[str, dict[str, int]] = {}
+
+    def record(
+        self,
+        module: str | None,
+        *,
+        crash: bool = False,
+        timeout: bool = False,
+        cpu_load: bool = False,
+    ) -> None:
+        """Fold one finished session into the counters."""
+        self.sessions += 1
+        if crash:
+            self.crashes += 1
+        if timeout:
+            self.timeouts += 1
+        if cpu_load:
+            self.cpu_load_kills += 1
+        # ``module`` can legitimately be None very early (before the first module loads);
+        # bucket those under "?" rather than dropping the session from the module view.
+        key = module or "?"
+        bucket = self.modules.get(key)
+        if bucket is None:
+            bucket = {"hits": 0, "crashes": 0, "timeouts": 0}
+            self.modules[key] = bucket
+        bucket["hits"] += 1
+        if crash:
+            bucket["crashes"] += 1
+        if timeout:
+            bucket["timeouts"] += 1
+        self.updated_at = self._clock()
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": SCHEMA_VERSION,
+            "gil_mode": self.gil_mode,
+            "pid": self.pid,
+            "run_dir": self.run_dir,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "sessions": self.sessions,
+            "crashes": self.crashes,
+            "timeouts": self.timeouts,
+            "cpu_load_kills": self.cpu_load_kills,
+            "modules": self.modules,
+        }
+
+    def write(self, path: str) -> None:
+        """Atomically write the sidecar (tmp + os.replace) so a reader never sees a partial file."""
+        tmp = "%s.tmp%d" % (path, os.getpid())
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(self.to_dict(), fh)
+        os.replace(tmp, path)
+
+    @classmethod
+    def load(cls, path: str) -> dict:
+        """Read a sidecar file back to a plain dict (reporter side). Raises on bad JSON/IO."""
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+
+    @staticmethod
+    def merge(dicts: list[dict]) -> dict:
+        """Aggregate several sidecar dicts (e.g. an instance's python-*/ run dirs) into one.
+
+        Scalar counters sum; per-module counters sum; ``started_at`` is the earliest and
+        ``updated_at`` the latest seen. Used by the reporter for campaign/instance rollups.
+        """
+        out = {
+            "schema": SCHEMA_VERSION,
+            "sessions": 0,
+            "crashes": 0,
+            "timeouts": 0,
+            "cpu_load_kills": 0,
+            "modules": {},
+            "started_at": None,
+            "updated_at": None,
+            "runs": 0,
+        }
+        for d in dicts:
+            if not d:
+                continue
+            out["runs"] += 1
+            for key in ("sessions", "crashes", "timeouts", "cpu_load_kills"):
+                out[key] += int(d.get(key, 0) or 0)
+            for name, bucket in (d.get("modules") or {}).items():
+                acc = out["modules"].setdefault(name, {"hits": 0, "crashes": 0, "timeouts": 0})
+                for field in ("hits", "crashes", "timeouts"):
+                    acc[field] += int(bucket.get(field, 0) or 0)
+            started = d.get("started_at")
+            if started is not None and (out["started_at"] is None or started < out["started_at"]):
+                out["started_at"] = started
+            updated = d.get("updated_at")
+            if updated is not None and (out["updated_at"] is None or updated > out["updated_at"]):
+                out["updated_at"] = updated
+        return out

--- a/fusil/python/stats_agent.py
+++ b/fusil/python/stats_agent.py
@@ -1,0 +1,102 @@
+"""StatsAgent: a score-neutral ProjectAgent that accumulates per-session fuzzing stats
+and flushes them to the ``fusil_stats.json`` sidecar for the fleet reporter to read.
+
+It observes the session event stream in the parent fusil process -- one increment per
+finished session -- and never influences scoring (it does not override ``getScore()``, so
+``Session.computeScore`` skips it). The pure counter/serialisation logic lives in
+``session_stats.py``; this file is only the MAS glue.
+
+Wiring: constructed in ``Fuzzer.setupProject`` as ``StatsAgent(project, self.source)`` --
+``ProjectAgent.__init__`` auto-registers it, and it is activated with every session.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from fusil.project_agent import ProjectAgent
+from fusil.python.session_stats import SessionStats
+
+SIDECAR_NAME = "fusil_stats.json"
+_FLUSH_INTERVAL = 1.0  # seconds; the sidecar lags in-memory counters by at most this
+
+
+class StatsAgent(ProjectAgent):
+    """Fold each finished session into a ``SessionStats`` and periodically write the sidecar.
+
+    Counters live on the instance (``__init__``), NOT in ``init()``, because a ProjectAgent's
+    ``init()``/``deinit()`` run once per *session* -- putting them in ``init()`` would reset
+    them every session.
+    """
+
+    def __init__(self, project, source):
+        ProjectAgent.__init__(self, project, "stats")
+        self.source = source  # the PythonSource agent -- read .module_name per session
+        run_dir = None
+        try:
+            run_dir = os.path.basename(project.directory.directory)
+        except Exception:
+            pass
+        self.stats = SessionStats(
+            gil_mode=os.environ.get("PYTHON_GIL"),
+            pid=os.getpid(),
+            run_dir=run_dir,
+        )
+        self._path = None  # resolved lazily on first flush
+        self._rename_parts: list[str] = []
+        self._last_flush = 0.0
+
+    # --- session event stream ---------------------------------------------------------
+
+    def on_session_start(self):
+        # Fresh per-session label accumulator; the rename parts (module, signal, "timeout",
+        # "cpu_load", oom bug-id, ...) all arrive on the shared session_rename channel.
+        self._rename_parts = []
+
+    def on_session_rename(self, part):
+        self._rename_parts.append(part)
+
+    def on_session_done(self, score):
+        project = self.project()
+        success = getattr(project, "success_score", 0.5) if project else 0.5
+        crash = score is not None and score >= success
+        module = getattr(self.source, "module_name", None)
+        self.stats.record(
+            module,
+            crash=crash,
+            timeout="timeout" in self._rename_parts,
+            cpu_load="cpu_load" in self._rename_parts,
+        )
+        self._maybe_flush()
+
+    def on_univers_stop(self):
+        # Best-effort final flush at shutdown (may be a no-op if already deactivated).
+        self._maybe_flush(force=True)
+
+    # --- sidecar io -------------------------------------------------------------------
+
+    def _sidecar_path(self):
+        if self._path is None:
+            project = self.project()
+            if project is None:
+                return None
+            # createFilename registers the name in the run dir's tracked-files set, so the
+            # sidecar is well-defined w.r.t. ProjectDirectory retention rather than looking
+            # like a stray foreign file.
+            self._path = project.createFilename(SIDECAR_NAME)
+        return self._path
+
+    def _maybe_flush(self, force=False):
+        now = time.monotonic()
+        if not force and (now - self._last_flush) < _FLUSH_INTERVAL:
+            return
+        path = self._sidecar_path()
+        if not path:
+            return
+        try:
+            self.stats.write(path)
+            self._last_flush = now
+        except Exception as err:
+            # Observability must never break fuzzing; log and carry on.
+            self.error("StatsAgent: failed to write %s: %s" % (path, err))

--- a/tests/python/test_fleet_report.py
+++ b/tests/python/test_fleet_report.py
@@ -1,0 +1,162 @@
+"""Tests for the fleet reporter (fusil/python/fleet_report.py).
+
+Pure-Python: builds a fixture fleet dir (sidecars + fake labelled crash dirs) and exercises
+collection, aggregation, anomaly flags, and rendering with injected time and systemd off.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
+
+from fusil.python import fleet_report as fr
+
+
+def _sidecar(path, **kw):
+    data = {
+        "schema": 1,
+        "gil_mode": "0",
+        "pid": 111,
+        "run_dir": os.path.basename(os.path.dirname(path)),
+        "started_at": 1000.0,
+        "updated_at": 1050.0,
+        "sessions": 0,
+        "crashes": 0,
+        "timeouts": 0,
+        "cpu_load_kills": 0,
+        "modules": {},
+    }
+    data.update(kw)
+    with open(path, "w") as fh:
+        json.dump(data, fh)
+
+
+def _crash(run_dir, name):
+    d = os.path.join(run_dir, name)
+    os.makedirs(d, exist_ok=True)
+    open(os.path.join(d, "source.py"), "w").close()
+
+
+class TestClassify(unittest.TestCase):
+    def test_labels_and_kinds(self):
+        cases = {
+            "_blake2-fatal_python_error-OOM-0043-2": ("_blake2", "fatal_python_error", "OOM-0043"),
+            "_curses-exitcode1-oomclean-5": ("_curses", "exitcode1", "oomclean"),
+            "email_mime_base-systemerror-oomclean": ("email_mime_base", "systemerror", "oomclean"),
+            "json-sigsegv-oomNEW": ("json", "sigsegv", "oomNEW"),
+            "mod-exitcode127-oomclean": ("mod", "exitcode127", "oomclean"),
+            "weird_name_only": ("weird_name_only", "other", "other"),
+        }
+        for name, expected in cases.items():
+            self.assertEqual(fr.classify_crash_dir(name), expected, name)
+
+
+class TestCollectAndAggregate(unittest.TestCase):
+    def _fleet(self, tmp):
+        # inst-01: 2 run dirs (a restart), a sidecar with counts, 2 crash dirs
+        r1 = os.path.join(tmp, "inst-01", "python")
+        r2 = os.path.join(tmp, "inst-01", "python-2")
+        os.makedirs(r1)
+        os.makedirs(r2)
+        _sidecar(
+            os.path.join(r1, "fusil_stats.json"),
+            sessions=100,
+            crashes=3,
+            timeouts=5,
+            modules={"json": {"hits": 60, "crashes": 3, "timeouts": 1}},
+        )
+        _sidecar(
+            os.path.join(r2, "fusil_stats.json"),
+            sessions=50,
+            crashes=1,
+            timeouts=2,
+            started_at=900.0,
+            updated_at=1200.0,
+            modules={"sqlite3": {"hits": 50, "crashes": 1, "timeouts": 1}},
+        )
+        _crash(r1, "json-sigsegv-oomNEW")
+        _crash(r2, "sqlite3-exitcode1-oomclean")
+        # inst-02: no sidecar, one crash dir (post-hoc only path)
+        r = os.path.join(tmp, "inst-02", "python")
+        os.makedirs(r)
+        _crash(r, "mod-fatal_python_error-OOM-0043")
+        return tmp
+
+    def test_collect_instance_merges_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._fleet(tmp)
+            r = fr.collect_instance(os.path.join(tmp, "inst-01"), now=2000.0, systemd=False)
+            self.assertEqual(r["instance"], 1)
+            self.assertEqual(r["sessions"], 150)  # summed across the two run dirs
+            self.assertEqual(r["restarts"], 2)
+            self.assertEqual(r["kept_crashes"], 2)
+            self.assertEqual(r["oomnew"], 1)
+            self.assertEqual(r["by_kind"].get("sigsegv"), 1)
+            self.assertEqual(r["by_label"].get("oomclean"), 1)
+            self.assertEqual(r["modules"]["json"]["hits"], 60)
+            self.assertGreater(r["disk_bytes"], 0)
+
+    def test_discover_and_campaign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._fleet(tmp)
+            insts = fr.discover_instances(tmp)
+            self.assertEqual([fr.instance_number(d) for d in insts], [1, 2])
+            report = fr.build_report(tmp, None, systemd=False, now=2000.0)
+            agg = report["campaign"]
+            self.assertEqual(agg["instances"], 2)
+            self.assertEqual(agg["sessions"], 150)  # inst-02 has no sidecar
+            self.assertEqual(agg["kept_crashes"], 3)
+            self.assertEqual(agg["oomnew"], 1)
+            self.assertEqual(agg["by_label"].get("OOM-0043"), 1)
+
+    def test_single_instance_filter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._fleet(tmp)
+            report = fr.build_report(tmp, 2, systemd=False, now=2000.0)
+            self.assertEqual(len(report["instances"]), 1)
+            self.assertEqual(report["instances"][0]["instance"], 2)
+
+    def test_discover_single_inst_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._fleet(tmp)
+            insts = fr.discover_instances(os.path.join(tmp, "inst-01"))
+            self.assertEqual(len(insts), 1)
+
+
+class TestAnomaliesAndRender(unittest.TestCase):
+    def test_churn_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = os.path.join(tmp, "inst-03")
+            for i in range(6):  # 6 run dirs >= CHURN_RESTARTS
+                os.makedirs(os.path.join(inst, "python" if i == 0 else "python-%d" % (i + 1)))
+            r = fr.collect_instance(inst, now=2000.0, systemd=False)
+            flags = fr.anomalies([r])
+            self.assertTrue(any("churn" in reason for _n, reason in flags))
+
+    def test_render_contains_key_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r1 = os.path.join(tmp, "inst-01", "python")
+            os.makedirs(r1)
+            _sidecar(
+                os.path.join(r1, "fusil_stats.json"),
+                sessions=100,
+                crashes=2,
+                modules={"json": {"hits": 100, "crashes": 2, "timeouts": 0}},
+            )
+            _crash(r1, "json-sigsegv-oomNEW")
+            report = fr.build_report(tmp, None, systemd=False, now=2000.0)
+            camp = fr.render(report, None)
+            self.assertIn("FUSIL FLEET", camp)
+            self.assertIn("HEALTH", camp)
+            self.assertIn("oomNEW", camp)
+            inst = fr.render(report, 1)
+            self.assertIn("fusil instance 1", inst)
+            self.assertIn("json", inst)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_session_stats.py
+++ b/tests/python/test_session_stats.py
@@ -1,0 +1,116 @@
+"""Tests for the pure stats engine (fusil/python/session_stats.py).
+
+Pure-Python, no runtime stack -- same isolation as test_oom_dedup.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
+
+from fusil.python.session_stats import SCHEMA_VERSION, SessionStats
+
+
+class TestRecord(unittest.TestCase):
+    def _stats(self):
+        # deterministic clock so updated_at is pinned
+        ticks = iter(range(1, 10_000))
+        return SessionStats(started_at=0.0, clock=lambda: next(ticks))
+
+    def test_counters_and_per_module(self):
+        s = self._stats()
+        s.record("json", crash=True)
+        s.record("json")
+        s.record("sqlite3", timeout=True)
+        s.record("json", crash=True, cpu_load=True)
+        self.assertEqual(s.sessions, 4)
+        self.assertEqual(s.crashes, 2)
+        self.assertEqual(s.timeouts, 1)
+        self.assertEqual(s.cpu_load_kills, 1)
+        self.assertEqual(s.modules["json"], {"hits": 3, "crashes": 2, "timeouts": 0})
+        self.assertEqual(s.modules["sqlite3"], {"hits": 1, "crashes": 0, "timeouts": 1})
+
+    def test_none_module_bucketed_as_question(self):
+        s = self._stats()
+        s.record(None)
+        self.assertIn("?", s.modules)
+        self.assertEqual(s.modules["?"]["hits"], 1)
+
+    def test_updated_at_advances_with_clock(self):
+        s = self._stats()
+        self.assertEqual(s.updated_at, 0.0)  # == started_at before any record
+        s.record("m")
+        first = s.updated_at
+        s.record("m")
+        self.assertGreater(s.updated_at, first)
+
+
+class TestSerialization(unittest.TestCase):
+    def test_to_dict_schema(self):
+        s = SessionStats(
+            gil_mode="1", pid=42, run_dir="python-2", started_at=5.0, clock=lambda: 9.0
+        )
+        s.record("m", crash=True)
+        d = s.to_dict()
+        self.assertEqual(d["schema"], SCHEMA_VERSION)
+        for key in (
+            "gil_mode",
+            "pid",
+            "run_dir",
+            "started_at",
+            "updated_at",
+            "sessions",
+            "crashes",
+            "timeouts",
+            "cpu_load_kills",
+            "modules",
+        ):
+            self.assertIn(key, d)
+        self.assertEqual(d["gil_mode"], "1")
+        self.assertEqual(d["pid"], 42)
+        self.assertEqual(d["sessions"], 1)
+
+    def test_write_is_atomic_and_roundtrips(self):
+        s = SessionStats(started_at=1.0, clock=lambda: 2.0)
+        s.record("m", crash=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "fusil_stats.json")
+            s.write(path)
+            # no leftover temp files (atomic replace cleaned up)
+            self.assertEqual(os.listdir(tmp), ["fusil_stats.json"])
+            with open(path) as fh:
+                loaded = json.load(fh)
+            self.assertEqual(loaded, s.to_dict())
+            self.assertEqual(SessionStats.load(path), s.to_dict())
+
+
+class TestMerge(unittest.TestCase):
+    def test_merge_sums_and_unions(self):
+        a = SessionStats(started_at=10.0, clock=lambda: 20.0)
+        a.record("json", crash=True)
+        b = SessionStats(started_at=5.0, clock=lambda: 30.0)
+        b.record("json")
+        b.record("sqlite3", timeout=True)
+        merged = SessionStats.merge([a.to_dict(), b.to_dict()])
+        self.assertEqual(merged["sessions"], 3)
+        self.assertEqual(merged["crashes"], 1)
+        self.assertEqual(merged["timeouts"], 1)
+        self.assertEqual(merged["runs"], 2)
+        self.assertEqual(merged["modules"]["json"], {"hits": 2, "crashes": 1, "timeouts": 0})
+        self.assertEqual(merged["started_at"], 5.0)  # earliest
+        self.assertEqual(merged["updated_at"], 30.0)  # latest
+
+    def test_merge_empty(self):
+        merged = SessionStats.merge([])
+        self.assertEqual(merged["sessions"], 0)
+        self.assertEqual(merged["runs"], 0)
+        self.assertEqual(merged["modules"], {})
+        self.assertIsNone(merged["started_at"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_stats_agent.py
+++ b/tests/python/test_stats_agent.py
@@ -1,0 +1,96 @@
+"""Wiring tests for StatsAgent (fusil/python/stats_agent.py).
+
+Skip-guarded like test_oom_dedup_wiring: importing StatsAgent pulls the runtime stack
+(ProjectAgent / fusil.python), absent on some boxes. We avoid constructing the full MAS by
+building a bare instance via object.__new__ and driving its on_* handlers directly with
+SimpleNamespace fakes -- exactly the "test the contract, not the machinery" approach.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
+
+try:
+    from fusil.python.session_stats import SessionStats
+    from fusil.python.stats_agent import StatsAgent
+
+    HAVE = True
+except Exception:  # noqa: BLE001 -- runtime stack (python-ptrace) may be absent
+    HAVE = False
+
+
+@unittest.skipUnless(HAVE, "requires the fusil runtime stack (python-ptrace)")
+class TestStatsAgentWiring(unittest.TestCase):
+    def _agent(self, tmp, module="json"):
+        """A StatsAgent wired to fakes, without running ProjectAgent.__init__/the MAS."""
+        agent = object.__new__(StatsAgent)
+        agent.source = SimpleNamespace(module_name=module)
+        agent.stats = SessionStats(started_at=0.0, clock=lambda: 1.0)
+        agent._rename_parts = []
+        agent._path = None
+        agent._last_flush = 0.0
+        fake_project = SimpleNamespace(
+            success_score=0.5,
+            createFilename=lambda name: os.path.join(tmp, name),
+        )
+        agent.project = lambda: fake_project
+        agent.error = lambda *a, **k: None
+        return agent
+
+    def test_score_neutral(self):
+        # StatsAgent must NOT influence scoring -> inherits ProjectAgent.getScore() == None.
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = self._agent(tmp)
+            self.assertIsNone(agent.getScore())
+
+    def test_crash_counted_per_module(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = self._agent(tmp, module="json")
+            agent.on_session_start()
+            agent.on_session_rename("json")
+            agent.on_session_rename("sigsegv")
+            agent.on_session_done(0.75)  # >= success_score -> crash
+            self.assertEqual(agent.stats.sessions, 1)
+            self.assertEqual(agent.stats.crashes, 1)
+            self.assertEqual(agent.stats.modules["json"]["crashes"], 1)
+
+    def test_non_crash_not_counted_as_crash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = self._agent(tmp, module="json")
+            agent.on_session_start()
+            agent.on_session_done(0.0)  # below success_score
+            self.assertEqual(agent.stats.crashes, 0)
+            self.assertEqual(agent.stats.modules["json"]["hits"], 1)
+
+    def test_timeout_and_cpu_load_via_rename(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = self._agent(tmp, module="slowmod")
+            agent.on_session_start()
+            agent.on_session_rename("slowmod")
+            agent.on_session_rename("timeout")
+            agent.on_session_done(0.0)  # timeouts score 0 by default -> must be seen via rename
+            self.assertEqual(agent.stats.timeouts, 1)
+
+            agent.on_session_start()  # resets rename parts
+            agent.on_session_rename("cpu_load")
+            agent.on_session_done(0.0)
+            self.assertEqual(agent.stats.cpu_load_kills, 1)
+
+    def test_flush_writes_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = self._agent(tmp, module="json")
+            agent.on_session_start()
+            agent.on_session_done(0.0)
+            agent._maybe_flush(force=True)
+            path = os.path.join(tmp, "fusil_stats.json")
+            self.assertTrue(os.path.exists(path))
+            self.assertEqual(SessionStats.load(path)["sessions"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase 1 of fleet observability.** Adds per-instance and whole-campaign visibility into throughput, module coverage, restarts, crash taxonomy, disk, and health — the things `./fleet status`/`triage` don't surface (and that diagnosing this campaign meant hand-grepping `project.log`/`fusil.out`/`journalctl` for). Modelled on lafleur's instance-vs-campaign observability split; its small formatting helpers are **imitated, not imported** (fusil takes no dependency on lafleur, and drops all its coverage/lineage machinery, which doesn't apply to a non-coverage-guided fuzzer).

## Two parts

**1. `StatsAgent` — the write side** (`stats_agent.py` + the stdlib-only engine `session_stats.py`)
A score-neutral `ProjectAgent` that folds each finished session into a per-run `fusil_stats.json` sidecar: `sessions`, `crashes`, `timeouts`, `cpu_load_kills`, and per-module `{hits, crashes, timeouts}`.
- Observes the parent-process session event stream: counts in `on_session_done(score)` (crash = `score >= project.success_score`), captures `timeout`/`cpu_load` via `on_session_rename` (they score 0 by default, so the rename channel is the reliable signal), reads the target from `PythonSource.module_name`.
- **Never overrides `getScore()`** → inherits `None` → cannot affect scoring or the generated source (golden output is unchanged).
- Writes via `project.createFilename` so the sidecar is well-defined w.r.t. run-dir retention; flush throttled to ≥1s.

**2. `fleet_report.py` — the read side** (pure-Python)
Sums the sidecars across an instance's `python-*/` run dirs (campaign-accurate across restarts) and enriches with **post-hoc** data that needs no instrumentation:
- kept-crash-dir taxonomy — by **dedup label** (`OOM-00NN`/`oomNEW`/`oomclean`/…) **and** by **kind** (`exitcode*`/`systemerror`/`fatal`/`segv`/…);
- restart count (`python-*` dirs), disk usage, best-effort `systemctl` state/memory (degrades gracefully when systemd/units are absent — e.g. an archived fleet dir), and the current-run `fusil.out` (failed imports + command line).
- Renders a **per-instance** or **campaign** text report (instance leaderboard + fleet crash taxonomy + most-crash-productive modules + **health/anomaly flags**: churn, stale heartbeat, near-mem-cap), with `--watch` (live refresh) and `--json`.

Fronted by **`./fleet report [N]`** (`--watch`, `--json`, `--no-systemd`).

## Sample (against a real fleet dir)

```
FUSIL FLEET  --  4 instances (0 running)  elapsed -  disk 676.7M
sessions 0 (-)  crashes 566 (0.0/1k)  oomNEW 1  timeouts 0
...
fleet crashes by label: oomclean=510, OOM-0027=28, OOM-0043=16, other=10, OOM-0008=1, oomNEW=1
fleet crashes by kind : systemerror=163, exitcode127=115, exitcode1=114, exitcode2=70, cpu_load=46, ...
most crash-productive : asyncio_tasks(28), readline(26), _uuid(24), site(19), _curses(18), ...
HEALTH: all instances nominal
```

## Verification

- **Tests** mirror the `oom_dedup` pure/wiring split: `test_session_stats` (pure engine), `test_stats_agent` (skip-guarded wiring via `SimpleNamespace` fakes; asserts `getScore()` is `None`), `test_fleet_report` (pure, on a fixture fleet dir). Full suite **382 OK**; `ruff check` + `ruff format --check` clean; `bash -n fleet/fleet` OK.
- **End-to-end**: a real 3-session run wrote a valid sidecar (per-module counts + crash/cpu-load detection correct); the reporter renders campaign/instance/`--json`/`--watch` against both a real fleet dir (post-hoc path) and a synthetic one (sidecar path).
- **Golden output unchanged** — `StatsAgent` is a parent-side observer and doesn't touch `WritePythonCode`.

## Follow-up (Phase 2)
`--html` self-contained dashboard (port lafleur's, minus coverage columns), append-only health-event JSONL, module-productivity refinements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)