### PR TITLE
feat(fleet): --html dashboard + per-module crash-rate (observability Phase 2)

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -35,7 +35,7 @@ and capture their logs — no VMs or containers needed.
 sudo ./fleet up            # start (nproc-1) instances; or: sudo ./fleet up 8
 ./fleet status             # per-instance state + crashes kept + NEW candidates
 ./fleet report             # rich observability: sessions, throughput, crash taxonomy, disk, health
-./fleet report 3           # ...for one instance;  add --watch for a live view, --json for scripts
+./fleet report 3           # ...for one instance;  add --watch (live), --html FILE (dashboard), or --json
 ./fleet finds              # list the oomNEW dirs across the whole fleet
 ./fleet tail 3             # follow instance 3's output live
 sudo ./fleet down          # stop everything

--- a/fleet/fleet
+++ b/fleet/fleet
@@ -6,7 +6,7 @@
 #   sudo ./fleet down        stop + disable all instances
 #   ./fleet status          per-instance state + crash/NEW-find counts
 #   ./fleet finds           list this fleet's oomNEW (new-bug candidate) dirs
-#   ./fleet report [N]      observability report: per-instance + campaign (--watch, --json, --no-systemd)
+#   ./fleet report [N]      observability report: per-instance + campaign (--watch, --json, --html PATH, --no-systemd)
 #   ./fleet triage          dedupe oomNEW/oomSEGV candidates across instances (needs INGEST); extra args pass to ingest (e.g. --gdb)
 #   ./fleet tail [N]        follow instance N's log (default: 1)
 #   sudo ./fleet restart    restart all instances (e.g. to pick up a new catalog)

--- a/fusil/python/fleet_report.py
+++ b/fusil/python/fleet_report.py
@@ -20,6 +20,7 @@ immediate children are ``inst-NN`` instance dirs; a single instance is one ``ins
 from __future__ import annotations
 
 import argparse
+import html as _html
 import json
 import os
 import re
@@ -257,6 +258,7 @@ def aggregate_campaign(reports: list[dict], *, now=None) -> dict:
         "by_label": {},
         "by_kind": {},
         "by_module_crash": {},
+        "modules": {},  # summed per-module {hits,crashes,timeouts} across instances
         "started_at": None,
     }
     for r in reports:
@@ -267,6 +269,10 @@ def aggregate_campaign(reports: list[dict], *, now=None) -> dict:
         ):
             for key, val in src.items():
                 dst[key] = dst.get(key, 0) + val
+        for name, bucket in (r["modules"] or {}).items():
+            acc = agg["modules"].setdefault(name, {"hits": 0, "crashes": 0, "timeouts": 0})
+            for field in ("hits", "crashes", "timeouts"):
+                acc[field] += int(bucket.get(field, 0) or 0)
         started = r["uptime_s"]
         if started is not None:
             start_epoch = now - started
@@ -313,6 +319,28 @@ def _taxo(counter: dict) -> str:
     return ", ".join("%s=%d" % (k, v) for k, v in _top(counter, 12)) or "(none)"
 
 
+def crash_rate_modules(
+    modules: dict, *, min_hits: int = 5, n: int = 8
+) -> list[tuple[str, float, int]]:
+    """(module, crash_rate_pct, hits) for modules with >= min_hits, most-crash-prone first.
+
+    Surfaces which fuzzed modules most reliably produce crashes (crashes/hits) -- the
+    productivity signal counts alone miss (a high-hit module with few crashes is quiet;
+    a module that crashes on nearly every hit is a hot target)."""
+    rows = []
+    for name, b in modules.items():
+        hits = int(b.get("hits", 0) or 0)
+        if hits >= min_hits:
+            rows.append((name, 100.0 * int(b.get("crashes", 0) or 0) / hits, hits))
+    rows.sort(key=lambda r: (-r[1], -r[2], r[0]))
+    return rows[:n]
+
+
+def _rate_str(modules: dict) -> str:
+    rows = crash_rate_modules(modules)
+    return ", ".join("%s(%.0f%%/%d)" % (m, rate, hits) for m, rate, hits in rows) or "(none)"
+
+
 def render_instance(r: dict) -> str:
     L = []
     L.append("=" * 72)
@@ -357,6 +385,7 @@ def render_instance(r: dict) -> str:
         "crash-productive   : %s"
         % (", ".join("%s(%d)" % (m, c) for m, c in _top(r["by_module_crash"], 8)) or "(none)")
     )
