### PR TITLE
oom-dedup: skip-list validate_list@gc.c:380 (OOM-0036 GC-head face)

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -63,7 +63,17 @@ GENERIC_FATAL = ("_PyObject_AssertFailed", "_Py_NegativeRefcount")
 # victim=tuple landing on the tuple freelist. Generic tuple-freelist-corruption detector. Expr only
 # (the exact expr `PyTuple_Check(op)` is unique to the tuple-alloc hash-cache-reset -- other RESET
 # sites use `result`/`newobj`); NOT the `tuple_alloc` func (it also asserts `size != 0`).
-GENERIC_ASSERT_FUNCS = ("Py_DECREF_MORTAL",)
+#
+# `validate_list` (Python/gc.c:380, `(gc->_gc_next & NEXT_MASK_UNREACHABLE) == next_value`) is the
+# GC-list-invariant checker run at collection/shutdown. It fires when a PyGC_Head is corrupted --
+# another OOM-0036 face: the list.append double-free's freed victim (e.g. an over-decref'd co_consts
+# str, freed one ref early) has its slot reused by a GC-tracked object (a shutdown weakref), and the
+# stale-stackref second decref decrements that object's `_gc_next` (flipping the NEXT_MASK_UNREACHABLE
+# bit) -> validate_list aborts at the next collection. Generic (any GC_Head-corrupting producer trips
+# it, and validate_list's every assert is a GC-invariant check, never the defect) -> resolve past it
+# to the producer / oomSEGV. Whole FUNC (all its asserts are detectors); does not collide OOM-0017,
+# which keys gc_decref/gc_get_refs/gc.c:96, not validate_list/gc.c:380.
+GENERIC_ASSERT_FUNCS = ("Py_DECREF_MORTAL", "validate_list")
 GENERIC_ASSERT_EXPRS = (
     "!_Py_IsStaticImmortal(op)",
     "mp == NULL || Py_IS_TYPE(mp, &PyDict_Type)",

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -91,6 +91,22 @@ ABORT_TUPLE_FREELIST = "\n".join(
         '  Binary file "/build/python", at _PyEval_EvalFrameDefault+0x8513 [0x4]',
     ]
 )
+# The GC-list-invariant DETECTOR assert: validate_list's `(gc->_gc_next & NEXT_MASK_UNREACHABLE)
+# == next_value` fires at collection/shutdown when a PyGC_Head is corrupted -- another OOM-0036
+# face (the freed double-free victim's slot is reused by a GC-tracked object whose _gc_next the
+# stale-stackref second decref decrements). Generic -> must NOT become a discriminating oomNEW key.
+ABORT_VALIDATE_LIST = "\n".join(
+    [
+        "python: Python/gc.c:380: void validate_list(PyGC_Head *, enum flagstates): "
+        "Assertion `(gc->_gc_next & NEXT_MASK_UNREACHABLE) == next_value' failed.",
+        "Fatal Python error: Aborted",
+        "Current thread's C stack trace (most recent call first):",
+        '  Binary file "/build/python", at _Py_DumpStack+0x32 [0x1]',
+        '  Binary file "/lib/libc.so.6", at abort+0x27 [0x2]',
+        '  Binary file "/build/python", at gc_collect_main+0x9ab [0x3]',
+        '  Binary file "/build/python", at _PyGC_Collect+0x41 [0x4]',
+    ]
+)
 
 
 class TestClassify(unittest.TestCase):
@@ -133,6 +149,13 @@ class TestClassify(unittest.TestCase):
         # tuple_alloc's `PyTuple_Check(op)` is the tuple-freelist analog (an OOM-0036 face) ->
         # no real site, classify past it (kind=segv).
         c = oom_dedup.classify(ABORT_TUPLE_FREELIST)
+        self.assertEqual(c["kind"], "segv")
+        self.assertIsNone(c["assert_expr"])
+
+    def test_validate_list_detector_assert_routes_to_segv(self):
+        # validate_list@gc.c:380 is a generic GC_Head-corruption detector (an OOM-0036 face) ->
+        # no real site, classify past it (kind=segv).
+        c = oom_dedup.classify(ABORT_VALIDATE_LIST)
         self.assertEqual(c["kind"], "segv")
         self.assertIsNone(c["assert_expr"])
 
@@ -297,6 +320,14 @@ class TestGenericDetectorAssert(unittest.TestCase):
         keep, label = d.decide(ABORT_TUPLE_FREELIST, source_path=None)
         self.assertEqual((keep, label), (True, "oomSEGV"))
         self.assertFalse(any("PyTuple_Check" in k or "tuple_alloc" in k for k in d.seen))
+
+    def test_validate_list_assert_is_segv_not_new(self):
+        # validate_list@gc.c:380's GC_Head-corruption assert (an OOM-0036 face) -> needs-resolution,
+        # never a distinct oomNEW keyed on gc.c:380 / validate_list.
+        d = self._deduper()
+        keep, label = d.decide(ABORT_VALIDATE_LIST, source_path=None)
+        self.assertEqual((keep, label), (True, "oomSEGV"))
+        self.assertFalse(any("validate_list" in k or "gc.c:380" in k for k in d.seen))
 
 
 class TestHardening(unittest.TestCase):


### PR DESCRIPTION
Closes #181.

`validate_list@gc.c:380` is the GC-list-invariant checker (collection/shutdown) — it *catches*
a corrupted `PyGC_Head`, never the defect. It is another **detector face of OOM-0036** (the
`list.append`-under-OOM double-free, python/cpython#151818): the freed victim's slot is reused by
a GC-tracked shutdown weakref whose `_gc_next` the stale-stackref second decref decrements
(flipping `NEXT_MASK_UNREACHABLE`) → `validate_list` aborts next collection.

Reproduced from scratch (`pkgutil.get_importer("<any str>")` under a `set_nomemory` window →
importlib `path.append` grow-fail); rr pinned the producer to
`_PyList_AppendTakeRefListResize@listobject.c:531 <- _CALL_LIST_APPEND`.

**Change:** add `validate_list` to `GENERIC_ASSERT_FUNCS` so a pure `validate_list` abort routes
to `oomSEGV`/rr-triage instead of keying `gc.c:380`. Whole func (all its asserts are GC-invariant
checks); does not collide OOM-0017 (`gc_decref`/`gc_get_refs`/`gc.c:96`). Two tests added
(`test_validate_list_detector_assert_routes_to_segv`, `test_validate_list_assert_is_segv_not_new`).
Kept in lockstep with the sibling catalog's `gen_known_sites`/`ingest`.

Verified: `test_oom_dedup` + `test_oom_dedup_wiring` (65 tests) pass; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)