### PR TITLE
feat(python): regex hit suppression (--suppress-hit-regex/-file) — closes #53

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,10 @@ PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe [options]
 #   --only-c                 only C-extension modules
 #   --sessions N             stop after N sessions
 #   --only-generate          write source.py without executing it
+#   --suppress-hit-regex R   drop a crashing session whose stdout matches regex R (repeatable);
+#                            --suppress-hit-file F reads rules from a file (one regex/line, '#'
+#                            comments, optional ' ## reason'); the general/non-OOM dedup path
+#                            (see Hit-suppression section). Composes with --oom-dedup-catalog.
 #   --oom-fuzz               OOM (allocation-failure) injection mode (see OOM section)
 #   --oom-seq                stateful call SEQUENCES (Phase 4): several calls per scan under
 #                            one failure window (found OOM-0036); --oom-seq-len/--oom-window;
@@ -201,6 +205,22 @@ via an injectable `segv_resolver`).
 `HANDOFF.md` + `CLAUDE.md` hold the campaign state, the commit/disclosure conventions, and
 how the maintainer and Claude work together. Read them before any outward-facing
 (issue / gist / PR) step.
+
+### Regex hit suppression — `--suppress-hit-regex` / `--suppress-hit-file`
+
+The general/non-OOM analogue of the OOM catalog dedupe: drop known/uninteresting *crashing
+sessions* by regex-matching their captured stdout (what a triager does by hand). Engine is
+`fusil/python/hit_suppression.py` — pure-Python, mirroring `oom_dedup.py`'s split (unit-tested
+in `tests/python/test_hit_suppression*.py`). Rules union three sources: repeatable
+`--suppress-hit-regex`, one or more `--suppress-hit-file` files (one regex/line; `#` comments;
+optional reason after ` ## `), and plugins via `PluginManager.add_suppression_entry` (the
+extensible store #52 asked for). `--suppress-hit-ignore-case` toggles case-insensitivity. On a
+crash, `Fuzzer._suppression_keep_policy` reads the session stdout (bounded via
+`read_crash_stdout`), and a match **prunes** the dir (reason logged) — returning `(False, None)`
+through the same `application.session_keep_policy` hook `SessionDirectory.checkKeepDirectory`
+consults. It **composes** with `--oom-dedup-catalog`: suppression runs first (a matched hit is
+pruned even if the OOM deduper would keep it); otherwise it defers to the OOM policy. Absent any
+`--suppress-hit-*` option, nothing is installed and behaviour is unchanged. Implements #53.
 
 ### JIT fuzzing — moved to lafleur (removed from fusil)
 

--- a/doc/python-fuzzer.md
+++ b/doc/python-fuzzer.md
@@ -91,6 +91,23 @@ signal/code; `WatchStdout` (`process/stdout.py`) matches the child's stdout/stde
 the child's stdout, the fuzzer's own diagnostics must go through the logger / stderr, not bare
 prints (see `fusil/application_logger.py`).
 
+### Hit suppression (`--suppress-hit-regex` / `--suppress-hit-file`)
+
+A run accumulates many *duplicate* crashing sessions — the same known abort/segfault site over
+and over — that a triager would normally drop by hand. `fusil/python/hit_suppression.py` (a pure
+engine, mirroring `oom_dedup.py`'s split) lets you drop those automatically: each rule is a regex
+`re.search`ed against a crashing session's captured stdout, and a match **prunes** the session
+dir (the reason is logged). Rules come from three composable sources, unioned — repeatable
+`--suppress-hit-regex`, one or more `--suppress-hit-file` files (one regex per line; `#` comments;
+an optional reason after ` ## `), and plugins (`PluginManager.add_suppression_entry`, the
+extensible store called for in #52). `--suppress-hit-ignore-case` makes matching
+case-insensitive.
+
+It wires in through the same `application.session_keep_policy` hook as the OOM dedupe and
+**composes** with it: suppression runs first (a matched hit is pruned even if the OOM deduper
+would keep it); otherwise control defers to the OOM policy if one is installed. This is the
+general/non-OOM analogue of `--oom-dedup-catalog` — it needs no catalog and works for any crash.
+
 ### Deep diving (`--deep-dive`, off by default)
 
 After a method call, the generator can recursively fuzz the call's *return value*
@@ -167,7 +184,7 @@ PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe [options]
 | Argument values / counts | `fusil/python/argument_generator.py`, `arg_numbers.py` |
 | Hostile inputs | `fusil/python/tricky_weird.py`, `samples/` |
 | OOM dedup engine | `fusil/python/oom_dedup.py` |
-| JIT generation | `fusil/python/jit/` |
+| Hit-suppression engine | `fusil/python/hit_suppression.py` |
 | Crash probes | `fusil/process/watch.py`, `process/stdout.py` |
 | Child setup / privilege drop / limits | `fusil/process/prepare.py`, `create.py`, `tools.py` |
 | MAS substrate | `fusil/mas/` |

--- a/fusil/plugin_manager.py
+++ b/fusil/plugin_manager.py
@@ -98,6 +98,19 @@ class NameFilterEntry:
 
 
 @dataclass
+class SuppressionEntry:
+    """A hit-suppression rule contributed by a plugin (issues #53/#52).
+
+    ``pattern`` is a regex matched (``re.search``) against a crashing session's stdout to
+    drop known/uninteresting hits, the same way ``--suppress-hit-regex`` does; ``reason``
+    is an optional human-readable note recorded in the logs when the rule fires.
+    """
+
+    pattern: str
+    reason: str | None = None
+
+
+@dataclass
 class PluginMetadata:
     """Metadata about a loaded plugin."""
 
@@ -125,6 +138,7 @@ class PluginManager:
         self.class_handlers: list[ClassHandler] = []
         self.blacklist_entries: list[NameFilterEntry] = []
         self.whitelist_entries: list[NameFilterEntry] = []
+        self.suppression_entries: list[SuppressionEntry] = []
         self.hooks: dict[str, list[Callable]] = {
             "startup": [],
             "shutdown": [],
@@ -294,6 +308,19 @@ class PluginManager:
         """
         self.whitelist_entries.append(NameFilterEntry(kind, pattern, pattern_type))
 
+    def add_suppression_entry(self, pattern: str, reason: str | None = None) -> None:
+        """Register a regex that suppresses a crashing-session hit when it matches stdout.
+
+        Lets a plugin drop known/uninteresting hits the same way ``--suppress-hit-regex``
+        does (issue #53); ``reason`` is recorded in the logs when the rule fires. This is
+        the plugin-extensible suppression store called for in #52.
+
+        Args:
+            pattern: a regex matched (``re.search``) against a crash's captured stdout.
+            reason: optional human-readable note logged when the rule suppresses a hit.
+        """
+        self.suppression_entries.append(SuppressionEntry(pattern=pattern, reason=reason))
+
     def add_hook(self, hook_name: str, hook_func: Callable) -> None:
         """
         Register a lifecycle hook.
@@ -412,6 +439,10 @@ class PluginManager:
     def is_whitelisted(self, kind: str, name: str) -> bool:
         """True if a plugin whitelisted `name` for the given `kind`."""
         return any(e.kind == kind and e.matches(name) for e in self.whitelist_entries)
+
+    def get_suppression_entries(self) -> list[tuple[str, str | None]]:
+        """Return plugin-registered hit-suppression rules as ``(pattern, reason)`` pairs."""
+        return [(e.pattern, e.reason) for e in self.suppression_entries]
 
     def get_active_mode(self, config: Any) -> FuzzingMode | None:
         """

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -136,6 +136,31 @@ class Fuzzer(Application):
             action="store_true",
             default=False,
         )
+        running_options.add_option(
+            "--suppress-hit-regex",
+            help="Drop a crashing-session hit whose stdout matches this regex (re.search), "
+            "the way troublesome/known crashes are deduplicated by hand. Repeatable; "
+            "composes with --suppress-hit-file and plugin rules (default: none)",
+            action="append",
+            dest="suppress_hit_regex",
+            default=None,
+        )
+        running_options.add_option(
+            "--suppress-hit-file",
+            help="Read hit-suppression regexes from FILE (one per line; '#' comments; an "
+            "optional reason after ' ## '). Repeatable; composes with --suppress-hit-regex "
+            "(default: none)",
+            action="append",
+            dest="suppress_hit_file",
+            default=None,
+        )
+        running_options.add_option(
+            "--suppress-hit-ignore-case",
+            help="Match --suppress-hit-regex / --suppress-hit-file patterns "
+            "case-insensitively (default: False)",
+            action="store_true",
+            default=False,
+        )
         fuzzing_options = OptionGroup(parser, "Fuzzing")
         fuzzing_options.add_option(
             "--functions-number",
@@ -515,6 +540,70 @@ class Fuzzer(Application):
                 )
             )
 
+        # Regex hit suppression (issue #53): drop known/uninteresting crashing-session hits
+        # whose stdout matches a user- or plugin-supplied regex -- the general/non-OOM analogue
+        # of the OOM-catalog dedupe above. Composes with it: suppression runs first (a matched
+        # hit is pruned even if the OOM deduper would keep it); otherwise the previously-installed
+        # policy (if any) still decides.
+        self._hit_suppressor = None
+        suppress_regexes = self.options.suppress_hit_regex or []
+        suppress_files = self.options.suppress_hit_file or []
+        plugin_suppressions = self.plugin_manager.get_suppression_entries()
+        if suppress_regexes or suppress_files or plugin_suppressions:
+            from fusil.python.hit_suppression import build_suppressor
+
+            self._hit_suppressor = build_suppressor(
+                regexes=suppress_regexes,
+                files=suppress_files,
+                plugin_entries=plugin_suppressions,
+                ignore_case=self.options.suppress_hit_ignore_case,
+            )
+            self._suppression_prev_policy = getattr(self, "session_keep_policy", None)
+            self.session_keep_policy = self._suppression_keep_policy
+            project.error(
+                "Hit suppression enabled: %d rule(s) (%d CLI, %d file(s), %d plugin)"
+                % (
+                    len(self._hit_suppressor.rules),
+                    len(suppress_regexes),
+                    len(suppress_files),
+                    len(plugin_suppressions),
+                )
+            )
+
+    def _suppression_keep_policy(self, session):
+        """Return (keep, label): drop a crashed session whose stdout matches a suppression
+        regex (issue #53), else defer to the previously-installed policy (e.g. OOM dedupe).
+
+        Consulted synchronously by SessionDirectory.checkKeepDirectory, where the stdout file
+        is already complete. Returns (True, None) on any error so a crash is never lost to a
+        suppression failure.
+        """
+        import os
+
+        session_dir = session.directory.directory
+        try:
+            from fusil.python.oom_dedup import read_crash_stdout
+
+            # Bounded read: a crashing session's stdout can be tens of MB; reading it whole
+            # would make the suppression regexes backtrack catastrophically in this
+            # synchronous keep-policy (runs in deinit).
+            text = read_crash_stdout(os.path.join(session_dir, "stdout"))
+            keep, rule = self._hit_suppressor.decide(text)
+            if not keep:
+                reason = " (%s)" % rule.reason if rule.reason else ""
+                self.error(
+                    "Hit suppressed by regex %r%s: prune %s" % (rule.pattern, reason, session_dir)
+                )
+                return False, None
+        except Exception as err:
+            self.error("Hit suppression failed (%s); keeping crash dir" % err)
+            return True, None
+        # Not suppressed: defer to the previous keep-policy (e.g. OOM dedupe) if one exists.
+        prev = getattr(self, "_suppression_prev_policy", None)
+        if prev is not None:
+            return prev(session)
+        return True, None
+
     def _oom_keep_policy(self, session):
         """Return (keep, label) for a crashed session from its captured stdout.
 
@@ -546,6 +635,8 @@ class Fuzzer(Application):
         super().exit(keep_log=keep_log)
         if getattr(self, "_deduper", None):
             self.error(self._deduper.report())
+        if getattr(self, "_hit_suppressor", None):
+            self.error(self._hit_suppressor.report())
         self.error(print_running_time(time_start))
 
 

--- a/fusil/python/hit_suppression.py
+++ b/fusil/python/hit_suppression.py
@@ -1,0 +1,147 @@
+"""Regex-based hit suppression for the Python fuzzer (issue #53).
+
+Pure-Python engine (no runtime stack), mirroring ``oom_dedup.py``'s split so it unit-tests
+in isolation. A "hit" is a crashing session that scored as a success; this engine decides,
+from that session's captured stdout, whether the hit matches a user- or plugin-supplied
+suppression regex -- a known or uninteresting crash the maintainer would otherwise drop by
+hand when deduplicating -- and should be pruned rather than persisted. The matched rule's
+reason is returned so the caller can record it in the logs.
+
+Rules come from three composable sources, unioned in this order:
+  * repeatable ``--suppress-hit-regex`` command-line options,
+  * one or more ``--suppress-hit-file`` files, and
+  * plugins (via ``PluginManager.add_suppression_entry`` -- issue #52).
+
+Suppression-file format (one rule per line):
+  * blank lines and lines whose first non-space character is ``#`` are ignored (comments),
+  * an optional human-readable reason may follow the regex after a `` ## `` separator, e.g.
+    ``Objects/dictobject\\.c:205 ## known FT set_keys OOM assert (benign on release)``.
+Matching is ``re.search`` over the decoded stdout, case-sensitive unless ``ignore_case``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Separator between a regex and its optional human reason in a suppression file. Chosen to be
+# readable in a hand-authored file and very unlikely to occur inside a real stdout regex.
+REASON_SEPARATOR = " ## "
+
+
+class InvalidSuppressionRule(ValueError):
+    """A suppression pattern failed to compile (bad regex)."""
+
+
+@dataclass
+class SuppressionRule:
+    """A compiled hit-suppression rule: a regex plus an optional human reason."""
+
+    pattern: str
+    reason: str | None
+    regex: re.Pattern[str]
+
+    def matches(self, text: str) -> bool:
+        return self.regex.search(text) is not None
+
+
+def compile_rule(
+    pattern: str, reason: str | None = None, ignore_case: bool = False
+) -> SuppressionRule:
+    """Compile a single pattern into a SuppressionRule, raising on a bad regex."""
+    flags = re.IGNORECASE if ignore_case else 0
+    try:
+        regex = re.compile(pattern, flags)
+    except re.error as err:
+        raise InvalidSuppressionRule(f"invalid suppression regex {pattern!r}: {err}") from err
+    return SuppressionRule(pattern=pattern, reason=reason, regex=regex)
+
+
+def parse_suppression_file(text: str, ignore_case: bool = False) -> list[SuppressionRule]:
+    """Parse a suppression file's contents into rules (see module docstring for format)."""
+    rules: list[SuppressionRule] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if REASON_SEPARATOR in line:
+            pattern, reason = line.split(REASON_SEPARATOR, 1)
+            reason = reason.strip() or None
+        elif line.endswith(REASON_SEPARATOR.rstrip()):
+            # a dangling ' ##' with an empty reason (the trailing space was stripped away)
+            pattern, reason = line[: -len(REASON_SEPARATOR.rstrip())], None
+        else:
+            pattern, reason = line, None
+        rules.append(compile_rule(pattern.strip(), reason, ignore_case=ignore_case))
+    return rules
+
+
+class HitSuppressor:
+    """Holds suppression rules and decides whether a crashing hit's stdout should be dropped."""
+
+    def __init__(self, rules):
+        self.rules = list(rules)
+        self.suppressed_count = 0
+        self._hits_by_pattern: dict[str, int] = {}
+
+    def __bool__(self):
+        return bool(self.rules)
+
+    def match(self, text: str) -> SuppressionRule | None:
+        """Return the first rule whose regex matches ``text``, or None."""
+        for rule in self.rules:
+            if rule.matches(text):
+                return rule
+        return None
+
+    def decide(self, text: str):
+        """Return ``(keep, rule)``: ``keep`` is False (drop the hit) when a rule matches.
+
+        On a match the hit is tallied for :meth:`report`; ``rule`` is the matched
+        :class:`SuppressionRule` (carrying ``.reason`` and ``.pattern``), or None when
+        nothing matched (``keep`` True).
+        """
+        rule = self.match(text)
+        if rule is None:
+            return True, None
+        self.suppressed_count += 1
+        self._hits_by_pattern[rule.pattern] = self._hits_by_pattern.get(rule.pattern, 0) + 1
+        return False, rule
+
+    def report(self) -> str:
+        """A one-shot summary of how many hits each rule dropped (for the exit log)."""
+        if not self.suppressed_count:
+            return "Hit suppression: no hits dropped (%d rule(s) active)" % len(self.rules)
+        lines = [
+            "Hit suppression: dropped %d hit(s) via %d of %d rule(s):"
+            % (self.suppressed_count, len(self._hits_by_pattern), len(self.rules))
+        ]
+        by_pattern = {r.pattern: r for r in self.rules}
+        for pattern, count in sorted(self._hits_by_pattern.items(), key=lambda kv: (-kv[1], kv[0])):
+            reason = by_pattern[pattern].reason if pattern in by_pattern else None
+            suffix = "  (%s)" % reason if reason else ""
+            lines.append("    %5d  %s%s" % (count, pattern, suffix))
+        return "\n".join(lines)
+
+
+def build_suppressor(
+    regexes=None, files=None, plugin_entries=None, ignore_case=False
+) -> HitSuppressor:
+    """Build a HitSuppressor from CLI regexes, suppression files, and plugin entries.
+
+    ``regexes``: iterable of pattern strings (from ``--suppress-hit-regex``).
+    ``files``: iterable of file paths (from ``--suppress-hit-file``), read as UTF-8.
+    ``plugin_entries``: iterable of ``(pattern, reason)`` pairs (PluginManager entries).
+    Rules are unioned in that order. Raises :class:`InvalidSuppressionRule` on a bad
+    pattern and lets file-read errors (OSError) propagate to the caller.
+    """
+    rules: list[SuppressionRule] = []
+    for pattern in regexes or ():
+        rules.append(compile_rule(pattern, None, ignore_case=ignore_case))
+    for path in files or ():
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        rules.extend(parse_suppression_file(text, ignore_case=ignore_case))
+    for pattern, reason in plugin_entries or ():
+        rules.append(compile_rule(pattern, reason, ignore_case=ignore_case))
+    return HitSuppressor(rules)

--- a/tests/python/test_hit_suppression.py
+++ b/tests/python/test_hit_suppression.py
@@ -1,0 +1,145 @@
+"""Unit tests for the regex hit-suppression engine (fusil.python.hit_suppression, issue #53).
+
+Pure-Python: exercises rule compilation, file parsing, the keep/drop decision, and the
+report, without the python-ptrace runtime stack, so it runs in the dev venv.
+"""
+
+import os
+import tempfile
+import unittest
+
+from fusil.python import hit_suppression as hs
+
+# A crash stdout that names a specific abort site (the kind the maintainer dedups by hand).
+CRASH = "\n".join(
+    [
+        "Fatal Python error: Segmentation fault",
+        "python: Objects/dictobject.c:205: set_keys: Assertion failed.",
+        "Current thread 0x00 (most recent call first):",
+    ]
+)
+
+
+class TestCompileRule(unittest.TestCase):
+    def test_valid_pattern_matches_via_search(self):
+        rule = hs.compile_rule(r"dictobject\.c:205", reason="known FT assert")
+        self.assertEqual(rule.reason, "known FT assert")
+        self.assertTrue(rule.matches(CRASH))
+        self.assertFalse(rule.matches("nothing to see here"))
+
+    def test_invalid_pattern_raises(self):
+        with self.assertRaises(hs.InvalidSuppressionRule):
+            hs.compile_rule(r"unbalanced(")
+
+    def test_ignore_case(self):
+        self.assertFalse(hs.compile_rule("ASSERTION").matches(CRASH))
+        self.assertTrue(hs.compile_rule("ASSERTION", ignore_case=True).matches(CRASH))
+
+
+class TestParseFile(unittest.TestCase):
+    def test_comments_blanks_and_reason_separator(self):
+        text = "\n".join(
+            [
+                "# a comment",
+                "",
+                "   ",
+                r"dictobject\.c:205 ## FT set_keys OOM assert",
+                r"segfault",
+                "  # indented comment is NOT stripped as comment (starts with space)",
+            ]
+        )
+        rules = hs.parse_suppression_file(text)
+        # 3 non-comment, non-blank lines. The "indented comment" starts with '#' after strip,
+        # so it IS treated as a comment.
+        self.assertEqual(len(rules), 2)
+        self.assertEqual(rules[0].pattern, r"dictobject\.c:205")
+        self.assertEqual(rules[0].reason, "FT set_keys OOM assert")
+        self.assertEqual(rules[1].pattern, "segfault")
+        self.assertIsNone(rules[1].reason)
+
+    def test_empty_reason_after_separator_is_none(self):
+        (rule,) = hs.parse_suppression_file("pattern ## ")
+        self.assertEqual(rule.pattern, "pattern")
+        self.assertIsNone(rule.reason)
+
+
+class TestHitSuppressor(unittest.TestCase):
+    def test_no_rules_keeps_everything(self):
+        sup = hs.HitSuppressor([])
+        self.assertFalse(sup)  # __bool__
+        keep, rule = sup.decide(CRASH)
+        self.assertTrue(keep)
+        self.assertIsNone(rule)
+
+    def test_match_drops_and_returns_rule(self):
+        sup = hs.HitSuppressor([hs.compile_rule(r"Objects/dictobject\.c:205", "known")])
+        self.assertTrue(sup)
+        keep, rule = sup.decide(CRASH)
+        self.assertFalse(keep)
+        self.assertEqual(rule.reason, "known")
+        self.assertEqual(sup.suppressed_count, 1)
+
+    def test_no_match_keeps(self):
+        sup = hs.HitSuppressor([hs.compile_rule("this-never-appears")])
+        keep, rule = sup.decide(CRASH)
+        self.assertTrue(keep)
+        self.assertIsNone(rule)
+        self.assertEqual(sup.suppressed_count, 0)
+
+    def test_first_matching_rule_wins(self):
+        first = hs.compile_rule("Fatal Python error", "generic fatal")
+        second = hs.compile_rule(r"dictobject\.c:205", "specific")
+        sup = hs.HitSuppressor([first, second])
+        _, rule = sup.decide(CRASH)
+        self.assertEqual(rule.reason, "generic fatal")
+
+    def test_report_counts_per_rule(self):
+        sup = hs.HitSuppressor(
+            [hs.compile_rule(r"dictobject\.c:205", "known site"), hs.compile_rule("never-here")]
+        )
+        for _ in range(3):
+            sup.decide(CRASH)
+        report = sup.report()
+        self.assertIn("dropped 3 hit(s)", report)
+        self.assertIn("dictobject", report)
+        self.assertIn("(known site)", report)
+
+    def test_report_when_nothing_dropped(self):
+        sup = hs.HitSuppressor([hs.compile_rule("x")])
+        self.assertIn("no hits dropped", sup.report())
+
+
+class TestBuildSuppressor(unittest.TestCase):
+    def test_unions_cli_file_and_plugin_rules(self):
+        fd, path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "w") as fh:
+            fh.write("from-file ## file reason\n")
+        self.addCleanup(os.unlink, path)
+
+        sup = hs.build_suppressor(
+            regexes=["from-cli"],
+            files=[path],
+            plugin_entries=[("from-plugin", "plugin reason")],
+        )
+        self.assertEqual(len(sup.rules), 3)
+        patterns = [r.pattern for r in sup.rules]
+        self.assertEqual(patterns, ["from-cli", "from-file", "from-plugin"])
+        # reasons: CLI rule has none; file/plugin carry theirs
+        self.assertIsNone(sup.rules[0].reason)
+        self.assertEqual(sup.rules[1].reason, "file reason")
+        self.assertEqual(sup.rules[2].reason, "plugin reason")
+
+    def test_ignore_case_propagates(self):
+        sup = hs.build_suppressor(regexes=["ASSERTION"], ignore_case=True)
+        self.assertFalse(sup.decide(CRASH)[0])
+
+    def test_bad_regex_raises(self):
+        with self.assertRaises(hs.InvalidSuppressionRule):
+            hs.build_suppressor(regexes=["oops("])
+
+    def test_empty_sources_build_empty(self):
+        self.assertFalse(hs.build_suppressor())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_hit_suppression_wiring.py
+++ b/tests/python/test_hit_suppression_wiring.py
@@ -1,0 +1,95 @@
+"""Wiring tests for the hit-suppression keep-policy glue (Fuzzer._suppression_keep_policy).
+
+Unlike test_hit_suppression (pure engine), this exercises the method SessionDirectory calls,
+so it imports the runtime stack and SKIPS where python-ptrace is unavailable. It locks the
+contract the core hook depends on: reading <session.directory.directory>/stdout, consulting
+the suppressor, deferring to a previously-installed policy (e.g. OOM dedupe) when nothing
+matches, suppression winning over that policy, and never losing a crash on a read error.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+try:
+    from fusil.python import Fuzzer
+    from fusil.python.hit_suppression import build_suppressor
+
+    HAVE_FUSIL = True
+except Exception:  # pragma: no cover - env without python-ptrace
+    HAVE_FUSIL = False
+
+CRASH = "python: Objects/dictobject.c:205: set_keys: Assertion failed."
+
+
+@unittest.skipUnless(HAVE_FUSIL, "fusil runtime stack (python-ptrace) not importable")
+class TestSuppressionKeepPolicy(unittest.TestCase):
+    def _fake_self(self, suppressor, prev_policy=None):
+        # `error` mirrors the Application logger the real Fuzzer has; the keep-policy uses it
+        # to log a suppression (or a failure before falling back to keep).
+        self.logged = []
+        return SimpleNamespace(
+            _hit_suppressor=suppressor,
+            _suppression_prev_policy=prev_policy,
+            error=lambda *a, **k: self.logged.append(a[0] if a else ""),
+        )
+
+    def _session(self, text):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d)
+        with open(os.path.join(d, "stdout"), "w") as fh:
+            fh.write(text)
+        return SimpleNamespace(directory=SimpleNamespace(directory=d))
+
+    def test_matching_hit_is_pruned_and_logged(self):
+        sup = build_suppressor(regexes=[r"dictobject\.c:205"])
+        fs = self._fake_self(sup)
+        keep, label = Fuzzer._suppression_keep_policy(fs, self._session(CRASH))
+        self.assertFalse(keep)
+        self.assertIsNone(label)
+        self.assertEqual(sup.suppressed_count, 1)
+        self.assertTrue(any("Hit suppressed by regex" in m for m in self.logged))
+
+    def test_non_matching_hit_is_kept(self):
+        sup = build_suppressor(regexes=["never-appears"])
+        keep, label = Fuzzer._suppression_keep_policy(self._fake_self(sup), self._session(CRASH))
+        self.assertTrue(keep)
+        self.assertIsNone(label)
+
+    def test_non_match_defers_to_prev_policy(self):
+        sup = build_suppressor(regexes=["never-appears"])
+        prev = lambda session: (True, "OOM-0036")  # noqa: E731
+        keep, label = Fuzzer._suppression_keep_policy(
+            self._fake_self(sup, prev_policy=prev), self._session(CRASH)
+        )
+        self.assertTrue(keep)
+        self.assertEqual(label, "OOM-0036")
+
+    def test_suppression_wins_over_prev_policy(self):
+        # A hit the prev policy (OOM dedupe) would keep is still pruned when a rule matches,
+        # and the prev policy is never consulted.
+        sup = build_suppressor(regexes=[r"dictobject\.c:205"])
+        calls = []
+
+        def prev(session):
+            calls.append(session)
+            return True, "OOM-0036"
+
+        keep, label = Fuzzer._suppression_keep_policy(
+            self._fake_self(sup, prev_policy=prev), self._session(CRASH)
+        )
+        self.assertFalse(keep)
+        self.assertEqual(calls, [])
+
+    def test_missing_stdout_is_kept(self):
+        sup = build_suppressor(regexes=[r"dictobject\.c:205"])
+        sess = SimpleNamespace(directory=SimpleNamespace(directory="/no/such/dir/xyz"))
+        keep, label = Fuzzer._suppression_keep_policy(self._fake_self(sup), sess)
+        self.assertTrue(keep)
+        self.assertIsNone(label)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -70,5 +70,19 @@ class TestBlacklistWhitelist(unittest.TestCase):
         self.assertFalse(m.is_whitelisted("method", "anything"))
 
 
+class TestSuppressionEntries(unittest.TestCase):
+    def test_register_and_get_pairs(self):
+        m = PluginManager()
+        m.add_suppression_entry(r"dictobject\.c:205", reason="known FT assert")
+        m.add_suppression_entry("segfault")  # reason defaults to None
+        self.assertEqual(
+            m.get_suppression_entries(),
+            [(r"dictobject\.c:205", "known FT assert"), ("segfault", None)],
+        )
+
+    def test_empty_manager_has_no_entries(self):
+        self.assertEqual(PluginManager().get_suppression_entries(), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #53.

## What

Adds **regex-based hit suppression**: drop known/uninteresting *crashing sessions* by matching a regex against their captured stdout — the automated version of the by-hand dedup a triager does ("filter out hits that mention source code lines and abort/segfault messages"). This is the **general/non-OOM analogue** of the OOM catalog dedupe (`--oom-dedup-catalog`), and needs no catalog.

## How to use

```bash
# repeatable inline regexes
fusil-python-threaded --suppress-hit-regex 'Objects/dictobject\.c:205' --suppress-hit-regex 'known message'

# and/or a suppression file (repeatable): one regex per line, '#' comments,
# an optional reason after ' ## ' (recorded in the logs when the rule fires)
fusil-python-threaded --suppress-hit-file known_sites.txt

# case-insensitive matching
fusil-python-threaded --suppress-hit-regex ASSERTION --suppress-hit-ignore-case
```

Suppression-file example:
```
# Known crash sites to drop
Objects/dictobject\.c:205 ## known FT set_keys OOM assert (benign on release)
Fatal Python error
```

Rules union three composable sources: `--suppress-hit-regex`, `--suppress-hit-file`, and **plugins** via `PluginManager.add_suppression_entry(pattern, reason)` — the extensible suppression store called for in #52. On a match the session dir is **pruned** and the reason logged; an end-of-run summary reports how many hits each rule dropped.

## Design

- **Engine** — `fusil/python/hit_suppression.py`: pure-Python (no runtime stack), mirroring `oom_dedup.py`'s split so it unit-tests in isolation. `build_suppressor()` → `HitSuppressor.decide(text) -> (keep, rule)`.
- **Wiring** — `Fuzzer._suppression_keep_policy` reads the crash stdout (bounded via `read_crash_stdout`, to avoid catastrophic regex backtracking on huge/OOM-verbose spew) and returns `(False, None)` on a match through the same `application.session_keep_policy` hook `SessionDirectory.checkKeepDirectory` already consults for OOM dedupe.
- **Composes with `--oom-dedup-catalog`**: suppression runs first (a matched hit is pruned even if the OOM deduper would keep it); otherwise it defers to the previously-installed policy. Absent any `--suppress-hit-*` option, nothing is installed and behaviour is unchanged. Any failure falls back to *keep*, so a crash is never lost to a suppression error.

## Tests

Mirror the `oom_dedup` split — all green (`python -m unittest discover -s tests`, 420 tests), `ruff check` + `ruff format --check` clean:

- `tests/python/test_hit_suppression.py` — pure engine (compile / parse-file / decide / report / `build_suppressor`), no skip guard.
- `tests/python/test_hit_suppression_wiring.py` — skip-guarded keep-policy glue: prune+log, keep, defer-to-prev, suppression-wins-over-prev, and read-error → keep.
- `tests/test_plugin_manager.py` — `add_suppression_entry` / `get_suppression_entries`.

Also smoke-tested end-to-end (`--suppress-hit-regex`/`-file`/`-ignore-case` on a live 1-session run): the startup log reports the rule count and the run exits cleanly.

## Docs

`doc/python-fuzzer.md` (new *Hit suppression* subsection + *Where to look* row) and `CLAUDE.md` (options block + architecture subsection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