+    L.append("crash-rate (c/hits): %s" % _rate_str(r["modules"]))
     if r["failed_imports"]:
         L.append(
             "failed imports     : %s"
@@ -432,6 +461,7 @@ def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]
         "most crash-productive : %s"
         % (", ".join("%s(%d)" % (m, c) for m, c in _top(agg["by_module_crash"], 10)) or "(none)")
     )
+    L.append("highest crash-rate    : %s" % _rate_str(agg.get("modules", {})))
     L.append("-" * 84)
     if flags:
         L.append("HEALTH: %d flag(s)" % len(flags))
@@ -440,6 +470,172 @@ def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]
     else:
         L.append("HEALTH: all instances nominal")
     return "\n".join(L)
+
+
+# ------------------------------------------------------------------------- HTML dashboard
+#
+# A self-contained (single-file, zero-asset) dashboard -- KPI cards, a click-to-sort instance
+# leaderboard, bar-in-cell taxonomy/module panels, and health badges. Embedded CSS+JS in the
+# spirit of lafleur's campaign dashboard (imitated, not imported); no coverage/lineage columns.
+
+_CSS = (
+    ":root{--bg:#0f1720;--card:#182430;--fg:#dfe7ee;--mut:#8aa0b4;--acc:#4aa3ff;"
+    "--ok:#2ecc71;--bad:#ff6b6b;--bar:#2b5a8c}"
+    "*{box-sizing:border-box}body{margin:0;padding:20px;background:var(--bg);color:var(--fg);"
+    "font:13px/1.45 ui-monospace,Menlo,Consolas,monospace}"
+    "h1{font-size:18px;margin:0 0 14px}h1 .sub{font-size:12px;color:var(--mut);font-weight:400}"
+    "h2{font-size:14px;margin:22px 0 8px;color:var(--acc)}h3{font-size:12px;margin:0 0 6px;color:var(--mut)}"
+    ".kpis{display:flex;flex-wrap:wrap;gap:10px}.kpi{background:var(--card);border-radius:8px;"
+    "padding:10px 14px;min-width:96px}.kpi .v{font-size:20px;font-weight:600}.kpi .l{font-size:11px;color:var(--mut)}"
+    ".health{margin:14px 0;padding:10px 14px;border-radius:8px;background:var(--card)}"
+    ".health.ok{border-left:4px solid var(--ok)}.health.bad{border-left:4px solid var(--bad)}"
+    ".health ul{margin:6px 0 0;padding-left:18px}"
+    "table{border-collapse:collapse;width:100%;background:var(--card);border-radius:8px;overflow:hidden}"
+    "th,td{padding:6px 10px;text-align:right;white-space:nowrap}"
+    "th:first-child,td:first-child,td.k{text-align:left}"
+    "thead th{background:#0c141c;color:var(--mut);cursor:pointer;user-select:none}"
+    "thead th:hover{color:var(--fg)}tbody tr:nth-child(even){background:rgba(255,255,255,.02)}"
+    ".badge{padding:2px 7px;border-radius:10px;font-size:11px}"
+    ".badge.run{background:rgba(46,204,113,.2);color:var(--ok)}"
+    ".badge.stop{background:rgba(255,107,107,.2);color:var(--bad)}"
+    ".cols{display:flex;gap:14px;flex-wrap:wrap;margin-top:8px}.panel{flex:1;min-width:320px}"
+    "table.bars td.b{width:55%}table.bars td.b span{display:block;height:12px;background:var(--bar);border-radius:3px}"
+    "table.bars td.k{max-width:220px;overflow:hidden;text-overflow:ellipsis}"
+)
+
+_SORT_JS = (
+    "document.querySelectorAll('table.sortable thead th').forEach(function(th,i){var asc=true;"
+    "th.addEventListener('click',function(){var tb=th.closest('table').tBodies[0];"
+    "var rows=Array.prototype.slice.call(tb.rows);rows.sort(function(a,b){"
+    "var x=a.cells[i],y=b.cells[i];var xv=x.getAttribute('data-sort'),yv=y.getAttribute('data-sort');"
+    "if(xv!==null&&yv!==null){return (parseFloat(xv)-parseFloat(yv))*(asc?1:-1);}"
+    "return x.textContent.localeCompare(y.textContent)*(asc?1:-1);});asc=!asc;"
+    "rows.forEach(function(r){tb.appendChild(r);});});});"
+)
+
+
+def _esc(s) -> str:
+    return _html.escape(str(s), quote=True)
+
+
+def _num_td(display, sortval) -> str:
+    return "<td data-sort='%s'>%s</td>" % (_esc(sortval), _esc(display))
+
+
+def _bars_panel(title: str, counter: dict, n: int = 12) -> str:
+    rows = _top(counter, n)
+    mx = max((v for _, v in rows), default=1) or 1
+    out = ["<div class=panel><h3>%s</h3><table class=bars>" % _esc(title)]
+    for k, v in rows:
+        out.append(
+            "<tr><td class=k>%s</td><td class=b><span style='width:%.1f%%'></span></td>"
+            "<td>%d</td></tr>" % (_esc(k), 100.0 * v / mx, v)
+        )
+    if not rows:
+        out.append("<tr><td class=k>(none)</td></tr>")
+    out.append("</table></div>")
+    return "".join(out)
+
+
+def _rate_panel(title: str, modules: dict) -> str:
+    rows = crash_rate_modules(modules, n=12)
+    out = ["<div class=panel><h3>%s</h3><table class=bars>" % _esc(title)]
+    for m, rate, hits in rows:
+        out.append(
+            "<tr><td class=k>%s</td><td class=b><span style='width:%.1f%%'></span></td>"
+            "<td>%.0f%% /%d</td></tr>" % (_esc(m), rate, rate, hits)
+        )
+    if not rows:
+        out.append("<tr><td class=k>(none)</td></tr>")
+    out.append("</table></div>")
+    return "".join(out)
+
+
+def render_html(report: dict, *, generated: str | None = None) -> str:
+    reports = report["instances"]
+    agg = report["campaign"]
+    flags = report["anomalies"]
+    gen = generated if generated is not None else time.strftime("%Y-%m-%d %H:%M:%S")
+    find = (1000.0 * agg["kept_crashes"] / agg["sessions"]) if agg["sessions"] else 0.0
+    p = [
+        "<!doctype html><html lang=en><head><meta charset=utf-8>",
+        "<meta name=viewport content='width=device-width,initial-scale=1'>",
+        "<title>fusil fleet report</title><style>%s</style></head><body>" % _CSS,
+        "<h1>fusil fleet <span class=sub>%d instances &middot; %d running &middot; elapsed %s "
+        "&middot; generated %s</span></h1>"
+        % (agg["instances"], agg["running"], _esc(format_duration(agg["elapsed_s"])), _esc(gen)),
+        "<div class=kpis>",
+    ]
+    for label, value in (
+        ("sessions", "{:,}".format(agg["sessions"])),
+        ("throughput", format_rate(agg["sessions"], agg["elapsed_s"])),
+        ("crashes", "{:,}".format(agg["kept_crashes"])),
+        ("find rate", "%.1f/1k" % find),
+        ("oomNEW", agg["oomnew"]),
+        ("timeouts", agg["timeouts"]),
+        ("disk", human_bytes(agg["disk_bytes"])),
+    ):
+        p.append(
+            "<div class=kpi><div class=v>%s</div><div class=l>%s</div></div>"
+            % (_esc(value), _esc(label))
+        )
+    p.append("</div>")
+
+    if flags:
+        p.append("<div class='health bad'><b>HEALTH: %d flag(s)</b><ul>" % len(flags))
+        for num, reason in flags:
+            p.append("<li>inst-%02d: %s</li>" % (num, _esc(reason)))
+        p.append("</ul></div>")
+    else:
+        p.append("<div class='health ok'><b>HEALTH: all instances nominal</b></div>")
+
+    p.append("<h2>instances</h2><table class=sortable><thead><tr>")
+    for label in (
+        "#",
+        "gil",
+        "state",
+        "uptime",
+        "sessions",
+        "s/min",
+        "crash",
+        "NEW",
+        "TO%",
+        "mem",
+        "disk",
+    ):
+        p.append("<th>%s</th>" % _esc(label))
+    p.append("</tr></thead><tbody>")
+    for r in reports:
+        to_pct = (100.0 * r["timeouts"] / r["sessions"]) if r["sessions"] else 0.0
+        spm = (r["sessions"] / (r["uptime_s"] / 60.0)) if r["uptime_s"] else 0.0
+        badge = "run" if r["running"] else "stop"
+        p.append("<tr>")
+        p.append(_num_td(r["instance"], r["instance"]))
+        p.append("<td>%s</td>" % _esc(r["gil_mode"] if r["gil_mode"] is not None else "?"))
+        p.append("<td><span class='badge %s'>%s</span></td>" % (badge, badge))
+        p.append(_num_td(format_duration(r["uptime_s"]), r["uptime_s"] or 0))
+        p.append(_num_td("{:,}".format(r["sessions"]), r["sessions"]))
+        p.append(_num_td("%.1f" % spm, spm))
+        p.append(_num_td("{:,}".format(r["kept_crashes"]), r["kept_crashes"]))
+        p.append(_num_td(r["oomnew"], r["oomnew"]))
+        p.append(_num_td("%.0f%%" % to_pct, to_pct))
+        p.append(
+            _num_td(human_bytes(r["mem_current"]), r["mem_current"] if r["mem_current"] else -1)
+        )
+        p.append(_num_td(human_bytes(r["disk_bytes"]), r["disk_bytes"]))
+        p.append("</tr>")
+    p.append("</tbody></table>")
+
+    p.append("<h2>crash taxonomy</h2><div class=cols>")
+    p.append(_bars_panel("by dedup label", agg["by_label"]))
+    p.append(_bars_panel("by kind", agg["by_kind"]))
+    p.append("</div>")
+    p.append("<h2>modules</h2><div class=cols>")
+    p.append(_bars_panel("most crash-productive (crashes)", agg["by_module_crash"]))
+    p.append(_rate_panel("highest crash-rate (crashes/hits, &ge;5 hits)", agg.get("modules", {})))
+    p.append("</div>")
+    p.append("<script>%s</script></body></html>" % _SORT_JS)
+    return "".join(p)
 
 
 # --------------------------------------------------------------------------------- CLI
