### PR TITLE
OOM dedup: denylist Py_DECREF_MORTAL/!_Py_IsStaticImmortal UAF detector

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -38,6 +38,24 @@ IMPORTERR = re.compile(r"(ModuleNotFoundError|ImportError):")
 # Generic fatal wrappers that carry no usable site in stdout -> resolve via gdb instead.
 GENERIC_FATAL = ("_PyObject_AssertFailed", "_Py_NegativeRefcount")
 
+# Generic assert DETECTORS -- the assert() analog of GENERIC_FATAL. `Py_DECREF_MORTAL`'s
+# `!_Py_IsStaticImmortal(op)` fires when a mortal decref hits an object whose refcount word has
+# been corrupted to read back as static-immortal -- i.e. an over-decref / use-after-free where
+# the freed block's 0xDD PYMEM_DEADBYTE fill happens to set the static-immortal flag bits. It
+# CATCHES the corruption exactly like `_Py_NegativeRefcount` catches the negative-refcount face
+# of the SAME family (frame-teardown / eval-loop over-decref); the assert site (pycore_object.h
+# Py_DECREF_MORTAL) is never the defect. So carry NO site from it: drop it as a candidate and
+# resolve PAST it to the real caller (producer), just like a generic fatal. Matched by the
+# asserting FUNC or the expr (either alone is enough -- func parsing can vary by build). Kept in
+# lockstep with the catalog's gen_known_sites.GENERIC_DETECTOR_FUNCS / GENERIC_ASSERTS.
+GENERIC_ASSERT_FUNCS = ("Py_DECREF_MORTAL",)
+GENERIC_ASSERT_EXPRS = ("!_Py_IsStaticImmortal(op)",)
+
+
+def _is_generic_assert(func, expr):
+    """True if an assertion is a generic over-decref/UAF detector (carries no real site)."""
+    return func in GENERIC_ASSERT_FUNCS or expr in GENERIC_ASSERT_EXPRS
+
 
 def _nf(f):
     return f.lstrip("./")
