### PR TITLE
OOM dedup: skip-list the tuple_alloc:48 tuple-freelist corruption detector

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -56,8 +56,19 @@ GENERIC_FATAL = ("_PyObject_AssertFailed", "_Py_NegativeRefcount")
 # next-pointer (a real dict addr minus one byte) -> new_dict later pops the poisoned chain. Generic
 # (any freelist-corrupting producer trips it), so treat it the same way -> oomSEGV / rr-triage.
 # Expr only, NOT the `new_dict` func (dict allocation, not a pure detector -- may carry other asserts).
+#
+# `PyTuple_Check(op)` (tuple_alloc, Objects/tupleobject.c:48, via _PyTuple_RESET_HASH_CACHE) is the
+# TUPLE-freelist analog: the block popped from the tuple freelist isn't a tuple. The already-documented
+# OOM-0036 "tuple_alloc freelist SEGV" face, in its debug-abort form -- same list.append double-free,
+# victim=tuple landing on the tuple freelist. Generic tuple-freelist-corruption detector. Expr only
+# (the exact expr `PyTuple_Check(op)` is unique to the tuple-alloc hash-cache-reset -- other RESET
+# sites use `result`/`newobj`); NOT the `tuple_alloc` func (it also asserts `size != 0`).
 GENERIC_ASSERT_FUNCS = ("Py_DECREF_MORTAL",)
-GENERIC_ASSERT_EXPRS = ("!_Py_IsStaticImmortal(op)", "mp == NULL || Py_IS_TYPE(mp, &PyDict_Type)")
+GENERIC_ASSERT_EXPRS = (
+    "!_Py_IsStaticImmortal(op)",
+    "mp == NULL || Py_IS_TYPE(mp, &PyDict_Type)",
+    "PyTuple_Check(op)",
+)
 
 
 def _is_generic_assert(func, expr):

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -76,6 +76,21 @@ ABORT_DICT_FREELIST = "\n".join(
         '  Binary file "/build/python", at _PyEval_EvalFrameDefault+0xc4ac [0x4]',
     ]
 )
+# The tuple-freelist analog: tuple_alloc's `PyTuple_Check(op)` fires when a block popped from the
+# tuple freelist isn't a tuple -- the debug-abort form of the documented OOM-0036 "tuple_alloc
+# freelist SEGV" face. Generic -> must NOT become a discriminating oomNEW key.
+ABORT_TUPLE_FREELIST = "\n".join(
+    [
+        "python: Objects/tupleobject.c:48: PyTupleObject *tuple_alloc(Py_ssize_t): "
+        "Assertion `PyTuple_Check(op)' failed.",
+        "Fatal Python error: Aborted",
+        "Current thread's C stack trace (most recent call first):",
+        '  Binary file "/build/python", at _Py_DumpStack+0x32 [0x1]',
+        '  Binary file "/lib/libc.so.6", at abort+0x27 [0x2]',
+        '  Binary file "/build/python", at _PyTuple_FromStackRefStealOnSuccess+0x29 [0x3]',
+        '  Binary file "/build/python", at _PyEval_EvalFrameDefault+0x8513 [0x4]',
+    ]
+)
 
 
 class TestClassify(unittest.TestCase):
@@ -111,6 +126,13 @@ class TestClassify(unittest.TestCase):
         # new_dict's `mp == NULL || Py_IS_TYPE(mp, &PyDict_Type)` is a generic dict-freelist
         # corruption detector (an OOM-0036 face) -> no real site, classify past it (kind=segv).
         c = oom_dedup.classify(ABORT_DICT_FREELIST)
+        self.assertEqual(c["kind"], "segv")
+        self.assertIsNone(c["assert_expr"])
+
+    def test_tuple_freelist_detector_assert_routes_to_segv(self):
+        # tuple_alloc's `PyTuple_Check(op)` is the tuple-freelist analog (an OOM-0036 face) ->
+        # no real site, classify past it (kind=segv).
+        c = oom_dedup.classify(ABORT_TUPLE_FREELIST)
         self.assertEqual(c["kind"], "segv")
         self.assertIsNone(c["assert_expr"])
 
@@ -267,6 +289,14 @@ class TestGenericDetectorAssert(unittest.TestCase):
         keep, label = d.decide(ABORT_DICT_FREELIST, source_path=None)
         self.assertEqual((keep, label), (True, "oomSEGV"))
         self.assertFalse(any("PyDict_Type" in k or "new_dict" in k for k in d.seen))
+
+    def test_tuple_freelist_assert_is_segv_not_new(self):
+        # tuple_alloc's tuple-freelist corruption assert (an OOM-0036 face) -> needs-resolution,
+        # never a distinct oomNEW keyed on tupleobject.c:48 / tuple_alloc.
+        d = self._deduper()
+        keep, label = d.decide(ABORT_TUPLE_FREELIST, source_path=None)
+        self.assertEqual((keep, label), (True, "oomSEGV"))
+        self.assertFalse(any("PyTuple_Check" in k or "tuple_alloc" in k for k in d.seen))
 
 
 class TestHardening(unittest.TestCase):


### PR DESCRIPTION
Closes #179.

`tuple_alloc`'s `PyTuple_Check(op)` (`tupleobject.c:48`, via `_PyTuple_RESET_HASH_CACHE`) fires when a block popped from the tuple freelist isn't a tuple — the tuple-freelist analog of `new_dict:961`, and the debug-abort form of the documented OOM-0036 "tuple_alloc freelist SEGV" face. Surfaced on fusil-fleet8 (`venv-assertion-oomNEW-2`).

Add its expr to `GENERIC_ASSERT_EXPRS` → a bare tuple-freelist abort surfaces as `oomSEGV`, not `oomNEW`. **Expr only** (unique to the tuple-alloc hash-cache reset), **not** the `tuple_alloc` func (it also asserts `size != 0`). Lockstep with the sibling catalog's `gen_known_sites.GENERIC_ASSERTS` + `ingest.GENERIC_ASSERT_EXPRS`.

Verified: the fleet8 vehicle now routes to needs-resolution. Adds classify + deduper tests; suite 60 OK, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)