@@ -482,11 +678,16 @@ def main(argv=None) -> int:
     ap.add_argument(
         "--json", action="store_true", help="emit machine-readable JSON instead of text"
     )
+    ap.add_argument("--html", metavar="PATH", help="write a self-contained HTML dashboard to PATH")
     ap.add_argument("--no-systemd", action="store_true", help="skip systemctl enrichment")
     args = ap.parse_args(argv)
 
     def once():
         rep = build_report(args.fleet_dir, args.instance, systemd=not args.no_systemd)
+        if args.html:
+            with open(args.html, "w", encoding="utf-8") as fh:
+                fh.write(render_html(rep))
+            return "wrote HTML dashboard: %s" % args.html
         if args.json:
             return json.dumps(rep, default=str)
         return render(rep, args.instance)

--- a/tests/python/test_fleet_report.py
+++ b/tests/python/test_fleet_report.py
@@ -158,5 +158,71 @@ class TestAnomaliesAndRender(unittest.TestCase):
             self.assertIn("json", inst)
 
 
+class TestCrashRateAndHtml(unittest.TestCase):
+    def test_crash_rate_modules(self):
+        modules = {
+            "hot": {"hits": 20, "crashes": 20, "timeouts": 0},  # 100%
+            "warm": {"hits": 10, "crashes": 5, "timeouts": 0},  # 50%
+            "quiet": {"hits": 40, "crashes": 0, "timeouts": 0},  # 0%
+            "rare": {"hits": 2, "crashes": 2, "timeouts": 0},  # below min_hits
+        }
+        rows = fr.crash_rate_modules(modules, min_hits=5)
+        names = [r[0] for r in rows]
+        self.assertEqual(
+            names, ["hot", "warm", "quiet"]
+        )  # sorted by rate desc, min_hits drops 'rare'
+        self.assertAlmostEqual(dict((n, rate) for n, rate, _ in rows)["warm"], 50.0)
+
+    def test_campaign_aggregates_modules(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for inst, mod in (("inst-01", "json"), ("inst-02", "json")):
+                r = os.path.join(tmp, inst, "python")
+                os.makedirs(r)
+                _sidecar(
+                    os.path.join(r, "fusil_stats.json"),
+                    sessions=10,
+                    modules={mod: {"hits": 10, "crashes": 4, "timeouts": 0}},
+                )
+            agg = fr.build_report(tmp, None, systemd=False, now=2000.0)["campaign"]
+            self.assertEqual(agg["modules"]["json"], {"hits": 20, "crashes": 8, "timeouts": 0})
+
+    def test_render_html_is_self_contained(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r1 = os.path.join(tmp, "inst-01", "python")
+            os.makedirs(r1)
+            _sidecar(
+                os.path.join(r1, "fusil_stats.json"),
+                sessions=100,
+                crashes=2,
+                modules={"jsonmod": {"hits": 100, "crashes": 50, "timeouts": 0}},
+            )
+            _crash(r1, "jsonmod-sigsegv-oomNEW")
+            report = fr.build_report(tmp, None, systemd=False, now=2000.0)
+            doc = fr.render_html(report, generated="fixed-time")
+            self.assertTrue(doc.startswith("<!doctype html"))
+            self.assertIn("<style>", doc)  # embedded CSS -> self-contained
+            self.assertIn("<script>", doc)  # embedded JS
+            self.assertNotIn("http://", doc)  # no external assets
+            self.assertNotIn("https://", doc)
+            self.assertIn("jsonmod", doc)
+            self.assertIn("table class=sortable", doc)
+            # HTML is well-formed enough to parse without raising
+            import html.parser
+
+            html.parser.HTMLParser().feed(doc)
+
+    def test_main_writes_html_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r1 = os.path.join(tmp, "inst-01", "python")
+            os.makedirs(r1)
+            _sidecar(os.path.join(r1, "fusil_stats.json"), sessions=5, crashes=1)
+            out = os.path.join(tmp, "dash.html")
+            rc = fr.main(["--fleet-dir", tmp, "--no-systemd", "--html", out])
+            self.assertEqual(rc, 0)
+            self.assertTrue(os.path.exists(out))
+            with open(out, encoding="utf-8") as fh:
+                self.assertIn("fusil fleet", fh.read())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Phase 2 of fleet observability**, building on the Phase 1 `fleet_report` (#171). Two pure-reporter additions — no new instrumentation, both reuse the existing sidecar + post-hoc data.

## `--html PATH` — self-contained dashboard
A single-file, zero-asset HTML dashboard (embedded CSS + a tiny vanilla-JS click-to-sort, in the spirit of lafleur's campaign dashboard — imitated, not imported; minus the coverage/lineage columns fusil has no data for):
- **KPI cards**: sessions, throughput, crashes, find-rate, oomNEW, timeouts, disk.
- **Sortable instance leaderboard** (click any header): #, gil, state (colored run/stop badge), uptime, sessions, s/min, crash, NEW, TO%, mem, disk.
- **Bar-in-cell panels**: crash taxonomy (by dedup label + by kind) and modules (most crash-productive + highest crash-rate).
- **Health badges** (green nominal / red flagged).

Fronted by `./fleet report --html PATH` (composes with `--watch`, rewriting each cycle). All dynamic text is HTML-escaped.

## Per-module crash-rate
`crash_rate_modules()` surfaces which fuzzed modules most reliably crash (**crashes/hits**, ≥5 hits) — the productivity signal the raw counts miss (a high-hit/low-crash module is quiet; one that crashes on nearly every hit is a hot target). Shown in the text report (per-instance + campaign) and the HTML. Campaign aggregation now also sums per-module `{hits,crashes,timeouts}` across instances (`agg["modules"]`).

## Verification
- Tests: crash-rate ranking + min-hits filter, campaign per-module aggregation, `render_html` is self-contained + well-formed (HTMLParser) + escapes + no external assets, and `main --html` writes the file. **Full suite 386 OK**; `ruff check` + `ruff format --check` clean; `bash -n fleet/fleet` OK.
- Validated against the **live fusil-fleet6** run (`--oom-foreign-pythonmalloc`): 9.9 KB dashboard, 4-instance leaderboard, taxonomy showing the pythonmalloc noise (`oomclean`/`exitcode1` dominant), crash-rate all ~100% (expected under that flag).

## Deferred from the Phase 2 plan
The **health-event JSONL** — it needs new `StatsAgent` instrumentation and a design choice (discrete adverse-events vs a periodic **timeseries** for throughput-trend / stall detection, which is the more valuable version for a non-coverage-guided fuzzer). Scoped separately so this PR stays pure-reporter and low-risk; happy to do it next if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)