### PR TITLE
fix(python): remove ineffective logging-pycache workaround — closes #36

### DIFF
--- a/doc/code-review-findings.md
+++ b/doc/code-review-findings.md
@@ -25,9 +25,16 @@ The core runtime is mostly healthy (narrow, well-targeted excepts). Real items:
 - **H2 — `list_all_modules._process_package` uses `except (ImportError, Exception)`**: redundant
   and aborts the whole discovery pass on any non-ImportError. Decide policy → `except Exception`
   and skip the package.
-- **H3 — `utils.remove_logging_pycache`** runs unconditionally at startup, mutates the installed
-  stdlib, and is uncaught if `__pycache__` is missing; then `reload(logging)` runs regardless.
-  Make it a no-op on any failure (guard `iterdir()`), and reconsider whether the reload is needed.
+- **H3 — `utils.remove_logging_pycache`** — ✅ RESOLVED by removal (issue #36). Ran
+  unconditionally at startup and mutated the installed stdlib's `logging/__pycache__`, but only
+  in the *parent* interpreter — whereas the `--- Logging error ---` spam it targeted comes from
+  the `--python` *child* (which defaults to `sys.executable`, so parent==child only when
+  `--python` is unset; this campaign always overrides it → the workaround touched the wrong
+  interpreter, hence "still happening"). The real trigger is stale/mismatched `logging` bytecode
+  in the *target build's* `__pycache__` (a git-checkout/rebuild hazard). Non-destructive fix if
+  it recurs: run the child with `PYTHONPYCACHEPREFIX=<scratch>` so it never reads stale in-tree
+  `.pyc`. The `reload(logging)` was "unverified necessity" (its own docstring). Removed the
+  function + its call in `main()`.
 - **H4 — `Application.exit()` runs `deinitX11()` outside the cleanup try**: a non-ptrace error in
   `agents.clear()` skips X11 deinit (leaves X access granted). Move to `finally`.
 - **M-series:** `Directory.rmtree_error`/`isEmpty` swallow then degrade silently; `runProject`'s

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -16,7 +16,7 @@ with warnings.catch_warnings():
     from fusil.process.watch import WatchProcess
     from fusil.project import Project
     from fusil.python.python_source import PythonSource
-    from fusil.python.utils import print_running_time, remove_logging_pycache
+    from fusil.python.utils import print_running_time
     from fusil.python.write_python_code import time_start
 
 IGNORE_TIMEOUT = True
@@ -656,5 +656,4 @@ class PythonProcess(CreateProcess):
 
 def main() -> None:
     """Console-script entry point for ``fusil-python-threaded``."""
-    remove_logging_pycache()
     Fuzzer().main()

--- a/fusil/python/utils.py
+++ b/fusil/python/utils.py
@@ -3,41 +3,28 @@
 from __future__ import annotations
 
 import datetime
-import importlib
-import logging
-import pathlib
 import resource
 import time
 
 
-def remove_logging_pycache() -> None:
-    """Best-effort removal of stale logging ``__pycache__`` that can cause logging errors.
+def format_duration(seconds: float) -> str:
+    """Format a duration as ``H:MM:SS.ss`` (two fractional digits).
 
-    Runs at startup against the *installed* stdlib, so it must never abort startup: a
-    missing ``__pycache__`` (the common case -- e.g. ``PYTHONDONTWRITEBYTECODE``) or any
-    unlink/rmdir failure is reported and ignored. (The ``reload(logging)`` is a workaround
-    of unverified necessity -- kept conservatively, but wrapped so it can't crash startup.)
+    Robust to whole-second durations: ``datetime.timedelta``'s ``str`` omits the fractional
+    part for integral seconds, so a naive "slice off microseconds" corrupts e.g. ``0:01:30``
+    into ``0:0``. This always renders exactly two fractional digits.
     """
-    pycache = pathlib.Path(logging.__file__).parent / "__pycache__"
-    if pycache.is_dir():
-        for entry in pycache.iterdir():
-            try:
-                entry.unlink()
-            except OSError as e:
-                print(f"Error deleting file {entry.name}: {e}")
-        try:
-            pycache.rmdir()
-        except OSError as e:
-            print(f"Error removing directory {pycache.name}: {e}")
-    try:
-        importlib.reload(logging)
-    except Exception as e:
-        print(f"Error reloading logging: {e}")
+    text = str(datetime.timedelta(seconds=round(seconds, 2)))
+    if "." in text:
+        head, frac = text.split(".", 1)
+        return f"{head}.{frac[:2]}"
+    return f"{text}.00"
 
 
 def print_running_time(time_start: float) -> str:
-    """Calculate and return a string with total and user running times."""
-    raw_utime = resource.getrusage(resource.RUSAGE_SELF).ru_utime
-    user_time = str(datetime.timedelta(0, round(raw_utime, 2)))
-    total_time = str(datetime.timedelta(0, round(time.time() - time_start, 2)))
-    return f"\nRunning time: {total_time[:-4]}\nUser time:    {user_time[:-4]}"
+    """Return a summary of total (wall-clock) and user CPU time since ``time_start``."""
+    user_time = resource.getrusage(resource.RUSAGE_SELF).ru_utime
+    total_time = time.time() - time_start
+    return (
+        f"\nRunning time: {format_duration(total_time)}\nUser time:    {format_duration(user_time)}"
+    )

--- a/tests/python/test_utils.py
+++ b/tests/python/test_utils.py
@@ -1,0 +1,56 @@
+"""Unit tests for fusil.python.utils.
+
+Pure-Python: no runtime stack, so it runs in the dev venv.
+"""
+
+import re
+import time
+import unittest
+
+from fusil.python import utils
+
+
+class TestFormatDuration(unittest.TestCase):
+    def test_whole_seconds_keep_two_fractional_digits(self):
+        # Regression: the old print_running_time sliced a fixed 4 chars off the timedelta
+        # string, corrupting whole-second durations ("0:01:30" -> "0:0"). format_duration
+        # must always render H:MM:SS.ss.
+        self.assertEqual(utils.format_duration(90), "0:01:30.00")
+        self.assertEqual(utils.format_duration(0), "0:00:00.00")
+
+    def test_fractional_seconds_truncated_to_two_digits(self):
+        self.assertEqual(utils.format_duration(90.5), "0:01:30.50")
+        self.assertEqual(utils.format_duration(3661.239), "1:01:01.24")  # round(_,2)=3661.24
+
+    def test_shape_is_always_hmmss_dot_ss(self):
+        for value in (0, 1, 59.99, 60, 3600, 3661.239, 86399.5):
+            self.assertRegex(utils.format_duration(value), r"^\d+:\d\d:\d\d\.\d\d$")
+
+
+class TestPrintRunningTime(unittest.TestCase):
+    def test_format_has_both_lines(self):
+        out = utils.print_running_time(time.time())
+        self.assertIn("Running time:", out)
+        self.assertIn("User time:", out)
+        # Leading blank line + two labelled lines, each ending in a H:MM:SS.ss duration.
+        self.assertTrue(out.startswith("\n"))
+        lines = out.strip().splitlines()
+        self.assertEqual(len(lines), 2)
+        for line in lines:
+            self.assertRegex(line, r":\s+\d+:\d\d:\d\d\.\d\d$")
+
+    def test_elapsed_total_is_rendered(self):
+        out = utils.print_running_time(time.time() - 90)
+        m = re.search(r"Running time:\s+(\d+:\d\d:\d\d\.\d\d)", out)
+        self.assertIsNotNone(m, out)
+        assert m is not None  # for type-checkers
+        self.assertTrue(m.group(1).startswith("0:01:3"), out)
+
+    def test_no_stale_pycache_helper_remains(self):
+        # The parent-side remove_logging_pycache() workaround (issue #36) was removed; guard
+        # against it being reintroduced without the accompanying analysis.
+        self.assertFalse(hasattr(utils, "remove_logging_pycache"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #36.

## Root cause (why the `--- Logging error ---` spam happened)

`--- Logging error ---` is what `logging.Handler.handleError()` prints to stderr when an emit raises (with `logging.raiseExceptions` on, the default). It appears at the **top** of a session's `stdout` because the generated harness's very first startup imports (`asyncio` — which `import`s and uses `logging` — plus the target module) each emit during import; if `logging`'s bytecode is inconsistent, each failed emit prints one line, hence "lots of" them.

The trigger is **stale/mismatched `logging` bytecode in the target build's `__pycache__`** — a git-checkout/rebuild hazard. CPython's default timestamp-based `.pyc` validation can accept a cached `logging/__init__.*.pyc` that doesn't match the running (freshly-built, actively-developed) interpreter. That's consistent with the two data points on this issue: a *dummy edit* to `logging/__init__.py` fixed it (bumped the source mtime → forced recompilation), and it recurred after later rebuilds.

## Why the existing workaround couldn't fix it

`remove_logging_pycache()` deleted the installed stdlib's `logging/__pycache__` and reloaded `logging` **in the parent fusil process**. But the spam comes from the **`--python` child**'s stdout. `--python` defaults to `sys.executable` (parent == child), so the workaround only touched the right interpreter when `--python` was left unset. This campaign always points `--python` at a *separate* debug/JIT-patched build → the function operated on the wrong interpreter's cache. That's exactly why the owner reported it **"still happening"** after adding it.

It was also destructive (unlink + rmdir on a *shared* stdlib cache, requiring write permission there) and its `reload(logging)` was documented as "unverified necessity."

## What this PR does

- **Removes** `remove_logging_pycache()` and its call in `main()`. It doesn't reproduce anymore, and the workaround was structurally incapable of fixing the reported symptom. Resolves finding **H3** in `doc/code-review-findings.md`, with the analysis recorded there.
- **If it ever recurs**, the non-destructive fix is to run the child with `PYTHONPYCACHEPREFIX=<scratch>` so it never reads stale in-tree `.pyc` (documented in the findings entry). No need to mutate a shared stdlib.
- **Bonus fix in the same file:** `print_running_time` had a latent bug — its `[:-4]` slice assumed the `timedelta` string always carries microseconds, so a whole-second total rendered as the corrupted `0:0`. Extracted `format_duration()` (always `H:MM:SS.ss`).
- **Tests:** new `tests/python/test_utils.py` (the file had zero coverage) — `format_duration` edge cases (whole seconds, fractional truncation, shape), the running-time line shape, and a guard that the removed helper stays removed.

Full suite green (426 tests, +6); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