@@ -108,7 +126,14 @@ def classify(text):
     ``kind`` in {abort, fatal, segv, import, clean} plus the *first* resolved signal."""
     a = all_asserts(text)
     if a:
-        f, ln, func, expr = a[0]
+        # Drop generic-detector asserts (Py_DECREF_MORTAL/!_Py_IsStaticImmortal): like a generic
+        # fatal they carry no real site -> treat as segv so callers resolve past them.
+        real = [t for t in a if not _is_generic_assert(t[2], t[3])]
+        if not real:
+            return dict(
+                kind="segv", file=None, line=None, func=None, assert_expr=None, fatal_msg=None
+            )
+        f, ln, func, expr = real[0]
         return dict(kind="abort", file=f, line=ln, func=func, assert_expr=expr, fatal_msg=None)
     fa = FATAL.search(text)
     if fa and not SEGV.search(text):
@@ -476,6 +501,13 @@ class Deduper:
     def decide(self, stdout_text, source_path=None):
         """Return (keep: bool, label: str) for one crash, matching ALL of its signals."""
         asserts = all_asserts(stdout_text)
+        # Split off generic-detector asserts (Py_DECREF_MORTAL/!_Py_IsStaticImmortal): like a
+        # generic fatal they carry no real site, so don't key them -- resolve past them instead.
+        # ``generic_assert`` = the crash's ONLY assertion(s) were such detectors.
+        real_asserts = [
+            (f, ln, fn, expr) for (f, ln, fn, expr) in asserts if not _is_generic_assert(fn, expr)
+        ]
+        generic_assert = bool(asserts) and not real_asserts
         fa = FATAL.search(stdout_text)
         fmsg = fa.group(1).strip() if fa else None
         has_segv = bool(SEGV.search(stdout_text))
@@ -485,22 +517,30 @@ class Deduper:
         if not asserts and not has_segv and not fmsg:
             return True, ("oomimport" if IMPORTERR.search(stdout_text) else "oomclean")
 
-        # Build candidate signals from everything the crash offers.
+        # Build candidate signals from everything the crash offers (generic-detector asserts
+        # dropped -- they never key a real site).
         candidates = [
             dict(file=f, line=ln, func=fn, assert_expr=expr, fatal_msg=None)
-            for (f, ln, fn, expr) in asserts
+            for (f, ln, fn, expr) in real_asserts
         ]
         if fmsg and not generic_fatal and not fmsg.lower().startswith(("segmentation", "aborted")):
             candidates.append(
                 dict(file=None, line=None, func=None, assert_expr=None, fatal_msg=fmsg)
             )
         # Resolve a crash site when the stdout assertion text is unreliable (pure segv /
-        # generic-assert fatal) or nothing matched yet. PREFER the native backtrace the
+        # generic-assert fatal) or there is no assertion at all. PREFER the native backtrace the
         # crash already printed (ASan/debug build, captured in stdout): it is the actual
         # fault, so it is deterministic -- unlike a gdb re-run, which can fail to reproduce
         # under a different hash seed or thread timing and leave the crash mislabelled
         # oomSEGV. Fall back to a gdb re-run of source.py only when stdout has no parseable
         # native frames and --oom-dedup-resolve-segv is set.
+        #
+        # Guard on ``not asserts`` (NOT ``not real_asserts``): a pure generic-detector assert
+        # (Py_DECREF_MORTAL/!_Py_IsStaticImmortal) must NOT trigger resolution. Its producer
+        # already returned, so every backtrace method (native/gdb/faulthandler) yields only frame
+        # teardown + bystander frames -- a gdb re-run would be slow AND resolve to a bystander
+        # (Py_DECREF_MORTAL itself, or the eval frame -> spurious oomNEW / mis-fold). Leave it to
+        # the needs-resolution branch below; the real producer is pinned offline via rr.
         chain = []
         if has_segv or generic_fatal or not asserts:
             chain = extract_native_sites(stdout_text)
@@ -521,6 +561,11 @@ class Deduper:
         # Faulthandler-only fallback: a SEGV/generic-fatal with no ASan file:line frames and
         # no gdb resolution still carries func names in the faulthandler C stack -- match the
         # innermost catalog-keyed func by name (e.g. PyList_New -> OOM-0004) before giving up.
+        # NOT done for a generic-detector assert (Py_DECREF_MORTAL/!_Py_IsStaticImmortal): its
+        # producer is an over-decref that already returned, so the visible stack is only frame
+        # teardown + innocent-bystander call frames -- matching one by name mis-folds the UAF
+        # into an unrelated bug (e.g. a generic _PyObject_MakeTpCall frame -> OOM-0026). Those
+        # need rr to pin the producer, so leave them needs-resolution.
         if not matched and not chain and (has_segv or generic_fatal):
             matched |= fh_match(stdout_text, self.snap)[0]
 
@@ -533,8 +578,12 @@ class Deduper:
             return True, oid
 
         # Nothing matched the catalog.
-        if has_segv and not chain and not asserts:
-            self.seen["segv:unresolved"] += 1
+        if (has_segv or generic_assert) and not chain and not real_asserts:
+            # A pure segv, or a generic-detector over-decref assert (Py_DECREF_MORTAL/
+            # !_Py_IsStaticImmortal) we couldn't resolve to a real caller: it's the over-decref/
+            # UAF family (needs rr to fold), NOT a discriminating new site. Keep it as
+            # needs-resolution, never oomNEW -- mirrors ingest's needs_gdb bucket.
+            self.seen["segv:unresolved" if has_segv else "assert:unresolved"] += 1
             return True, "oomSEGV"  # couldn't resolve a site -> always keep
         prim = candidates[0] if candidates else {}
         key = (

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -43,6 +43,23 @@ FATAL_0022 = "Fatal Python error: _Py_CheckSlotResult: Slot __delitem__ of type 
 GENERIC_FATAL = "Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed"
 SEGV = "Fatal Python error: Segmentation fault\nCurrent thread's C stack trace ..."
 ABORT_NEW = "python: Objects/brandnew.c:5: void totally_new(void): Assertion `nope' failed."
+# The generic over-decref/UAF DETECTOR assert: Py_DECREF_MORTAL's !_Py_IsStaticImmortal(op)
+# fires on a freed object whose refcount word reads back as static-immortal. Carries no real
+# site (like _Py_NegativeRefcount) -> must NOT become a discriminating oomNEW key. The
+# faulthandler C stack's innermost real frames are themselves generic teardown detectors.
+ABORT_IMMORTAL = "\n".join(
+    [
+        "python: ./Include/internal/pycore_object.h:414: void Py_DECREF_MORTAL"
+        "(const char *, int, PyObject *): Assertion `!_Py_IsStaticImmortal(op)' failed.",
+        "Fatal Python error: Aborted",
+        "Current thread's C stack trace (most recent call first):",
+        '  Binary file "/build/python", at _Py_DumpStack+0x32 [0x1]',
+        '  Binary file "/lib/libc.so.6", at abort+0x27 [0x2]',
+        '  Binary file "/build/python", at _PyFrame_ClearLocals+0x142 [0x3]',
+        '  Binary file "/build/python", at _PyFrame_ClearExceptCode+0x50e [0x4]',
+        '  Binary file "/build/python", at _PyEval_EvalFrameDefault+0x39124 [0x5]',
+    ]
+)
 
 
 class TestClassify(unittest.TestCase):
@@ -62,6 +79,17 @@ class TestClassify(unittest.TestCase):
     def test_generic_assert_fatal_routes_to_segv(self):
         # carries no real site -> must not be trusted as a known fatal
         self.assertEqual(oom_dedup.classify(GENERIC_FATAL)["kind"], "segv")
+
+    def test_generic_detector_assert_routes_to_segv(self):
+        # Py_DECREF_MORTAL/!_Py_IsStaticImmortal is a generic UAF detector -> no real site,
+        # classify past it like a generic fatal (kind=segv), never a trusted abort site.
+        c = oom_dedup.classify(ABORT_IMMORTAL)
+        self.assertEqual(c["kind"], "segv")
+        self.assertIsNone(c["assert_expr"])
+        # but a REAL assert alongside the detector still wins (its site is the discriminator).
+        real = ABORT_IMMORTAL + "\n" + ABORT_0003
+        self.assertEqual(oom_dedup.classify(real)["kind"], "abort")
+        self.assertEqual(oom_dedup.classify(real)["func"], "code_dealloc")
 
     def test_segv_and_import_and_clean(self):
         self.assertEqual(oom_dedup.classify(SEGV)["kind"], "segv")
@@ -161,6 +189,53 @@ class TestDeduper(unittest.TestCase):
     def test_prune_disabled_keeps_all(self):
         d = self._deduper(keep=1, prune=False)
         self.assertTrue(all(d.decide(ABORT_0003)[0] for _ in range(5)))
+
+
+class TestGenericDetectorAssert(unittest.TestCase):
+    """Py_DECREF_MORTAL/!_Py_IsStaticImmortal is the assert() face of the over-decref/UAF
+    family (like _Py_NegativeRefcount): a generic detector, never a real site. It must fold
+    to needs-resolution (oomSEGV), NOT flood ./fleet finds as a discriminating oomNEW."""
+
+    def _deduper(self, resolver=None, keep=5, prune=False):
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(SNAPSHOT)
+        self.addCleanup(os.unlink, path)
+        return oom_dedup.Deduper(
+            path, keep=keep, prune=prune, resolve_segv=resolver is not None, segv_resolver=resolver
+        )
+
+    def test_unresolved_immortal_assert_is_segv_not_new(self):
+        # No ASan frames, no resolver, and the faulthandler C stack's real frames are
+        # themselves teardown detectors -> can't resolve a producer -> needs-resolution.
+        keep, label = self._deduper().decide(ABORT_IMMORTAL, source_path=None)
+        self.assertTrue(keep)
+        self.assertEqual(label, "oomSEGV")
+
+    def test_immortal_assert_never_pruned(self):
+        # never a discriminating new/known site -> always kept even with prune on.
+        d = self._deduper(keep=1, prune=True)
+        for _ in range(3):
+            self.assertEqual(d.decide(ABORT_IMMORTAL)[0], True)
+
+    def test_immortal_assert_does_not_trigger_gdb_resolution(self):
+        # A pure detector assert must NOT run the (slow, per-crash) gdb re-run: its producer
+        # already returned, so resolution only yields frame-teardown / bystander frames. Even
+        # with resolve_segv on and a resolver that WOULD match a bug, the resolver is never
+        # called and it stays oomSEGV -- the producer is pinned offline via rr, not in-loop.
+        called = []
+        d = self._deduper(
+            resolver=lambda sp: called.append(sp) or ["dictiter_dealloc@Objects/dictobject.c:5532"]
+        )
+        self.assertEqual(d.decide(ABORT_IMMORTAL, source_path="s"), (True, "oomSEGV"))
+        self.assertEqual(called, [])
+
+    def test_immortal_assert_never_keys_pycore_object_site(self):
+        # regression: the raw assert site must never appear as an oomNEW key.
+        d = self._deduper()
+        d.decide(ABORT_IMMORTAL, source_path=None)
+        self.assertFalse(any("_Py_IsStaticImmortal" in k for k in d.seen))
+        self.assertFalse(any("pycore_object.h" in k for k in d.seen))
 
 
 class TestHardening(unittest.TestCase):


### PR DESCRIPTION
Closes #173.

The `Py_DECREF_MORTAL` assert `!_Py_IsStaticImmortal(op)` (`pycore_object.h:414`) is the `assert()` face of the known over-decref/UAF family, the exact analog of `_Py_NegativeRefcount`: it fires when a mortal decref hits an already-freed object whose refcount word reads back as static-immortal (the `0xDD` `PYMEM_DEADBYTE` fill sets the static-immortal flag bits). The assert site is a generic detector — the real defect is the producer/frame-teardown caller — so keying it made every such crash a distinct, non-actionable `oomNEW` (**53 dirs/run on fusil-fleet6 python-2**).

### Change
- `classify()` / `decide()`: `GENERIC_ASSERT_FUNCS` / `GENERIC_ASSERT_EXPRS` + `_is_generic_assert` drop generic-detector asserts as candidate keys; a pure detector crash is labeled `oomSEGV` (needs-resolution, always kept) instead of `oomNEW`.
- A pure detector assert does **not** trigger in-loop resolution: the chain guard stays `not asserts` and `fh_match` is not consulted for it. Its producer already returned, so a gdb re-run (the fleet sets `--oom-dedup-resolve-segv`) would be slow AND resolve to a bystander (`Py_DECREF_MORTAL` itself, or the eval frame → spurious `oomNEW` / mis-fold). **Verified: 8/53 mis-folded into OOM-0026** via its generic `_PyObject_MakeTpCall` funcname key before this guard. The real producer is pinned offline via rr.
- A genuine segv / `_Py_NegativeRefcount` fatal still resolves normally; a real assert alongside the detector still wins its site.

### Verification
- Full suite **391 OK**; `ruff check` + `ruff format --check` clean.
- Adds `TestGenericDetectorAssert` (4 cases) + a `classify` case.
- `ingest.py '.../fusil-fleet6/inst-*/python-2/*oomNEW*'` moves all 53 immortal-assert dirs OUT of "NEW crash sites" into needs-resolution.

Kept in lockstep with the sibling `cpython-oom-findings` catalog's `gen_known_sites` `GENERIC_DETECTOR_FUNCS` / `GENERIC_ASSERTS` + `ingest.classify_dir` (mirrored there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)