### PR TITLE
OOM dedup: skip generic call/vectorcall/stackref frames in fh_match by-name

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -338,7 +338,19 @@ _FH_SKIP = re.compile(
     r"|fatal_error\w*|_Py_FatalError\w*|_PyObject_AssertFailed|_Py_NegativeRefcount"
     r"|_Py_Dealloc|_Py_MergeZeroLocalRefcount|Py_X?DECREF|Py_X?INCREF|_Py_X?DECREF\w*"
     r"|_PyMem_Debug\w*|PyMem_\w*Free|PyObject_\w*Free|PyMem_\w*Realloc|PyObject_\w*Realloc"
-    r"|hook_f\w+|tracemalloc_\w+)$"
+    r"|hook_f\w+|tracemalloc_\w+"
+    # Generic call/vectorcall dispatch trampolines + every *StackRef* frame (where an over-decref'd
+    # object's stolen stackref is dereferenced) -- bystanders in the over-decref/UAF family, never a
+    # real crash site. Skip them in this BY-NAME faulthandler walk so a faulthandler-only over-decref
+    # segv doesn't fh_match a bug that incidentally keys one: OOM-0026 absorbed 210 unrelated dirs via
+    # _PyObject_MakeTpCall on fusil-fleet7, and skipping only that exposed _Py_VectorCall_StackRefSteal
+    # -> OOM-0015/21 and _Py_BuiltinCallFastWithKeywords_StackRef -> OOM-0013/28. Bugs KEEP every
+    # func/line/assert key (a real OOM-0013 still matches via its result/error-contract assert, etc.);
+    # those keys just become inert here. Lockstep with the catalog's ingest.FH_SKIP. NOT skipped: the
+    # convention-specific cfunction_vectorcall_*/cfunction_check_kwargs (OOM-0015/0031) nor the result-
+    # check detectors _Py_CheckFunctionResult/_Py_CheckSlotResult (OOM-0021/0022) -- real defining sites.
+    r"|_PyObject_MakeTpCall|cfunction_call|_PyObject_Call|_PyObject_VectorcallTstate"
+    r"|\w*StackRef\w*)$"
 )
 
 

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -640,6 +640,42 @@ class TestFaulthandlerMatch(unittest.TestCase):
         keep, label = d.decide(self._segv("_Py_Dealloc", "some_unkeyed_helper"))
         self.assertEqual(label, "oomSEGV")
 
+    def test_generic_call_dispatch_frames_never_match(self):
+        # Regression (fusil-fleet7): a faulthandler-only over-decref segv whose only catalog-keyed
+        # frame is a generic call/vectorcall/stackref-steal trampoline must NOT fh_match the bug
+        # that keys it (OOM-0026 absorbed 210 unrelated dirs via _PyObject_MakeTpCall). Build a
+        # snapshot keying such frames to a fake bug and assert they are skipped.
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        os.write(
+            fd,
+            (
+                SNAPSHOT + "\n"
+                "OOM-9001\tsegv\tfunc\tObjects/call.c:_PyObject_MakeTpCall\n"
+                "OOM-9001\tsegv\tfunc\tPython/ceval.c:_Py_VectorCall_StackRefSteal\n"
+                "OOM-9001\tsegv\tfunc\tPython/ceval.c:_Py_BuiltinCallFastWithKeywords_StackRef\n"
+            ).encode(),
+        )
+        os.close(fd)
+        self.addCleanup(os.remove, path)
+        snap = oom_dedup.load_snapshot_file(path)
+        # every generic dispatch/steal frame is skipped -> no match -> the segv needs resolution.
+        oids, fn = oom_dedup.fh_match(
+            self._segv(
+                "_PyTuple_FromStackRefStealOnSuccess",
+                "_Py_VectorCall_StackRefSteal",
+                "_PyObject_MakeTpCall",
+                "cfunction_call",
+                "_PyEval_EvalFrameDefault",
+            ),
+            snap,
+        )
+        self.assertEqual((oids, fn), (set(), None))
+        # but a real discriminating frame deeper than the generic plumbing still wins.
+        oids2, fn2 = oom_dedup.fh_match(
+            self._segv("_PyObject_MakeTpCall", "dictiter_dealloc"), snap
+        )
+        self.assertEqual((oids2, fn2), ({"OOM-0006"}, "dictiter_dealloc"))
+
 
 class TestMsgFamily(unittest.TestCase):
     """msgfam catch-all: a new/fuzzer clears-exc type dedups to the family (OOM-0023) while


### PR DESCRIPTION
Closes #175.

`fh_match` (the faulthandler-only by-name fallback) matches the innermost catalog-keyed func *by name*. Bugs incidentally key generic call-dispatch plumbing (`_PyObject_MakeTpCall`, `cfunction_call`, `_PyObject_Call`, `_PyObject_VectorcallTstate`) and the `*StackRef*` frames where an over-decref'd object's stolen stackref is dereferenced — bystanders on the path to every C call, never a real crash site. So faulthandler-only over-decref segvs get absorbed into whatever bug keys them.

### Observed (fusil-fleet7)
- **210** unrelated over-decref segvs mislabeled **OOM-0026** via `_PyObject_MakeTpCall`
- same population over-matches **OOM-0015|0021** (`_Py_VectorCall_StackRefSteal`) and **OOM-0013|0028** (`_Py_BuiltinCallFastWithKeywords_StackRef`)
- all belong in needs-resolution (`oomSEGV`) for rr, like the already-unkeyed sibling steal frames

### Fix
Add the generic dispatchers + a `\w*StackRef\w*` catch-all to `_FH_SKIP`. **By-name skip only** — every bug KEEPS all its func/line/assert keys, so no dedup regression (a real OOM-0013 abort still matches via its `(res!=NULL)^(PyErr_Occurred()!=NULL)` assert; OOM-0015 via its `_Py_CheckFunctionResult` msg). The keys just become inert in the by-name walk. **Not** skipped: the convention-specific `cfunction_vectorcall_*`/`cfunction_check_kwargs` and the result-check detectors `_Py_CheckFunctionResult`/`_Py_CheckSlotResult` — real defining sites.

Verified via `ingest` over fleet7: OOM-0026 (210), OOM-0015|0021 (187), OOM-0013|0028 (391) all move to `needs_gdb`; the de-cluttered NEW-sites list then surfaces the one genuinely-new crash (a dict-freelist assert). Adds a regression test; full suite OK, ruff clean.

Lockstep with the sibling `cpython-oom-findings` catalog's `ingest.FH_SKIP`. Scope: the by-name faulthandler path only — the resolved-backtrace (ASan/gdb) path, where over-decref segvs still lack a discriminating site, is the separate needs-rr problem and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)