### PR TITLE
test: expand core-module coverage 60%→76% (+ MAS test harness)

### DIFF
--- a/tests/mas_harness.py
+++ b/tests/mas_harness.py
@@ -1,0 +1,76 @@
+"""Runtime-free scaffolding for testing fusil MAS agents.
+
+Builds a real ``fusil.mas.mta.MTA`` backed by a stub Application, wrapped in a lightweight
+fake Project, so ``ProjectAgent`` subclasses (``FileWatch``, ``WatchProcess`` ...) can be
+constructed and driven without python-ptrace or the ``Univers`` loop. Mirrors the stub-app
+approach in ``tests/test_mas.py``; shared here because many agent tests need the same setup.
+
+Typical use::
+
+    from tests.mas_harness import FakeProject
+
+    project = FakeProject()
+    agent = SomeProjectAgent(project, ...)
+    agent.send = record            # optionally intercept emitted events
+"""
+
+from types import SimpleNamespace
+
+from fusil.mas.mta import MTA
+
+
+class StubLogger:
+    """Records log calls so tests can assert on them; the MAS logger contract is
+    ``method(message, sender=None)``."""
+
+    def __init__(self):
+        self.records: list[tuple[str, object]] = []
+
+    def debug(self, message, sender=None):
+        self.records.append(("debug", message))
+
+    def info(self, message, sender=None):
+        self.records.append(("info", message))
+
+    def warning(self, message, sender=None):
+        self.records.append(("warning", message))
+
+    def error(self, message, sender=None):
+        self.records.append(("error", message))
+
+
+class StubApplication:
+    """Weakref-able Application stand-in (ProjectAgent stores a weakref to it)."""
+
+    def __init__(self, debug=False, **options):
+        self.logger = StubLogger()
+        self.options = SimpleNamespace(debug=debug, **options)
+
+    def registerAgent(self, agent):
+        pass
+
+    def unregisterAgent(self, agent, destroy=True):
+        pass
+
+
+class FakeProject:
+    """Minimal Project exposing the ``ProjectAgent.__init__`` contract (``mta()``,
+    ``application()``, ``registerAgent()``) over a real MTA."""
+
+    def __init__(self, debug=False, **options):
+        self._application = StubApplication(debug=debug, **options)
+        self._mta = MTA(self._application)
+        self.registered: list[object] = []
+        self.session = None
+
+    def mta(self):
+        return self._mta
+
+    def application(self):
+        return self._application
+
+    def registerAgent(self, agent):
+        self.registered.append(agent)
+
+    def unregisterAgent(self, agent, destroy=True):
+        pass

--- a/tests/test_agent_list.py
+++ b/tests/test_agent_list.py
@@ -1,0 +1,101 @@
+"""Unit tests for fusil.mas.agent_list.AgentList — the registry of active agents.
+
+AgentList is the collection the MTA/Project use to hold agents; remove/clear also drive each
+agent's deactivate()/unregister() teardown and must swallow ptrace errors during deinit.
+Runtime-free: exercised with tiny fake agents (no real MAS). python-ptrace is imported by the
+module, so the suite skips cleanly where it is unavailable.
+"""
+
+import unittest
+
+try:
+    from ptrace.error import PTRACE_ERRORS
+
+    from fusil.mas.agent_list import AgentList
+
+    HAVE_PTRACE = True
+except Exception:  # pragma: no cover - env without python-ptrace
+    HAVE_PTRACE = False
+
+
+class FakeAgent:
+    def __init__(self, deactivate_error=None):
+        self.deactivated = 0
+        self.unregistered = []
+        self._deactivate_error = deactivate_error
+
+    def deactivate(self):
+        self.deactivated += 1
+        if self._deactivate_error is not None:
+            raise self._deactivate_error
+
+    def unregister(self, destroy=True):
+        self.unregistered.append(destroy)
+
+
+@unittest.skipUnless(HAVE_PTRACE, "python-ptrace not importable")
+class TestAgentList(unittest.TestCase):
+    def test_append_and_membership(self):
+        lst = AgentList()
+        a = FakeAgent()
+        lst.append(a)
+        self.assertIn(a, lst)
+        self.assertEqual(list(lst), [a])
+
+    def test_append_duplicate_raises(self):
+        lst = AgentList()
+        a = FakeAgent()
+        lst.append(a)
+        with self.assertRaises(KeyError):
+            lst.append(a)
+
+    def test_remove_destroys_by_default(self):
+        lst = AgentList()
+        a = FakeAgent()
+        lst.append(a)
+        lst.remove(a)
+        self.assertNotIn(a, lst)
+        self.assertEqual(a.deactivated, 1)
+        self.assertEqual(a.unregistered, [False])  # _destroy calls unregister(False)
+
+    def test_remove_without_destroy_leaves_agent_untouched(self):
+        lst = AgentList()
+        a = FakeAgent()
+        lst.append(a)
+        lst.remove(a, destroy=False)
+        self.assertNotIn(a, lst)
+        self.assertEqual(a.deactivated, 0)
+        self.assertEqual(a.unregistered, [])
+
+    def test_remove_non_member_is_noop(self):
+        lst = AgentList()
+        a = FakeAgent()
+        lst.remove(a)  # not present -> silently ignored
+        self.assertEqual(a.deactivated, 0)
+
+    def test_clear_destroys_all(self):
+        lst = AgentList()
+        agents = [FakeAgent() for _ in range(3)]
+        for a in agents:
+            lst.append(a)
+        lst.clear()
+        self.assertEqual(list(lst), [])
+        for a in agents:
+            self.assertEqual(a.deactivated, 1)
+            self.assertEqual(a.unregistered, [False])
+
+    def test_destroy_swallows_ptrace_errors(self):
+        # A ptrace error during deactivate() must not abort teardown; unregister still runs.
+        # PTRACE_ERRORS may be a single exception class or a tuple of them, depending on the
+        # python-ptrace version.
+        exc_type = PTRACE_ERRORS if isinstance(PTRACE_ERRORS, type) else PTRACE_ERRORS[0]
+        a = FakeAgent(deactivate_error=exc_type("boom"))
+        lst = AgentList()
+        lst.append(a)
+        lst.remove(a)  # must not raise
+        self.assertNotIn(a, lst)
+        self.assertEqual(a.unregistered, [False])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_application_logger.py
+++ b/tests/test_application_logger.py
@@ -1,0 +1,378 @@
+"""Unit tests for fusil.application_logger.ApplicationLogger — the dual-sink logger.
+
+ApplicationLogger drives two sinks off the root logger: a terse stdout stream and a verbose
+``fusil.log`` file. Its interesting, testable core is ``formatMessage``, which prefixes each
+line with ``[nb_success][session][step][agent]`` context assembled from a weakref'd
+Application, plus the level-selection logic in ``applyOptions`` and the handler add/remove
+bookkeeping. These tests exercise that pure logic directly.
+
+Because the logger mutates the *global* root logger (adds handlers, sets its level) in
+``__init__``, every test snapshots the root logger's handlers/level in ``setUp`` and restores
+them in ``tearDown`` so the suite has no global side effects. Sinks use ``io.StringIO`` / temp
+files; the Application is a minimal weakref-able fake (``types.SimpleNamespace`` is *not*
+weakref-able here, so a plain class is used — only the Application is weakref'd, nested
+options/project/session stay ``SimpleNamespace``). Runtime-free.
+"""
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from logging import (
+    CRITICAL,
+    DEBUG,
+    ERROR,
+    INFO,
+    WARNING,
+    Formatter,
+    LogRecord,
+    StreamHandler,
+    getLogger,
+)
+from types import SimpleNamespace
+
+from fusil.application_logger import LOG_FILENAME, ApplicationLogger
+
+
+class _FakeApp:
+    """Weakref-able Application stand-in (ApplicationLogger stores ``weakref(application)``).
+
+    A plain class is required because ``types.SimpleNamespace`` instances are not
+    weakref-able on this interpreter.
+    """
+
+    def __init__(self, options=None, project=None):
+        self.options = options
+        self.project = project
+
+
+def _opts(debug=False, verbose=False, quiet=False):
+    return SimpleNamespace(debug=debug, verbose=verbose, quiet=quiet)
+
+
+def _project(session_index=1, nb_success=0, session=None, step=0):
+    return SimpleNamespace(
+        session_index=session_index,
+        nb_success=nb_success,
+        session=session,
+        step=step,
+    )
+
+
+def _session(name="session-1"):
+    return SimpleNamespace(name=name)
+
+
+def _sender(name="agent"):
+    return SimpleNamespace(name=name)
+
+
+class LoggerTestCase(unittest.TestCase):
+    """Base class that snapshots/restores global root-logger state around each test."""
+
+    def setUp(self):
+        self._root = getLogger()
+        self._orig_handlers = self._root.handlers[:]
+        self._orig_level = self._root.level
+        self._apps = []  # strong refs so the loggers' weakrefs stay alive
+
+    def tearDown(self):
+        # Remove only the handlers this test added; leave any pre-existing ones intact.
+        for handler in self._root.handlers[:]:
+            if handler not in self._orig_handlers:
+                self._root.removeHandler(handler)
+                try:
+                    handler.close()
+                except Exception:
+                    pass
+        self._root.setLevel(self._orig_level)
+
+    def make_logger(self, application=None):
+        if application is None:
+            application = _FakeApp()
+        self._apps.append(application)
+        return ApplicationLogger(application)
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _tmpfile(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        return path
+
+    def _enter_tempdir(self):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        cwd = os.getcwd()
+        os.chdir(tmp)
+        self.addCleanup(os.chdir, cwd)
+        return tmp
+
+    def _close_file_handler(self, logger):
+        fh = logger.file_handler
+        if fh is not None and not fh.stream.closed:
+            fh.stream.close()
+
+
+class TestInit(LoggerTestCase):
+    def test_defaults(self):
+        logger = self.make_logger()
+        self.assertIsNone(logger.filename)
+        self.assertIsNone(logger.file_handler)
+        self.assertEqual(logger.timestamp_format, "%(asctime)s: %(message)s")
+
+    def test_stdout_handler_registered_at_error(self):
+        logger = self.make_logger()
+        self.assertEqual(logger.stdout.level, ERROR)
+        self.assertEqual(logger.logger.level, ERROR)
+        self.assertIn(logger.stdout, logger.logger.handlers)
+
+    def test_application_stored_as_weakref(self):
+        app = _FakeApp()
+        logger = self.make_logger(app)
+        self.assertIs(logger.application(), app)
+
+
+class TestFormatMessage(LoggerTestCase):
+    def test_no_prefix_without_project(self):
+        logger = self.make_logger(_FakeApp(options=_opts(debug=False), project=None))
+        self.assertEqual(logger.formatMessage("hello", None), "hello")
+
+    def test_str_coercion_without_prefix(self):
+        logger = self.make_logger(_FakeApp(options=_opts(debug=False), project=None))
+        self.assertEqual(logger.formatMessage(12345, None), "12345")
+
+    def test_options_none_disables_debug(self):
+        # options is falsey -> debug=False, so no [step] and no [agent] even with a project.
+        proj = _project(session_index=1, nb_success=4, session=_session("s"), step=9)
+        logger = self.make_logger(_FakeApp(options=None, project=proj))
+        self.assertEqual(logger.formatMessage("hello", _sender("a")), "[4][s] hello")
+
+    def test_session_prefix_without_debug(self):
+        proj = _project(session_index=1, nb_success=7, session=_session("sess"), step=3)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=False), project=proj))
+        self.assertEqual(logger.formatMessage("hi", None), "[7][sess] hi")
+
+    def test_session_index_zero_skips_project_block(self):
+        # session_index falsey -> no [nb][session][step], but debug+sender still adds [agent].
+        proj = _project(session_index=0, nb_success=5, session=_session("x"), step=3)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=proj))
+        self.assertEqual(logger.formatMessage("msg", _sender("agent")), "[agent] msg")
+
+    def test_project_without_session_omits_session_name(self):
+        proj = _project(session_index=2, nb_success=7, session=None, step=0)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=False), project=proj))
+        self.assertEqual(logger.formatMessage("hello", None), "[7] hello")
+
+    def test_full_debug_prefix_order(self):
+        proj = _project(session_index=1, nb_success=2, session=_session("s1"), step=7)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=proj))
+        self.assertEqual(
+            logger.formatMessage("payload", _sender("worker")),
+            "[2][s1][step 7][worker] payload",
+        )
+
+    def test_step_omitted_when_step_zero(self):
+        proj = _project(session_index=1, nb_success=2, session=_session("s1"), step=0)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=proj))
+        self.assertEqual(
+            logger.formatMessage("payload", _sender("agent")),
+            "[2][s1][agent] payload",
+        )
+
+    def test_step_omitted_without_debug_even_when_set(self):
+        proj = _project(session_index=1, nb_success=2, session=_session("s1"), step=9)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=False), project=proj))
+        # debug False -> no [step] and no [agent].
+        self.assertEqual(logger.formatMessage("payload", _sender("agent")), "[2][s1] payload")
+
+    def test_sender_prefix_requires_debug(self):
+        logger = self.make_logger(_FakeApp(options=_opts(debug=False), project=None))
+        self.assertEqual(logger.formatMessage("hi", _sender("agent")), "hi")
+
+    def test_sender_prefix_added_with_debug_and_no_project(self):
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=None))
+        self.assertEqual(logger.formatMessage("hi", _sender("agent")), "[agent] hi")
+
+    def test_sender_none_with_debug_adds_nothing(self):
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=None))
+        self.assertEqual(logger.formatMessage("hi", None), "hi")
+
+    def test_str_coercion_with_prefix(self):
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=None))
+        self.assertEqual(logger.formatMessage(999, _sender("a")), "[a] 999")
+
+    def test_dead_application_returns_plain_message(self):
+        # Do NOT keep a strong ref: the weakref should die and formatMessage must degrade
+        # gracefully (no prefix, just str-coercion).
+        import gc
+
+        app = _FakeApp(options=_opts(debug=True), project=None)
+        logger = ApplicationLogger(app)
+        del app
+        gc.collect()
+        self.assertIsNone(logger.application())
+        self.assertEqual(logger.formatMessage(42, _sender("agent")), "42")
+
+
+class TestApplyOptions(LoggerTestCase):
+    """applyOptions selects stdout/file/logger levels from debug/verbose/quiet flags."""
+
+    def _apply(self, **flags):
+        self._enter_tempdir()  # applyOptions writes ./fusil.log
+        logger = self.make_logger(_FakeApp(options=_opts()))
+        logger.applyOptions(_opts(**flags))
+        self.addCleanup(self._close_file_handler, logger)
+        return logger
+
+    def test_debug_levels(self):
+        logger = self._apply(debug=True)
+        self.assertEqual(logger.stdout.level, INFO)
+        self.assertEqual(logger.file_handler.level, DEBUG)
+        self.assertEqual(logger.logger.level, DEBUG)  # min(INFO, INFO, DEBUG)
+
+    def test_verbose_levels(self):
+        logger = self._apply(verbose=True)
+        self.assertEqual(logger.stdout.level, WARNING)
+        self.assertEqual(logger.file_handler.level, INFO)
+        self.assertEqual(logger.logger.level, INFO)  # min(INFO, WARNING, INFO)
+
+    def test_default_levels(self):
+        logger = self._apply()  # not debug/verbose/quiet
+        self.assertEqual(logger.stdout.level, ERROR)
+        self.assertEqual(logger.file_handler.level, WARNING)
+        self.assertEqual(logger.logger.level, INFO)  # min(INFO, ERROR, WARNING)
+
+    def test_quiet_levels(self):
+        logger = self._apply(quiet=True)
+        self.assertEqual(logger.stdout.level, ERROR)
+        self.assertEqual(logger.file_handler.level, INFO)
+        self.assertEqual(logger.logger.level, INFO)  # min(INFO, ERROR, INFO)
+
+    def test_creates_log_file(self):
+        logger = self._apply(verbose=True)
+        self.assertEqual(logger.filename, LOG_FILENAME)
+        self.assertTrue(os.path.exists(LOG_FILENAME))
+
+
+class TestFileHandlers(LoggerTestCase):
+    def test_level_none_uses_debug_when_verbose(self):
+        logger = self.make_logger(_FakeApp(options=SimpleNamespace(verbose=True)))
+        path = self._tmpfile()
+        fh = logger.addFileHandler(path)  # level=None -> consults options.verbose
+        self.addCleanup(fh.stream.close)
+        self.assertEqual(fh.level, DEBUG)
+        self.assertIn(fh, logger.logger.handlers)
+
+    def test_level_none_uses_info_when_not_verbose(self):
+        logger = self.make_logger(_FakeApp(options=SimpleNamespace(verbose=False)))
+        path = self._tmpfile()
+        fh = logger.addFileHandler(path)
+        self.addCleanup(fh.stream.close)
+        self.assertEqual(fh.level, INFO)
+
+    def test_explicit_level_and_registration(self):
+        logger = self.make_logger()
+        path = self._tmpfile()
+        fh = logger.addFileHandler(path, WARNING)
+        self.addCleanup(fh.stream.close)
+        self.assertEqual(fh.level, WARNING)
+        self.assertIn(fh, logger.logger.handlers)
+
+    def test_formatter_uses_timestamp_format(self):
+        logger = self.make_logger()
+        path = self._tmpfile()
+        fh = logger.addFileHandler(path, INFO)
+        self.addCleanup(fh.stream.close)
+        record = LogRecord("root", INFO, path, 1, "hi", None, None)
+        rendered = fh.format(record)
+        # timestamp_format == "%(asctime)s: %(message)s" -> "<ts>: hi"
+        self.assertTrue(rendered.endswith("hi"))
+        self.assertIn(": ", rendered)
+
+    def test_add_handler_returns_sets_level_and_registers(self):
+        logger = self.make_logger()
+        handler = StreamHandler(io.StringIO())
+        returned = logger.addHandler(handler, WARNING)
+        self.assertIs(returned, handler)
+        self.assertEqual(handler.level, WARNING)
+        self.assertIn(handler, logger.logger.handlers)
+
+    def test_remove_file_handler_closes_stream_and_unregisters(self):
+        logger = self.make_logger(_FakeApp(options=SimpleNamespace(verbose=False)))
+        path = self._tmpfile()
+        fh = logger.addFileHandler(path, INFO)
+        logger.removeFileHandler(fh)
+        self.assertNotIn(fh, logger.logger.handlers)
+        self.assertTrue(fh.stream.closed)
+
+    def test_remove_handler_unregisters(self):
+        logger = self.make_logger()
+        handler = StreamHandler(io.StringIO())
+        logger.addHandler(handler, INFO)
+        logger.removeHandler(handler)
+        self.assertNotIn(handler, logger.logger.handlers)
+
+
+class TestUnlinkFile(LoggerTestCase):
+    def test_unlink_removes_handler_and_file(self):
+        self._enter_tempdir()
+        logger = self.make_logger(_FakeApp(options=_opts()))
+        logger.applyOptions(_opts())  # creates ./fusil.log + file_handler
+        self.assertTrue(os.path.exists(LOG_FILENAME))
+        logger.unlinkFile()
+        self.assertIsNone(logger.file_handler)
+        self.assertIsNone(logger.filename)
+        self.assertFalse(os.path.exists(LOG_FILENAME))
+
+    def test_unlink_is_noop_when_nothing_configured(self):
+        logger = self.make_logger()  # fresh: filename/file_handler are None
+        logger.unlinkFile()  # must not raise
+        self.assertIsNone(logger.file_handler)
+        self.assertIsNone(logger.filename)
+
+
+class TestLevelMethods(LoggerTestCase):
+    def test_log_formats_then_calls_func(self):
+        proj = _project(session_index=1, nb_success=3, session=_session("s"), step=0)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=proj))
+        recorded = []
+        logger.log(recorded.append, "boom", _sender("w"))
+        self.assertEqual(recorded, ["[3][s][w] boom"])
+
+    def test_level_methods_route_to_matching_logger_method(self):
+        logger = self.make_logger()  # default app -> no prefix
+        calls = []
+        logger.logger = SimpleNamespace(
+            debug=lambda m: calls.append(("debug", m)),
+            info=lambda m: calls.append(("info", m)),
+            warning=lambda m: calls.append(("warning", m)),
+            error=lambda m: calls.append(("error", m)),
+        )
+        logger.debug("d", None)
+        logger.info("i", None)
+        logger.warning("w", None)
+        logger.error("e", None)
+        self.assertEqual(
+            calls,
+            [("debug", "d"), ("info", "i"), ("warning", "w"), ("error", "e")],
+        )
+
+    def test_end_to_end_error_is_prefixed_and_written(self):
+        proj = _project(session_index=1, nb_success=1, session=_session("sess"), step=4)
+        logger = self.make_logger(_FakeApp(options=_opts(debug=True), project=proj))
+        # Silence the real-stdout sink so the test is quiet; capture via our own StringIO sink.
+        logger.stdout.setLevel(CRITICAL)
+        sink = io.StringIO()
+        handler = StreamHandler(sink)
+        handler.setFormatter(Formatter("%(message)s"))
+        logger.addHandler(handler, DEBUG)
+        logger.logger.setLevel(DEBUG)
+        logger.error("kaboom", _sender("worker"))
+        self.assertEqual(sink.getvalue().strip(), "[1][sess][step 4][worker] kaboom")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,134 @@
+"""Unit tests for fusil.config — the config-path resolver and the non-CLI defaults holder.
+
+``createFilename`` resolves where ``fusil.conf`` would live (XDG_CONFIG_HOME, else
+``$HOME/.config``, else error); ``FusilConfig`` is the single source of truth for the handful
+of settings that have no ``--*`` CLI flag (scoring thresholds, memory caps, sandbox user/group).
+The old ``fusil.conf`` read/write round-trip was removed, so the surface to test is the path
+resolution branches and that the defaults are the exact, correctly-typed constants the rest of
+the fuzzer relies on. Runtime-free: environment is exercised with ``patch.dict``, no I/O.
+"""
+
+import os
+import unittest
+from os.path import join as path_join
+from unittest import mock
+
+from fusil.config import ConfigError, FusilConfig, createFilename
+
+
+class TestCreateFilename(unittest.TestCase):
+    def test_default_name_and_xdg_config_home(self):
+        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/xdg/cfg"}, clear=True):
+            self.assertEqual(createFilename(), path_join("/xdg/cfg", "fusil.conf"))
+
+    def test_custom_name_uses_xdg(self):
+        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/xdg/cfg"}, clear=True):
+            self.assertEqual(createFilename("other.ini"), path_join("/xdg/cfg", "other.ini"))
+
+    def test_falls_back_to_home_config_when_xdg_unset(self):
+        with mock.patch.dict(os.environ, {"HOME": "/home/joe"}, clear=True):
+            self.assertEqual(createFilename(), path_join("/home/joe", ".config", "fusil.conf"))
+
+    def test_empty_xdg_is_treated_as_unset(self):
+        # `if not configdir` means an empty XDG_CONFIG_HOME falls through to HOME.
+        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "", "HOME": "/home/joe"}, clear=True):
+            self.assertEqual(createFilename(), path_join("/home/joe", ".config", "fusil.conf"))
+
+    def test_explicit_configdir_bypasses_environment(self):
+        # An explicit configdir must not consult XDG/HOME at all.
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                createFilename(name="x.conf", configdir="/etc/fusil"),
+                path_join("/etc/fusil", "x.conf"),
+            )
+
+    def test_explicit_configdir_with_default_name(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                createFilename(configdir="/etc/fusil"),
+                path_join("/etc/fusil", "fusil.conf"),
+            )
+
+    def test_missing_home_raises_config_error(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ConfigError):
+                createFilename()
+
+    def test_empty_home_raises_config_error(self):
+        with mock.patch.dict(os.environ, {"HOME": ""}, clear=True):
+            with self.assertRaises(ConfigError) as ctx:
+                createFilename()
+        self.assertIn("HOME", str(ctx.exception))
+
+    def test_config_error_is_an_exception(self):
+        self.assertTrue(issubclass(ConfigError, Exception))
+
+
+class TestFusilConfigDefaults(unittest.TestCase):
+    def setUp(self):
+        # Keep filename resolution deterministic and I/O-free for the whole class.
+        patcher = mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/xdg/cfg"}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.config = FusilConfig()
+
+    def test_filename_resolved_from_environment(self):
+        self.assertEqual(self.config.filename, path_join("/xdg/cfg", "fusil.conf"))
+
+    def test_application_scoring_and_limits(self):
+        self.assertEqual(self.config.fusil_max_memory, 500 * 1024 * 1024)
+        self.assertEqual(self.config.fusil_success_score, 0.50)
+        self.assertEqual(self.config.fusil_error_score, -0.50)
+        self.assertEqual(self.config.fusil_success, 1)
+        self.assertEqual(self.config.fusil_session, 0)
+        self.assertEqual(self.config.fusil_normal_calm_load, 0.50)
+        self.assertEqual(self.config.fusil_normal_calm_sleep, 0.5)
+
+    def test_subprocess_defaults(self):
+        self.assertEqual(self.config.process_max_memory, 2000 * 1024 * 1024)
+        self.assertIs(self.config.process_core_dump, True)
+        self.assertEqual(self.config.process_max_user_process, 5000)
+        self.assertEqual(self.config.process_user, "fusil")
+        self.assertIsNone(self.config.process_uid)
+        self.assertEqual(self.config.process_group, "fusil")
+        self.assertIsNone(self.config.process_gid)
+
+    def test_default_types(self):
+        # The consumers rely on these types (int memory caps, float scores/thresholds, bool).
+        self.assertIsInstance(self.config.fusil_max_memory, int)
+        self.assertIsInstance(self.config.process_max_memory, int)
+        self.assertIsInstance(self.config.fusil_success_score, float)
+        self.assertIsInstance(self.config.fusil_error_score, float)
+        self.assertIsInstance(self.config.fusil_normal_calm_load, float)
+        self.assertIsInstance(self.config.fusil_normal_calm_sleep, float)
+        self.assertIsInstance(self.config.process_core_dump, bool)
+        self.assertIsInstance(self.config.process_user, str)
+
+    def test_error_score_is_below_success_score(self):
+        # Sanity invariant the session scorer depends on.
+        self.assertLess(self.config.fusil_error_score, self.config.fusil_success_score)
+
+
+class TestFusilConfigInstances(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/xdg/cfg"}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_overrides_do_not_leak_across_instances(self):
+        # Defaults live on the instance, so overriding one config must not touch another.
+        a = FusilConfig()
+        b = FusilConfig()
+        a.fusil_success = 99
+        a.process_user = "someoneelse"
+        self.assertEqual(b.fusil_success, 1)
+        self.assertEqual(b.process_user, "fusil")
+
+    def test_filename_follows_current_environment(self):
+        with mock.patch.dict(os.environ, {"HOME": "/home/zoe"}, clear=True):
+            config = FusilConfig()
+        self.assertEqual(config.filename, path_join("/home/zoe", ".config", "fusil.conf"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpu_load.py
+++ b/tests/test_cpu_load.py
@@ -1,0 +1,372 @@
+"""Unit tests for fusil.linux.cpu_load — the CPU-load measurement helpers.
+
+These classes read the running kernel's ``/proc/stat`` and per-process ``stat`` files and
+turn the raw tick counters into load fractions. The *arithmetic* (idle-percent, tick deltas,
+process-start reconstruction, clamping) and the *data-selection* logic (``searchLast`` picking
+the freshest valid sample) are what matter and where the bugs would hide, but they are buried
+behind ``ptrace.linux_proc`` readers. We inject fakes for those readers (``openProc``,
+``readProcessStat``, ``getSystemBoot``) and for the sample classes themselves, so every
+computation runs deterministically with no real ``/proc`` access. Runtime-free apart from the
+``ptrace`` import the module requires to load at all.
+"""
+
+import unittest
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest import mock
+
+try:
+    from fusil.linux import cpu_load
+    from fusil.linux.cpu_load import (
+        CpuLoad,
+        CpuLoadError,
+        ProcessCpuLoad,
+        ProcessCpuLoadValue,
+        SystemCpuLoad,
+        SystemCpuLoadValue,
+    )
+
+    HAS_PTRACE = True
+except ImportError:  # pragma: no cover - ptrace is a hard runtime dependency
+    HAS_PTRACE = False
+
+_SKIP = "python-ptrace is required to import fusil.linux.cpu_load"
+
+
+class _FakeProcStat:
+    """Stand-in for the file object ``openProc('stat')`` returns: iterable of lines with a
+    ``close()`` the reader is expected to call."""
+
+    def __init__(self, lines):
+        self._lines = lines
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def close(self):
+        self.closed = True
+
+
+def _val(timestamp, data=True):
+    """A minimal CpuLoadValue-shaped sample (only ``.timestamp``/``.data`` are read)."""
+    return SimpleNamespace(timestamp=timestamp, data=data)
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestCpuLoadBase(unittest.TestCase):
+    """The abstract ``CpuLoad`` base: ``isValid`` is a contract stub, ``searchLast`` is pure
+    sample-selection logic driven by timestamps + an injected ``isValid``."""
+
+    def _cpuload(self, datas, is_valid, mesure_duration=timedelta(seconds=1.0)):
+        cl = CpuLoad()
+        cl.datas = datas
+        cl.mesure_duration = mesure_duration
+        cl.isValid = is_valid  # instance override of the abstract method
+        return cl
+
+    def test_isvalid_is_abstract(self):
+        with self.assertRaises(NotImplementedError):
+            CpuLoad().isValid(object(), object())
+
+    def test_searchlast_returns_single_valid_recent_item(self):
+        # One sample, younger than mesure_duration so the loop skips it, but isValid -> True,
+        # so the `ok is None` fallback returns datas[0].
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        v0 = _val(now - timedelta(seconds=0.5))
+        cl = self._cpuload([v0], is_valid=lambda item, current: True)
+        self.assertIs(cl.searchLast(_val(now)), v0)
+
+    def test_searchlast_returns_none_when_only_item_invalid(self):
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        v0 = _val(now - timedelta(seconds=3))
+        cl = self._cpuload([v0], is_valid=lambda item, current: False)
+        self.assertIsNone(cl.searchLast(_val(now)))
+
+    def test_searchlast_trims_older_samples_and_returns_pivot(self):
+        # v0/v1 are both old + valid (loop advances ok to 1), v2 is too young (skipped).
+        # ok == 1 -> datas[0:1] deleted (v0 dropped); the returned pivot is v1.
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        v0 = _val(now - timedelta(seconds=3))
+        v1 = _val(now - timedelta(seconds=2))
+        v2 = _val(now - timedelta(seconds=0.5))
+        cl = self._cpuload([v0, v1, v2], is_valid=lambda item, current: True)
+        result = cl.searchLast(_val(now))
+        self.assertIs(result, v1)
+        self.assertEqual(cl.datas, [v1, v2])
+
+    def test_searchlast_ok_zero_keeps_all_samples(self):
+        # Only index 0 qualifies (ok == 0): no trimming, datas[0] returned unchanged.
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        v0 = _val(now - timedelta(seconds=3))
+        v1 = _val(now - timedelta(seconds=0.5))  # too young to qualify
+        cl = self._cpuload([v0, v1], is_valid=lambda item, current: True)
+        result = cl.searchLast(_val(now))
+        self.assertIs(result, v0)
+        self.assertEqual(cl.datas, [v0, v1])
+
+    def test_searchlast_skips_invalid_middle_sample(self):
+        # v1 old but invalid -> ok jumps to the last valid (v2); v0 trimmed.
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        v0 = _val(now - timedelta(seconds=3), data=True)
+        v1 = _val(now - timedelta(seconds=2), data=False)
+        v2 = _val(now - timedelta(seconds=1.5), data=True)
+        cl = self._cpuload([v0, v1, v2], is_valid=lambda item, current: item.data)
+        result = cl.searchLast(_val(now))
+        self.assertIs(result, v2)
+        self.assertEqual(cl.datas, [v2])
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestSystemCpuLoadValue(unittest.TestCase):
+    """Parsing of the ``/proc/stat`` 'cpu ' aggregate line into a list of counters."""
+
+    def _parse(self, lines):
+        fake = _FakeProcStat(lines)
+        with mock.patch.object(cpu_load, "openProc", lambda name: fake):
+            value = SystemCpuLoadValue()
+        return value, fake
+
+    def test_parses_cpu_line_and_closes_file(self):
+        value, fake = self._parse(["cpu  10 20 30 40 50\n", "cpu0 1 2 3 4 5\n"])
+        self.assertEqual(value.data, [10, 20, 30, 40, 50])
+        self.assertTrue(fake.closed)
+        self.assertIsInstance(value.timestamp, datetime)
+
+    def test_negative_counters_clamped_to_zero(self):
+        value, _ = self._parse(["cpu 10 -5 30 -1\n"])
+        self.assertEqual(value.data, [10, 0, 30, 0])
+
+    def test_skips_non_aggregate_lines(self):
+        # Per-core 'cpuN' and other lines must be ignored; only the 'cpu ' line counts.
+        value, _ = self._parse(["cpu0 99 99 99\n", "intr 5 6 7\n", "cpu 7 8 9\n"])
+        self.assertEqual(value.data, [7, 8, 9])
+
+    def test_missing_cpu_line_raises(self):
+        with self.assertRaises(CpuLoadError):
+            self._parse(["cpu0 1 2 3\n", "intr 5\n"])
+
+    def test_empty_cpu_line_raises(self):
+        # 'cpu ' with no counters -> data == [] -> treated as failure.
+        with self.assertRaises(CpuLoadError):
+            self._parse(["cpu \n"])
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestSystemCpuLoad(unittest.TestCase):
+    """The system-load validity check and the ``load = 1 - idle/total`` computation."""
+
+    def _bare(self, min_cycles=50, min_duration=timedelta(seconds=0.5)):
+        s = SystemCpuLoad.__new__(SystemCpuLoad)
+        s.datas = []
+        s.min_cycles = min_cycles
+        s.min_duration = min_duration
+        s.mesure_duration = timedelta(seconds=1.0)
+        return s
+
+    def test_init_reads_initial_sample(self):
+        # Full construction: __init__ reads one /proc/stat sample and seeds datas.
+        fake = _FakeProcStat(["cpu 1 2 3 4\n"])
+        with mock.patch.object(cpu_load, "openProc", lambda name: fake):
+            s = SystemCpuLoad()
+        self.assertEqual(len(s.datas), 1)
+        self.assertEqual(s.datas[0].data, [1, 2, 3, 4])
+        self.assertEqual(s.min_cycles, cpu_load.SYSLOAD_MIN_CYCLES)
+
+    def test_isvalid_true_with_enough_cycles_and_duration(self):
+        s = self._bare(min_cycles=50)
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(data=[0, 0, 0, 0], timestamp=now - timedelta(seconds=1))
+        current = SimpleNamespace(data=[20, 20, 20, 20], timestamp=now)
+        self.assertTrue(s.isValid(item, current))
+
+    def test_isvalid_false_when_too_few_cycles(self):
+        s = self._bare(min_cycles=1000)
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(data=[0, 0, 0, 0], timestamp=now - timedelta(seconds=1))
+        current = SimpleNamespace(data=[1, 1, 1, 1], timestamp=now)
+        self.assertFalse(s.isValid(item, current))
+
+    def test_isvalid_false_when_duration_too_short(self):
+        s = self._bare(min_cycles=1)
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(data=[0, 0, 0, 0], timestamp=now - timedelta(seconds=0.1))
+        current = SimpleNamespace(data=[20, 20, 20, 20], timestamp=now)
+        self.assertFalse(s.isValid(item, current))
+
+    def test_get_computes_one_minus_idle_fraction(self):
+        # diff = [10, 20, 30, 40], idle (index 3) = 40, total = 100 -> load = 0.6.
+        s = self._bare()
+        last = SimpleNamespace(data=[0, 0, 0, 0])
+        s.searchLast = lambda current: last
+        current = SimpleNamespace(data=[10, 20, 30, 40])
+        with mock.patch.object(cpu_load, "SystemCpuLoadValue", lambda: current):
+            load = s.get(estimate=True)
+        self.assertAlmostEqual(load, 0.6)
+        self.assertEqual(s.datas, [current])  # current sample stored
+
+    def test_get_estimate_returns_none_when_no_valid_sample(self):
+        s = self._bare()
+        s.searchLast = lambda current: None
+        with mock.patch.object(
+            cpu_load, "SystemCpuLoadValue", lambda: SimpleNamespace(data=[1, 1, 1, 1])
+        ):
+            self.assertIsNone(s.get(estimate=True))
+
+    def test_get_sleeps_and_retries_until_sample_available(self):
+        # First searchLast miss -> sleep() then retry; second call yields a sample.
+        s = self._bare()
+        last = SimpleNamespace(data=[0, 0, 0, 0])
+        results = [None, last]
+        s.searchLast = lambda current: results.pop(0)
+        slept = []
+        with (
+            mock.patch.object(
+                cpu_load, "SystemCpuLoadValue", lambda: SimpleNamespace(data=[25, 25, 25, 25])
+            ),
+            mock.patch.object(cpu_load, "sleep", lambda secs: slept.append(secs)),
+        ):
+            load = s.get(estimate=False)
+        self.assertAlmostEqual(load, 0.75)  # idle 25 / total 100
+        self.assertEqual(slept, [cpu_load.SYSLOAD_SLEEP])
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestProcessCpuLoadValue(unittest.TestCase):
+    """Reading a process's cumulative user+system ticks and start time."""
+
+    def test_reads_start_time_and_tics(self):
+        stat = SimpleNamespace(starttime=1000, utime=50, stime=30)
+        with mock.patch.object(cpu_load, "readProcessStat", lambda pid: stat):
+            value = ProcessCpuLoadValue(4242)
+        self.assertEqual(value.start_time, 1000)
+        self.assertEqual(value.tics, 80)
+        self.assertIsInstance(value.timestamp, datetime)
+
+    def test_unicode_decode_error_is_swallowed(self):
+        def boom(pid):
+            raise UnicodeDecodeError("utf-8", b"", 0, 1, "bad byte")
+
+        with mock.patch.object(cpu_load, "readProcessStat", boom):
+            value = ProcessCpuLoadValue(1)
+        # The except clause leaves the fields unset rather than crashing.
+        self.assertFalse(hasattr(value, "tics"))
+        self.assertFalse(hasattr(value, "start_time"))
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestProcessCpuLoad(unittest.TestCase):
+    """Process start-datetime reconstruction, validity check, and the ticks/time load calc."""
+
+    def _bare(self, min_cycles=10, min_duration=timedelta(seconds=0.5)):
+        p = ProcessCpuLoad.__new__(ProcessCpuLoad)
+        p.datas = []
+        p.min_cycles = min_cycles
+        p.min_duration = min_duration
+        p.mesure_duration = timedelta(seconds=1.0)
+        p.pid = 1234
+        return p
+
+    def test_init_reconstructs_start_datetime(self):
+        boot = datetime(2020, 1, 1, 0, 0, 0)
+        stat = SimpleNamespace(starttime=cpu_load.HERTZ * 2, utime=0, stime=0)
+        with (
+            mock.patch.object(cpu_load, "readProcessStat", lambda pid: stat),
+            mock.patch.object(cpu_load, "getSystemBoot", lambda: boot),
+        ):
+            p = ProcessCpuLoad(777)
+        # starttime is HERTZ*2 ticks -> 2.0s after boot.
+        self.assertEqual(p.pid, 777)
+        self.assertEqual(len(p.datas), 1)
+        self.assertEqual(p.start, boot + timedelta(seconds=2.0))
+        self.assertEqual(p.min_cycles, cpu_load.CPULOAD_MIN_CYCLES)
+
+    def test_isvalid_true_with_enough_tics_and_duration(self):
+        p = self._bare(min_cycles=10)
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(tics=0, timestamp=now - timedelta(seconds=1))
+        current = SimpleNamespace(tics=50, timestamp=now)
+        self.assertTrue(p.isValid(item, current))
+
+    def test_isvalid_false_when_too_few_tics(self):
+        p = self._bare(min_cycles=100)
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(tics=0, timestamp=now - timedelta(seconds=1))
+        current = SimpleNamespace(tics=5, timestamp=now)
+        self.assertFalse(p.isValid(item, current))
+
+    def test_isvalid_false_when_duration_too_short(self):
+        p = self._bare(min_cycles=1)
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(tics=0, timestamp=now - timedelta(seconds=0.1))
+        current = SimpleNamespace(tics=50, timestamp=now)
+        self.assertFalse(p.isValid(item, current))
+
+    def test_isvalid_false_on_missing_tics_attribute(self):
+        # A sample built from a UnicodeDecodeError has no `tics` -> AttributeError -> False.
+        p = self._bare()
+        now = datetime(2020, 1, 1, 12, 0, 0)
+        item = SimpleNamespace(timestamp=now - timedelta(seconds=1))  # no tics
+        current = SimpleNamespace(tics=50, timestamp=now)
+        self.assertFalse(p.isValid(item, current))
+
+    def _get(self, p, current, previous):
+        p.searchLast = lambda cur: previous
+        with mock.patch.object(cpu_load, "ProcessCpuLoadValue", lambda pid: current):
+            return p.get()
+
+    def test_get_uses_delta_between_two_samples(self):
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        p = self._bare()
+        previous = SimpleNamespace(tics=50, timestamp=base)
+        # Half of HERTZ ticks over 1 second -> load 0.5.
+        current = SimpleNamespace(
+            tics=50 + cpu_load.HERTZ // 2, timestamp=base + timedelta(seconds=1)
+        )
+        load = self._get(p, current, previous)
+        self.assertAlmostEqual(load, 0.5)
+
+    def test_get_estimates_from_start_when_no_previous(self):
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        p = self._bare()
+        p.start = base
+        ticks = cpu_load.HERTZ  # HERTZ ticks over 2s -> load 0.5
+        current = SimpleNamespace(tics=ticks, timestamp=base + timedelta(seconds=2))
+        load = self._get(p, current, None)
+        self.assertAlmostEqual(load, 0.5)
+
+    def test_get_returns_none_without_previous_when_not_estimating(self):
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        p = self._bare()
+        current = SimpleNamespace(tics=10, timestamp=base)
+        p.searchLast = lambda cur: None
+        with mock.patch.object(cpu_load, "ProcessCpuLoadValue", lambda pid: current):
+            self.assertIsNone(p.get(estimate=False))
+        self.assertEqual(p.datas, [current])  # sample stored before the early return
+
+    def test_get_clamps_load_above_one(self):
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        p = self._bare()
+        previous = SimpleNamespace(tics=0, timestamp=base)
+        current = SimpleNamespace(tics=cpu_load.HERTZ * 100, timestamp=base + timedelta(seconds=1))
+        self.assertEqual(self._get(p, current, previous), 1.0)
+
+    def test_get_clamps_negative_load_to_zero(self):
+        # Counter went backwards (tics delta negative) -> clamp to 0.0.
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        p = self._bare()
+        previous = SimpleNamespace(tics=100, timestamp=base)
+        current = SimpleNamespace(tics=10, timestamp=base + timedelta(seconds=1))
+        self.assertEqual(self._get(p, current, previous), 0.0)
+
+    def test_get_falls_back_to_half_on_missing_tics(self):
+        # current sample lacks `tics` -> AttributeError -> default load 0.5.
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        p = self._bare()
+        current = SimpleNamespace(timestamp=base)  # no tics
+        load = self._get(p, current, None)
+        self.assertEqual(load, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpu_probe.py
+++ b/tests/test_cpu_probe.py
@@ -1,0 +1,182 @@
+"""Unit tests for fusil.process.cpu_probe.CpuProbe — the CPU-runaway detection agent.
+
+CpuProbe polls a child process's CPU load each MAS step and, once the load stays above a
+threshold for long enough, scores the session as a hit (a wedged/spinning child). All the
+interesting behaviour is the ``live()`` state machine — reset timer below threshold, arm the
+timer on first overload, then fire after ``max_duration`` — plus its handling of a missing
+sample / ``ProcError``. We drive it with a fake ``load`` object (so no real process or
+``/proc`` is read) and a patched ``time()`` clock, so the timing decisions are deterministic.
+Runtime-free apart from the ``ptrace`` import the module requires to load at all.
+"""
+
+import unittest
+from unittest import mock
+
+try:
+    from ptrace.linux_proc import ProcError
+
+    from fusil.process import cpu_probe
+    from fusil.process.cpu_probe import CpuProbe
+
+    HAS_PTRACE = True
+except ImportError:  # pragma: no cover - ptrace is a hard runtime dependency
+    HAS_PTRACE = False
+
+if HAS_PTRACE:
+    from tests.mas_harness import FakeProject
+
+_SKIP = "python-ptrace is required to import fusil.process.cpu_probe"
+
+
+class _FakeLoad:
+    """Stand-in for ProcessCpuLoad: its ``get()`` returns a fixed value or raises."""
+
+    def __init__(self, value=None, exc=None):
+        self._value = value
+        self._exc = exc
+        self.calls = 0
+
+    def get(self):
+        self.calls += 1
+        if self._exc is not None:
+            raise self._exc
+        return self._value
+
+
+def _probe(max_load=0.75, max_duration=10.0, max_score=1.0):
+    """An initialized CpuProbe with ``send`` captured (avoids needing an active agent)."""
+    probe = CpuProbe(
+        FakeProject(),
+        "cpu:test",
+        max_load=max_load,
+        max_duration=max_duration,
+        max_score=max_score,
+    )
+    probe.init()
+    probe.sent = []
+    probe.send = lambda event, *args: probe.sent.append((event, args))
+    return probe
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestConstruction(unittest.TestCase):
+    def test_defaults(self):
+        probe = CpuProbe(FakeProject(), "cpu")
+        self.assertEqual(probe.max_load, 0.75)
+        self.assertEqual(probe.max_duration, 10.0)
+        self.assertEqual(probe.max_score, 1.0)
+
+    def test_custom_thresholds(self):
+        probe = CpuProbe(FakeProject(), "cpu", max_load=0.5, max_duration=3.0, max_score=0.8)
+        self.assertEqual(probe.max_load, 0.5)
+        self.assertEqual(probe.max_duration, 3.0)
+        self.assertEqual(probe.max_score, 0.8)
+
+    def test_init_resets_state(self):
+        probe = _probe()
+        self.assertIsNone(probe.score)
+        self.assertIsNone(probe.timeout)
+        self.assertIsNone(probe.load)
+
+    def test_get_score_returns_score(self):
+        probe = _probe()
+        self.assertIsNone(probe.getScore())
+        probe.score = 0.42
+        self.assertEqual(probe.getScore(), 0.42)
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestSetPid(unittest.TestCase):
+    def test_setpid_builds_process_cpu_load(self):
+        probe = _probe()
+        sentinel = object()
+        seen = {}
+
+        def fake_ctor(pid):
+            seen["pid"] = pid
+            return sentinel
+
+        with mock.patch.object(cpu_probe, "ProcessCpuLoad", fake_ctor):
+            probe.setPid(31337)
+        self.assertIs(probe.load, sentinel)
+        self.assertEqual(seen["pid"], 31337)
+
+
+@unittest.skipUnless(HAS_PTRACE, _SKIP)
+class TestLive(unittest.TestCase):
+    """The overload-detection state machine."""
+
+    def test_noop_without_load(self):
+        probe = _probe()
+        probe.load = None
+        probe.live()
+        self.assertIsNone(probe.score)
+        self.assertIsNone(probe.timeout)
+
+    def test_ignores_missing_sample(self):
+        # get() returning a falsy value (None/0.0) means "no reading yet": bail, don't arm.
+        for value in (None, 0.0):
+            probe = _probe()
+            probe.timeout = None
+            probe.load = _FakeLoad(value=value)
+            probe.live()
+            self.assertIsNone(probe.timeout)
+            self.assertIsNone(probe.score)
+
+    def test_clears_load_on_procerror(self):
+        probe = _probe()
+        probe.load = _FakeLoad(exc=ProcError("process gone"))
+        probe.live()
+        self.assertIsNone(probe.load)
+        self.assertIsNone(probe.score)
+
+    def test_resets_timer_below_threshold(self):
+        probe = _probe(max_load=0.75)
+        probe.timeout = 1000.0  # an armed timer...
+        probe.load = _FakeLoad(value=0.5)  # ...but load dropped back below the threshold
+        probe.live()
+        self.assertIsNone(probe.timeout)
+        self.assertIsNone(probe.score)
+
+    def test_arms_timer_on_first_overload(self):
+        probe = _probe(max_load=0.75)
+        probe.load = _FakeLoad(value=0.9)
+        with mock.patch.object(cpu_probe, "time", lambda: 1000.0):
+            probe.live()
+        self.assertEqual(probe.timeout, 1000.0)
+        self.assertIsNone(probe.score)
+        self.assertEqual(probe.sent, [])  # not a hit yet
+        self.assertIn(("warning", "CPU load: 90.0%"), probe.logger.records)
+
+    def test_holds_during_grace_period(self):
+        probe = _probe(max_load=0.75, max_duration=10.0)
+        probe.timeout = 1000.0
+        probe.load = _FakeLoad(value=0.9)
+        with mock.patch.object(cpu_probe, "time", lambda: 1005.0):  # duration 5s < 10s
+            probe.live()
+        self.assertIsNone(probe.score)
+        self.assertEqual(probe.sent, [])
+        self.assertEqual(probe.timeout, 1000.0)  # timer keeps running
+
+    def test_scores_after_sustained_overload(self):
+        probe = _probe(max_load=0.75, max_duration=10.0, max_score=1.0)
+        probe.timeout = 1000.0
+        probe.load = _FakeLoad(value=0.9)
+        with mock.patch.object(cpu_probe, "time", lambda: 1011.0):  # duration 11s >= 10s
+            probe.live()
+        self.assertEqual(probe.score, 1.0)
+        self.assertEqual(probe.getScore(), 1.0)
+        self.assertIn(("session_rename", ("cpu_load",)), probe.sent)
+        self.assertIsNone(probe.load)  # detached after firing
+
+    def test_custom_max_score_is_used(self):
+        probe = _probe(max_load=0.5, max_duration=2.0, max_score=0.6)
+        probe.timeout = 100.0
+        probe.load = _FakeLoad(value=0.8)
+        with mock.patch.object(cpu_probe, "time", lambda: 103.0):
+            probe.live()
+        self.assertEqual(probe.score, 0.6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_file_watch.py
+++ b/tests/test_file_watch.py
@@ -1,0 +1,199 @@
+"""Unit tests for fusil.file_watch.FileWatch — the stdout crash-scoring engine.
+
+FileWatch reads a watched file (a fuzzed child's stdout) line by line and scores it against
+word/regex patterns; a high enough score marks the session a crash. It is the substrate the
+Python fuzzer's WatchStdout builds on, and it had essentially no direct coverage. Runtime-free:
+a real MTA-backed FakeProject constructs the agent, `send` is intercepted to capture emitted
+``session_rename`` events, and file I/O uses temp files.
+"""
+
+import os
+import tempfile
+import unittest
+
+from fusil.file_watch import VALID_POS, FileWatch
+from tests.mas_harness import FakeProject
+
+
+def _watch(*, words=None, kill_words=None, regexs=None, max_nb_line=None, start=None):
+    """Build an initialized FileWatch with `send` captured into ``.sent``."""
+    project = FakeProject()
+    w = FileWatch(project, None, "watch:test", start=start)
+    if words is not None:
+        w.words = words
+    if kill_words is not None:
+        w.kill_words = set(kill_words)
+    if max_nb_line is not None:
+        w.max_nb_line = max_nb_line
+    for pattern, score in regexs or ():
+        w.addRegex(pattern, score)
+    w.init()
+    w.sent = []
+    w.send = lambda event, *args: w.sent.append((event, args))
+    return w
+
+
+class TestConstruction(unittest.TestCase):
+    def test_invalid_start_position_rejected(self):
+        with self.assertRaises(ValueError):
+            FileWatch(FakeProject(), None, "w", start="middle")
+
+    def test_valid_positions(self):
+        for pos in VALID_POS:
+            w = FileWatch(FakeProject(), None, "w", start=pos)
+            self.assertEqual(w.start, pos)
+
+    def test_default_start_is_zero(self):
+        self.assertEqual(FileWatch(FakeProject(), None, "w").start, "zero")
+
+
+class TestPatternRegistration(unittest.TestCase):
+    def test_add_regex_encodes_str_and_marks_recompile(self):
+        w = FileWatch(FakeProject(), None, "w")
+        w._need_compile = False
+        w.addRegex("boom", 1.0)
+        pattern, score, match = w.regexs[0]
+        self.assertEqual(pattern, b"boom")
+        self.assertEqual(score, 1.0)
+        self.assertTrue(w._need_compile)
+
+    def test_ignore_regex_appends_search_callable(self):
+        w = FileWatch(FakeProject(), None, "w")
+        w.ignoreRegex("skip.*me")
+        self.assertEqual(len(w.ignore), 1)
+        self.assertTrue(w.ignore[0](b"skip and me"))
+        self.assertFalse(w.ignore[0](b"unrelated"))
+
+    def test_compile_patterns_wraps_words_with_word_boundaries(self):
+        w = _watch(words={"error": 0.3})
+        # "error" matches as a whole token but not as a substring of "errors".
+        self.assertIsNone(w.processLine(b"errors everywhere"))
+        self.assertEqual(w.score, 0.0)
+        self.assertIsNone(w.processLine(b"an error occurred"))
+        self.assertEqual(w.score, 0.3)
+
+
+class TestProcessLineScoring(unittest.TestCase):
+    def test_word_match_adds_score_and_renames(self):
+        w = _watch(words={"segfault": 1.0})
+        w.processLine(b"got a segfault here")
+        self.assertEqual(w.score, 1.0)
+        self.assertIn(("session_rename", (b"segfault",)), w.sent)
+
+    def test_highest_absolute_score_wins(self):
+        w = _watch(words={"warning": 0.1, "critical": 1.0})
+        w.processLine(b"warning: critical failure")
+        self.assertEqual(w.score, 1.0)
+
+    def test_non_matching_line_scores_nothing(self):
+        w = _watch(words={"segfault": 1.0})
+        self.assertIsNone(w.processLine(b"all good here"))
+        self.assertEqual(w.score, 0.0)
+        self.assertEqual(w.sent, [])
+
+    def test_ignored_line_skips_scoring(self):
+        w = _watch(words={"error": 1.0})
+        w.ignoreRegex("ast.Assert")  # emulate the WatchStdout false-positive filter
+        # Recompile ignore is separate from patterns; ignore is consulted directly.
+        self.assertIsNone(w.processLine(b"ast.Assert() error"))
+        self.assertEqual(w.score, 0.0)
+
+    def test_kill_word_returns_KILL(self):
+        w = _watch(words={"error": 0.3}, kill_words={"MemoryError"})
+        self.assertEqual(w.processLine(b"MemoryError: out of memory"), "KILL")
+
+    def test_cleanup_func_applied_before_matching(self):
+        w = _watch(words={"boom": 1.0})
+        w.cleanup_func = lambda line: line.replace(b"XXX", b"boom")
+        w.processLine(b"a XXX happened")
+        self.assertEqual(w.score, 1.0)
+
+    def test_empty_line_after_cleanup_is_skipped(self):
+        w = _watch(words={"boom": 1.0})
+        w.cleanup_func = lambda line: b""
+        self.assertIsNone(w.processLine(b"boom"))
+        self.assertEqual(w.score, 0.0)
+
+    def test_long_output_increments_and_renames_once(self):
+        w = _watch(words={}, max_nb_line=(2, 0.5))
+        w.processLine(b"line one")
+        w.processLine(b"line two")  # total_line hits 2 -> trigger
+        self.assertEqual(w.score, 0.5)
+        self.assertIn(("session_rename", ("long_output",)), w.sent)
+        # Only fires once (max_nb_line cleared).
+        w.processLine(b"line three")
+        self.assertEqual(w.score, 0.5)
+
+
+class TestSessionStopAndScore(unittest.TestCase):
+    def test_get_score_returns_accumulated(self):
+        w = _watch(words={"boom": 1.0})
+        w.processLine(b"boom")
+        self.assertEqual(w.getScore(), 1.0)
+
+    def test_min_nb_line_penalty_applied(self):
+        w = _watch(words={})
+        w.min_nb_line = (5, -0.2)
+        w.total_line = 2
+        w.on_session_stop()
+        self.assertAlmostEqual(w.score, -0.2)
+
+    def test_min_nb_line_not_applied_when_enough_lines(self):
+        w = _watch(words={})
+        w.min_nb_line = (5, -0.2)
+        w.total_line = 10
+        w.on_session_stop()
+        self.assertEqual(w.score, 0.0)
+
+
+class TestFileReading(unittest.TestCase):
+    def _watch_over(self, data: bytes, read_size=4096):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.unlink, path)
+        os.write(fd, data)
+        os.close(fd)
+        project = FakeProject()
+        w = FileWatch(project, None, "w")
+        w.read_size = read_size
+        w.setFileObject(open(path, "rb"))
+        self.addCleanup(w.close)
+        w.init()
+        return w
+
+    def test_readlines_splits_complete_lines(self):
+        w = self._watch_over(b"alpha\nbeta\ngamma\n")
+        self.assertEqual(list(w.readlines()), [b"alpha", b"beta", b"gamma"])
+
+    def test_readlines_buffers_partial_trailing_line(self):
+        w = self._watch_over(b"one\ntwo\npartial", read_size=1)
+        # The trailing 'partial' has no newline yet, so it is buffered, not yielded.
+        self.assertEqual(list(w.readlines()), [b"one", b"two"])
+
+    def test_live_accumulates_score_from_file(self):
+        w = self._watch_over(b"nothing\na segfault occurred\nmore\n")
+        w.words = {"segfault": 1.0}
+        w.init()  # recompile with the new words + reset position
+        w.sent = []
+        w.send = lambda event, *a: w.sent.append((event, a))
+        w.live()
+        self.assertGreaterEqual(w.getScore(), 1.0)
+
+    def test_close_is_idempotent(self):
+        w = self._watch_over(b"x\n")
+        w.close()
+        w.close()  # second close must not raise
+        self.assertIsNone(w.file_obj)
+
+    def test_from_filename_builds_watch(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.unlink, path)
+        os.write(fd, b"hello\n")
+        os.close(fd)
+        w = FileWatch.fromFilename(FakeProject(), path)
+        self.addCleanup(w.close)
+        w.init()
+        self.assertEqual(list(w.readlines()), [b"hello"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_cmdline.py
+++ b/tests/test_process_cmdline.py
@@ -1,0 +1,99 @@
+"""Unit tests for fusil.process.cmdline.CommandLine — the argv assembler.
+
+CommandLine is the tiny ProjectAgent that owns a process's argument vector and hands out a
+*fresh copy* of it via ``create()`` each time the process is (re)launched. WHY the copy
+matters: CreateProcess mutates the returned list in place (it rewrites ``argv[0]`` to the
+resolved program path), so ``create()`` must not leak those edits back into the stored
+template. Runtime-free: no python-ptrace needed (cmdline only imports ProjectAgent), so a
+real MTA-backed FakeProject constructs the agent directly.
+"""
+
+import unittest
+
+from fusil.process.cmdline import CommandLine
+from tests.mas_harness import FakeProject
+
+
+class _FakeProcess:
+    """Minimal process stand-in exposing the ``project()`` / ``name`` that
+    ``CommandLine.__init__`` reads."""
+
+    def __init__(self, project, name="target"):
+        self._project = project
+        self.name = name
+
+    def project(self):
+        return self._project
+
+
+def _cmdline(arguments, name="target"):
+    project = FakeProject()
+    proc = _FakeProcess(project, name=name)
+    return CommandLine(proc, arguments), project
+
+
+class TestConstruction(unittest.TestCase):
+    def test_name_derived_from_process(self):
+        cmd, _ = _cmdline(["python", "-c", "pass"], name="python")
+        self.assertEqual(cmd.name, "python:cmdline")
+
+    def test_arguments_stored_by_reference(self):
+        args = ["python", "-c", "pass"]
+        cmd, _ = _cmdline(args)
+        self.assertIs(cmd.arguments, args)
+
+    def test_registers_with_project(self):
+        cmd, project = _cmdline(["python"])
+        self.assertIn(cmd, project.registered)
+
+
+class TestCreate(unittest.TestCase):
+    def test_create_returns_equal_list(self):
+        cmd, _ = _cmdline(["python", "-c", "pass"])
+        self.assertEqual(cmd.create(), ["python", "-c", "pass"])
+
+    def test_create_returns_a_copy_not_the_stored_list(self):
+        args = ["python", "-c", "pass"]
+        cmd, _ = _cmdline(args)
+        result = cmd.create()
+        self.assertIsNot(result, args)
+        # Mutating the returned list (as CreateProcess does to argv[0]) must not touch the
+        # stored template.
+        result[0] = "/usr/bin/python3"
+        self.assertEqual(cmd.arguments, ["python", "-c", "pass"])
+
+    def test_each_create_is_an_independent_copy(self):
+        cmd, _ = _cmdline(["python"])
+        first = cmd.create()
+        second = cmd.create()
+        self.assertIsNot(first, second)
+        self.assertEqual(first, second)
+
+    def test_create_from_tuple_returns_list(self):
+        cmd, _ = _cmdline(("python", "-c", "pass"))
+        result = cmd.create()
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, ["python", "-c", "pass"])
+
+    def test_create_empty_arguments(self):
+        cmd, _ = _cmdline([])
+        self.assertEqual(cmd.create(), [])
+
+    def test_create_preserves_order_and_mixed_types(self):
+        # CommandLine does no validation (CreateProcess does); create() is a pure passthrough
+        # copy that preserves element order and type (bytes/str mix here).
+        args = [b"python", "-c", b"print(1)"]
+        cmd, _ = _cmdline(args)
+        self.assertEqual(cmd.create(), [b"python", "-c", b"print(1)"])
+
+    def test_create_reflects_later_mutation_of_stored_arguments(self):
+        # arguments is stored by reference, so edits made before create() are visible — this
+        # is what lets a caller build up argv on the CommandLine and have it take effect.
+        args = ["python"]
+        cmd, _ = _cmdline(args)
+        args.append("-v")
+        self.assertEqual(cmd.create(), ["python", "-v"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_env.py
+++ b/tests/test_process_env.py
@@ -1,0 +1,383 @@
+"""Unit tests for fusil.process.env — the child-process environment builder.
+
+``fusil.process.env`` decides what environment a fuzzed child process is spawned with:
+the ``EnvironmentVariable`` family generates variable *values* (fixed strings, random
+integers, random byte strings, fixed-length filler…), the ``Environment`` agent collects
+those plus a whitelist of variables to *copy* from the parent, and ``augment_asan_options``
+fills in the AddressSanitizer flags the crash-dedup pipeline relies on (``handle_abort=1``
+so an abort prints a symbolized backtrace to stdout). A mistake here silently changes what
+every fuzzed child inherits — a wrong ASAN_OPTIONS breaks crash-site resolution, and a
+stray nul byte in a value is rejected outright — so the value generators, the copy/set
+bookkeeping, and the ASan-option merge all deserve direct coverage. It previously sat at
+~33%.
+
+The ``Environment`` agent is a ``ProjectAgent``; it is driven here with the real-MTA
+``FakeProject`` harness (as ``tests/test_file_watch.py`` does) and a ``SimpleNamespace``
+stand-in for the spawning process. No child process is actually launched. Runtime-free.
+"""
+
+import os
+import random
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from fusil.process.env import (
+    Environment,
+    EnvironmentVariable,
+    EnvVarInteger,
+    EnvVarIntegerRange,
+    EnvVarLength,
+    EnvVarRandom,
+    EnvVarValue,
+    augment_asan_options,
+)
+from tests.mas_harness import FakeProject
+
+DEFAULT_COPIES = [
+    "PYTHON_GIL",
+    "PYTHON_JIT",
+    "LSAN_OPTIONS",
+    "ASAN_OPTIONS",
+    "PYTHON_LLTRACE",
+    "PYTHON_OPT_DEBUG_4",
+]
+
+
+def _make_env():
+    """Build an ``Environment`` over a real-MTA FakeProject and a fake spawning process."""
+    project = FakeProject()
+    process = SimpleNamespace(project=lambda: project, name="proc")
+    return Environment(process), project
+
+
+class TestAugmentAsanOptions(unittest.TestCase):
+    def test_none_fills_both_defaults(self):
+        self.assertEqual(augment_asan_options(None), "handle_abort=1:abort_on_error=1")
+
+    def test_empty_string_fills_both_defaults(self):
+        self.assertEqual(augment_asan_options(""), "handle_abort=1:abort_on_error=1")
+
+    def test_preserves_unrelated_option_and_appends_defaults(self):
+        self.assertEqual(
+            augment_asan_options("detect_leaks=1"),
+            "detect_leaks=1:handle_abort=1:abort_on_error=1",
+        )
+
+    def test_existing_handle_abort_value_is_not_overwritten(self):
+        # A caller-provided handle_abort=0 must survive; only the missing key is added.
+        self.assertEqual(
+            augment_asan_options("handle_abort=0"),
+            "handle_abort=0:abort_on_error=1",
+        )
+
+    def test_both_present_returns_unchanged(self):
+        val = "handle_abort=1:abort_on_error=1"
+        self.assertEqual(augment_asan_options(val), val)
+
+    def test_both_present_with_custom_values_preserved_in_order(self):
+        val = "abort_on_error=0:handle_abort=5"
+        self.assertEqual(augment_asan_options(val), val)
+
+    def test_empty_segments_are_filtered_out(self):
+        self.assertEqual(
+            augment_asan_options(":::detect_leaks=1:::"),
+            "detect_leaks=1:handle_abort=1:abort_on_error=1",
+        )
+
+    def test_bare_key_without_value_counts_as_present(self):
+        # Key detection splits on '=', so a valueless "handle_abort" is still "present".
+        self.assertEqual(
+            augment_asan_options("handle_abort"),
+            "handle_abort:abort_on_error=1",
+        )
+
+    def test_idempotent(self):
+        once = augment_asan_options("detect_leaks=1")
+        self.assertEqual(augment_asan_options(once), once)
+
+
+class TestEnvironmentVariableBase(unittest.TestCase):
+    def test_default_counts(self):
+        var = EnvironmentVariable("X")
+        self.assertEqual(var.min_count, 1)
+        self.assertEqual(var.max_count, 1)
+
+    def test_custom_max_count_stored(self):
+        self.assertEqual(EnvironmentVariable("X", max_count=7).max_count, 7)
+
+    def test_has_name_scalar(self):
+        var = EnvironmentVariable("FOO")
+        self.assertTrue(var.hasName("FOO"))
+        self.assertFalse(var.hasName("BAR"))
+
+    def test_has_name_list_membership(self):
+        var = EnvironmentVariable(["A", "B"])
+        self.assertTrue(var.hasName("A"))
+        self.assertTrue(var.hasName("B"))
+        self.assertFalse(var.hasName("C"))
+
+    def test_create_name_scalar_returns_name(self):
+        self.assertEqual(EnvironmentVariable("X").createName(), "X")
+
+    def test_create_name_list_returns_member(self):
+        var = EnvironmentVariable(("A", "B", "C"))
+        for _ in range(25):
+            self.assertIn(var.createName(), ("A", "B", "C"))
+
+    def test_create_value_is_abstract(self):
+        with self.assertRaises(NotImplementedError):
+            EnvironmentVariable("X").createValue()
+
+    def test_create_iterates_into_abstract_create_value(self):
+        # create() is a generator; the NotImplementedError only fires when iterated.
+        with self.assertRaises(NotImplementedError):
+            list(EnvironmentVariable("X").create())
+
+
+class TestEnvironmentVariableCreate(unittest.TestCase):
+    """The generic create() count/name logic, exercised via the concrete EnvVarValue."""
+
+    def test_scalar_yields_single_pair(self):
+        self.assertEqual(list(EnvVarValue("N", "v").create()), [("N", "v")])
+
+    def test_list_name_is_capped_by_default_max_count_one(self):
+        var = EnvVarValue(["A", "B", "C"], "v")  # max_count defaults to 1
+        pairs = list(var.create())
+        self.assertEqual(len(pairs), 1)
+        name, value = pairs[0]
+        self.assertIn(name, ("A", "B", "C"))
+        self.assertEqual(value, "v")
+
+    def test_list_name_with_max_count_allows_multiple(self):
+        random.seed(1234)
+        var = EnvVarValue(["A", "B", "C"], "v", max_count=3)
+        lengths = set()
+        for _ in range(50):
+            pairs = list(var.create())
+            lengths.add(len(pairs))
+            for name, value in pairs:
+                self.assertIn(name, ("A", "B", "C"))
+                self.assertEqual(value, "v")
+        self.assertTrue(lengths <= {1, 2, 3})
+        self.assertGreaterEqual(min(lengths), 1)
+
+    def test_falsy_max_count_means_no_cap_on_list_length(self):
+        # max_count=0 is falsy, so the min() cap is skipped and the full name-list
+        # length becomes the ceiling: count is drawn from [1, len(name)].
+        random.seed(99)
+        var = EnvVarValue(["A", "B"], "v", max_count=0)
+        lengths = {len(list(var.create())) for _ in range(50)}
+        self.assertTrue(lengths <= {1, 2})
+        self.assertIn(2, lengths)
+
+
+class TestEnvVarValue(unittest.TestCase):
+    def test_default_value_is_empty_string(self):
+        self.assertEqual(EnvVarValue("N").createValue(), "")
+
+    def test_custom_value_returned_verbatim(self):
+        self.assertEqual(EnvVarValue("N", "hello").createValue(), "hello")
+
+    def test_is_environment_variable(self):
+        self.assertIsInstance(EnvVarValue("N"), EnvironmentVariable)
+
+
+class TestEnvVarInteger(unittest.TestCase):
+    def test_value_is_parseable_integer_string(self):
+        random.seed(0)
+        var = EnvVarInteger("N")
+        for _ in range(50):
+            value = var.createValue()
+            self.assertIsInstance(value, str)
+            int(value)  # must parse (may be negative)
+
+
+class TestEnvVarIntegerRange(unittest.TestCase):
+    def test_value_within_bounds(self):
+        var = EnvVarIntegerRange("N", 10, 20)
+        for _ in range(100):
+            self.assertTrue(10 <= int(var.createValue()) <= 20)
+
+    def test_single_value_range_is_deterministic(self):
+        self.assertEqual(EnvVarIntegerRange("N", 5, 5).createValue(), "5")
+
+    def test_bounds_are_stored(self):
+        var = EnvVarIntegerRange("N", 1, 2)
+        self.assertEqual((var.min, var.max), (1, 2))
+
+
+class TestEnvVarLength(unittest.TestCase):
+    def test_fixed_length_is_filler_bytes(self):
+        self.assertEqual(EnvVarLength("N", max_length=5, min_length=5).createValue(), b"AAAAA")
+
+    def test_zero_length_is_empty_bytes(self):
+        self.assertEqual(EnvVarLength("N", max_length=0).createValue(), b"")
+
+    def test_length_within_range_and_only_filler(self):
+        var = EnvVarLength("N", max_length=8, min_length=2)
+        for _ in range(50):
+            value = var.createValue()
+            self.assertIsInstance(value, bytes)
+            self.assertTrue(2 <= len(value) <= 8)
+            self.assertEqual(set(value), {ord("A")})
+
+
+class TestEnvVarRandom(unittest.TestCase):
+    def test_value_is_bytes_of_expected_length(self):
+        value = EnvVarRandom("N", min_length=4, max_length=4).createValue()
+        self.assertIsInstance(value, bytes)
+        self.assertEqual(len(value), 4)
+
+    def test_single_element_byte_set_is_deterministic(self):
+        var = EnvVarRandom("N", min_length=20, max_length=20, bytes_set={ord("x")})
+        self.assertEqual(var.createValue(), b"x" * 20)
+
+    def test_default_byte_set_excludes_nul(self):
+        # The default ASCII0 set is 1..255, so a random value never contains a nul byte
+        # (which Environment.create() would otherwise reject).
+        value = EnvVarRandom("N", min_length=200, max_length=200).createValue()
+        self.assertNotIn(0, value)
+
+
+class TestEnvironmentSetup(unittest.TestCase):
+    def test_name_is_derived_from_process(self):
+        env, _ = _make_env()
+        self.assertEqual(env.name, "proc:env")
+
+    def test_registers_with_project(self):
+        env, project = _make_env()
+        self.assertIn(env, project.registered)
+
+    def test_default_copies_and_empty_variables(self):
+        env, _ = _make_env()
+        self.assertEqual(env.copies, DEFAULT_COPIES)
+        self.assertEqual(env.variables, [])
+
+    def test_clear_empties_copies_and_variables(self):
+        env, _ = _make_env()
+        env.add(EnvVarValue("X", "1"))
+        env.clear()
+        self.assertEqual(env.copies, [])
+        self.assertEqual(env.variables, [])
+
+    def test_add_appends_variable(self):
+        env, _ = _make_env()
+        var = EnvVarValue("X", "1")
+        env.add(var)
+        self.assertIn(var, env.variables)
+
+    def test_copy_appends_new_name(self):
+        env, _ = _make_env()
+        env.copy("BRAND_NEW")
+        self.assertIn("BRAND_NEW", env.copies)
+
+    def test_copy_is_idempotent(self):
+        env, _ = _make_env()
+        before = list(env.copies)
+        env.copy("PYTHON_GIL")  # already a default
+        self.assertEqual(env.copies, before)
+
+
+class TestEnvironmentSetAndGetItem(unittest.TestCase):
+    def test_set_creates_and_registers_env_var_value(self):
+        env, _ = _make_env()
+        var = env.set("FOO", "bar")
+        self.assertIsInstance(var, EnvVarValue)
+        self.assertIs(env["FOO"], var)
+        self.assertEqual(var.value, "bar")
+
+    def test_set_existing_returns_same_object_without_updating_value(self):
+        env, _ = _make_env()
+        first = env.set("FOO", "bar")
+        second = env.set("FOO", "baz")
+        self.assertIs(first, second)
+        self.assertEqual(first.value, "bar")  # the second value is ignored
+
+    def test_set_over_incompatible_type_raises(self):
+        env, _ = _make_env()
+        env.add(EnvVarInteger("N"))  # not an EnvVarValue
+        with self.assertRaises(TypeError):
+            env.set("N", "x")
+
+    def test_getitem_missing_raises_key_error(self):
+        env, _ = _make_env()
+        with self.assertRaises(KeyError):
+            env["NOPE"]
+
+    def test_getitem_rejects_list_name(self):
+        env, _ = _make_env()
+        with self.assertRaises(TypeError):
+            env[["A", "B"]]
+
+    def test_getitem_matches_list_named_variable(self):
+        env, _ = _make_env()
+        var = EnvVarValue(["A", "B"], "1")
+        env.add(var)
+        self.assertIs(env["A"], var)
+        self.assertIs(env["B"], var)
+
+
+class TestEnvironmentCreate(unittest.TestCase):
+    def test_empty_environment_yields_only_asan_options(self):
+        env, _ = _make_env()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = env.create()
+        self.assertEqual(result, {"ASAN_OPTIONS": "handle_abort=1:abort_on_error=1"})
+
+    def test_present_copy_names_are_copied_from_parent(self):
+        env, _ = _make_env()
+        with mock.patch.dict(os.environ, {"PYTHON_GIL": "0", "PYTHON_JIT": "1"}, clear=True):
+            result = env.create()
+        self.assertEqual(result["PYTHON_GIL"], "0")
+        self.assertEqual(result["PYTHON_JIT"], "1")
+
+    def test_absent_copy_names_are_skipped(self):
+        env, _ = _make_env()
+        env.copy("SOME_ABSENT_VAR_XYZ")
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = env.create()
+        self.assertNotIn("SOME_ABSENT_VAR_XYZ", result)
+
+    def test_copied_asan_options_are_augmented(self):
+        env, _ = _make_env()
+        with mock.patch.dict(os.environ, {"ASAN_OPTIONS": "detect_leaks=1"}, clear=True):
+            result = env.create()
+        self.assertEqual(result["ASAN_OPTIONS"], "detect_leaks=1:handle_abort=1:abort_on_error=1")
+
+    def test_generated_variable_is_included(self):
+        env, _ = _make_env()
+        env.set("FOO", "bar")
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = env.create()
+        self.assertEqual(result["FOO"], "bar")
+
+    def test_nul_byte_in_value_is_rejected(self):
+        env, _ = _make_env()
+        env.set("BAD", "a\0b")
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                env.create()
+
+    def test_create_logs_variables_and_final_environment(self):
+        env, project = _make_env()
+        env.set("FOO", "bar")
+        with mock.patch.dict(os.environ, {}, clear=True):
+            env.create()
+        messages = [m for level, m in project.application().logger.records if level == "info"]
+        self.assertTrue(any("Create environment variable FOO" in m for m in messages))
+        self.assertTrue(any("Environment:" in m for m in messages))
+
+    def test_bytes_valued_variable_currently_raises_type_error(self):
+        # Documents current coupling (see testability note): create()'s `"\0" in value`
+        # nul-byte guard assumes str values, so a bytes-producing variable
+        # (EnvVarRandom / EnvVarLength) raises TypeError instead of being emitted.
+        env, _ = _make_env()
+        env.add(EnvVarRandom("R", min_length=3, max_length=3))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(TypeError):
+                env.create()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_tools.py
+++ b/tests/test_process_tools.py
@@ -1,0 +1,345 @@
+"""Unit tests for fusil.process.tools — process-related utility helpers.
+
+This module holds the small building blocks the fuzzer uses to launch and constrain
+child processes: resource-limit setters (``limitMemory``/``limitCpuTime``/...),
+process-status formatting (``displayProcessStatus``), command running/locating
+(``runCommand``/``locateProgram``), the ASan-target probe (``target_is_asan``), and the
+``splitCommand`` tokenizer. It had ~38% coverage, most of it from the ``splitCommand``
+doctests wired via ``tests/python/test_doctests.py``.
+
+These tests COMPLEMENT those doctests: they cover the functions and branches the doctests
+don't touch (error paths, resource-limit clamping logic, PATH lookup, status formatting)
+and add error/edge cases for ``splitCommand`` (antislash, unclosed quotes) rather than
+repeating its normal-case doctests.
+
+Mostly runtime-free: the resource/``nice`` primitives are patched at the module level so
+no real process limits are changed, and a ``StubLogger`` captures log calls. The handful of
+tests that genuinely need a real subprocess (``runCommand``, ``target_is_asan`` against a
+real interpreter) are ``@unittest.skipUnless``-guarded on the availability of the required
+binary, so they skip gracefully in constrained environments.
+"""
+
+import io
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from fusil.process import tools
+from tests.mas_harness import StubLogger
+
+# Guards for the few tests that spawn a real subprocess.
+_SH = shutil.which("sh")
+_TRUE = shutil.which("true")
+
+
+class TestSetrlimitLogic(unittest.TestCase):
+    """_setrlimit clamps the soft limit to the hard limit and optionally lowers the hard
+    limit. getrlimit/setrlimit are patched so no real process limit is touched."""
+
+    def _run(self, getrlimit_return, value, change_hard):
+        recorded = {}
+
+        def fake_setrlimit(key, limits):
+            recorded["key"] = key
+            recorded["limits"] = limits
+
+        with (
+            mock.patch.object(tools, "getrlimit", return_value=getrlimit_return),
+            mock.patch.object(tools, "setrlimit", side_effect=fake_setrlimit),
+        ):
+            ret = tools._setrlimit(tools.RLIMIT_CPU, value, change_hard)
+        return ret, recorded
+
+    def test_soft_clamped_to_hard_when_value_exceeds_hard(self):
+        ret, rec = self._run((100, 200), value=500, change_hard=False)
+        self.assertEqual(ret, 200)  # min(500, 200)
+        self.assertEqual(rec["limits"], (200, 200))
+
+    def test_soft_used_directly_when_below_hard(self):
+        ret, rec = self._run((100, 200), value=50, change_hard=False)
+        self.assertEqual(ret, 50)
+        self.assertEqual(rec["limits"], (50, 200))  # hard untouched
+
+    def test_unlimited_hard_lets_value_pass_through(self):
+        # hard == -1 (RLIM_INFINITY) => value is used verbatim, no clamping.
+        ret, rec = self._run((100, -1), value=300, change_hard=False)
+        self.assertEqual(ret, 300)
+        self.assertEqual(rec["limits"], (300, -1))
+
+    def test_change_hard_lowers_hard_to_new_soft(self):
+        ret, rec = self._run((100, 200), value=50, change_hard=True)
+        self.assertEqual(ret, 50)
+        self.assertEqual(rec["limits"], (50, 50))
+
+    def test_valueerror_from_getrlimit_hits_buggy_except_branch(self):
+        # Characterization test (documents a latent bug, see testability notes):
+        # when getrlimit raises ValueError, `soft` is never bound, so the final
+        # setrlimit((soft, hard)) raises UnboundLocalError rather than degrading
+        # gracefully. Pinned here so the behaviour can't change silently.
+        with (
+            mock.patch.object(tools, "getrlimit", side_effect=ValueError("bad key")),
+            mock.patch.object(tools, "setrlimit"),
+        ):
+            with self.assertRaises((UnboundLocalError, NameError)):
+                tools._setrlimit(tools.RLIMIT_CPU, 10, False)
+
+
+class TestResourceLimitWrappers(unittest.TestCase):
+    """The thin wrappers forward the right RLIMIT_* key/value/hard to _setrlimit."""
+
+    def _capture_setrlimit_call(self, call):
+        calls = []
+
+        def fake(key, value, change_hard):
+            calls.append((key, value, change_hard))
+            return value
+
+        with mock.patch.object(tools, "_setrlimit", side_effect=fake):
+            ret = call()
+        return ret, calls
+
+    def test_limit_memory_targets_rlimit_as(self):
+        ret, calls = self._capture_setrlimit_call(lambda: tools.limitMemory(1234, hard=True))
+        self.assertEqual(calls, [(tools.RLIMIT_AS, 1234, True)])
+        self.assertEqual(ret, 1234)
+
+    def test_limit_memory_defaults_hard_false(self):
+        _, calls = self._capture_setrlimit_call(lambda: tools.limitMemory(1234))
+        self.assertEqual(calls[0][2], False)
+
+    def test_limit_user_process_targets_rlimit_nproc(self):
+        _, calls = self._capture_setrlimit_call(lambda: tools.limitUserProcess(16))
+        self.assertEqual(calls[0][0], tools.RLIMIT_NPROC)
+        self.assertEqual(calls[0][1], 16)
+
+    def test_limit_cpu_time_rounds_float_up(self):
+        _, calls = self._capture_setrlimit_call(lambda: tools.limitCpuTime(2.6))
+        self.assertEqual(calls[0], (tools.RLIMIT_CPU, 3, False))  # int(2.6 + 0.5)
+
+    def test_limit_cpu_time_rounds_float_down(self):
+        _, calls = self._capture_setrlimit_call(lambda: tools.limitCpuTime(2.4))
+        self.assertEqual(calls[0][1], 2)  # int(2.4 + 0.5) == 2
+
+    def test_limit_cpu_time_leaves_int_unchanged(self):
+        _, calls = self._capture_setrlimit_call(lambda: tools.limitCpuTime(7))
+        self.assertEqual(calls[0][1], 7)
+
+    def test_allow_core_dump_returns_setrlimit_result(self):
+        ret, calls = self._capture_setrlimit_call(lambda: tools.allowCoreDump(hard=True))
+        self.assertEqual(calls, [(tools.RLIMIT_CORE, -1, True)])
+        self.assertEqual(ret, -1)
+
+    def test_allow_core_dump_swallows_exception_and_prints(self):
+        with mock.patch.object(tools, "_setrlimit", side_effect=ValueError("boom")):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                ret = tools.allowCoreDump()
+        self.assertIsNone(ret)
+        self.assertIn("ValueError: boom", buf.getvalue())
+
+
+class TestBeNice(unittest.TestCase):
+    """beNice passes the right niceness increment to os.nice (patched, not applied)."""
+
+    def test_default_is_moderate(self):
+        with mock.patch.object(tools, "nice") as m_nice:
+            tools.beNice()
+        m_nice.assert_called_once_with(5)
+
+    def test_very_nice_is_higher(self):
+        with mock.patch.object(tools, "nice") as m_nice:
+            tools.beNice(very_nice=True)
+        m_nice.assert_called_once_with(10)
+
+
+class TestDisplayProcessStatus(unittest.TestCase):
+    """Maps an exit status onto the correct log level/message."""
+
+    def test_zero_status_logs_info(self):
+        logger = StubLogger()
+        tools.displayProcessStatus(logger, 0)
+        self.assertEqual(logger.records, [("info", "Process exited normally")])
+
+    def test_negative_status_logs_error_with_signal(self):
+        logger = StubLogger()
+        tools.displayProcessStatus(logger, -9)
+        self.assertEqual(logger.records, [("error", "Process killed by signal 9")])
+
+    def test_positive_status_logs_warning_with_code(self):
+        logger = StubLogger()
+        tools.displayProcessStatus(logger, 3)
+        self.assertEqual(logger.records, [("warning", "Process exited with error code: 3")])
+
+    def test_custom_prefix_is_used(self):
+        logger = StubLogger()
+        tools.displayProcessStatus(logger, 0, prefix="Child")
+        self.assertEqual(logger.records, [("info", "Child exited normally")])
+
+
+class TestLocateProgram(unittest.TestCase):
+    """PATH resolution: absolute/relative shortcuts, PATH scan, and not-found policy."""
+
+    def test_absolute_path_returned_unchanged(self):
+        self.assertEqual(tools.locateProgram("/usr/bin/whatever"), "/usr/bin/whatever")
+
+    def test_relative_with_dirname_is_made_absolute(self):
+        result = tools.locateProgram("./sub/prog")
+        self.assertTrue(os.path.isabs(result))
+        self.assertTrue(result.endswith("/sub/prog"))
+        self.assertEqual(result, os.path.normpath(os.path.join(os.getcwd(), "./sub/prog")))
+
+    def test_found_in_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            prog = os.path.join(d, "myprog")
+            with open(prog, "w") as f:
+                f.write("#!/bin/sh\n")
+            os.chmod(prog, 0o755)
+            with mock.patch.dict(os.environ, {"PATH": d}):
+                self.assertEqual(tools.locateProgram("myprog"), prog)
+
+    def test_non_executable_in_path_is_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            prog = os.path.join(d, "myprog")
+            with open(prog, "w") as f:
+                f.write("data\n")
+            os.chmod(prog, stat.S_IRUSR | stat.S_IWUSR)  # readable but not executable
+            with mock.patch.dict(os.environ, {"PATH": d}):
+                # use_none=False => the bare program name is returned as the default.
+                self.assertEqual(tools.locateProgram("myprog"), "myprog")
+
+    def test_not_found_returns_program_by_default(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {"PATH": d}):
+                self.assertEqual(tools.locateProgram("nope_xyz"), "nope_xyz")
+
+    def test_not_found_returns_none_with_use_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {"PATH": d}):
+                self.assertIsNone(tools.locateProgram("nope_xyz", use_none=True))
+
+    def test_not_found_raises_with_raise_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {"PATH": d}):
+                with self.assertRaises(ValueError):
+                    tools.locateProgram("nope_xyz", raise_error=True)
+
+    def test_missing_path_env_returns_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(tools.locateProgram("prog"), "prog")
+            self.assertIsNone(tools.locateProgram("prog", use_none=True))
+
+    def test_missing_path_env_raises_when_requested(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                tools.locateProgram("prog", raise_error=True)
+
+
+class TestSplitCommandErrorPaths(unittest.TestCase):
+    """Error/edge cases for splitCommand not covered by its doctests."""
+
+    def test_antislash_is_rejected(self):
+        with self.assertRaises(SyntaxError):
+            tools.splitCommand(r"echo a\b")
+
+    def test_unclosed_quote_is_rejected(self):
+        with self.assertRaises(SyntaxError):
+            tools.splitCommand("echo 'unterminated")
+
+    def test_empty_command_yields_empty_list(self):
+        self.assertEqual(tools.splitCommand(""), [])
+
+    def test_trailing_space_does_not_add_empty_arg(self):
+        self.assertEqual(tools.splitCommand("ls "), ["ls"])
+
+    def test_consecutive_spaces_produce_empty_arg(self):
+        # Characterization: back-to-back separators emit an empty token.
+        self.assertEqual(tools.splitCommand("a  b"), ["a", "", "b"])
+
+    def test_tab_is_treated_as_a_quote_char(self):
+        # Characterization (documents a quirk, see testability notes): a tab is in the
+        # separator set but only ' ' is handled as whitespace, so a lone tab is parsed
+        # as an *opening quote* and left unclosed -> SyntaxError.
+        with self.assertRaises(SyntaxError):
+            tools.splitCommand("a\tb")
+
+
+@unittest.skipUnless(_TRUE and _SH, "needs real 'true'/'sh' binaries")
+class TestRunCommand(unittest.TestCase):
+    """runCommand against trivial real subprocesses (skipped if the binaries are absent)."""
+
+    def test_success_returns_none(self):
+        logger = StubLogger()
+        self.assertIsNone(tools.runCommand(logger, [_TRUE]))
+        # It logs the command it ran.
+        self.assertTrue(any(level == "info" for level, _ in logger.records))
+
+    def test_string_command_is_accepted(self):
+        # Exercises the isinstance(command, str) repr branch.
+        self.assertIsNone(tools.runCommand(StubLogger(), "true"))
+
+    def test_nonzero_exit_raises_runtime_error(self):
+        with self.assertRaises(RuntimeError) as cm:
+            tools.runCommand(StubLogger(), [_SH, "-c", "exit 3"])
+        self.assertIn("exit code 3", str(cm.exception))
+
+    def test_nonzero_exit_returned_when_not_raising(self):
+        status = tools.runCommand(StubLogger(), [_SH, "-c", "exit 5"], raise_error=False)
+        self.assertEqual(status, 5)
+
+    def test_signal_death_raises_with_signal_message(self):
+        with self.assertRaises(RuntimeError) as cm:
+            tools.runCommand(StubLogger(), [_SH, "-c", "kill -9 $$"])
+        self.assertIn("killed by signal 9", str(cm.exception))
+
+    def test_stdout_false_suppresses_output(self):
+        # stdout=False routes stdout/stderr to the null device; command still succeeds.
+        self.assertIsNone(tools.runCommand(StubLogger(), [_SH, "-c", "echo hi"], stdout=False))
+
+    def test_stdout_redirected_to_file_object(self):
+        # The `stdout is not True` branch: caller supplies a file to write to.
+        with tempfile.TemporaryFile() as out:
+            tools.runCommand(StubLogger(), [_SH, "-c", "echo captured"], stdout=out)
+            out.seek(0)
+            self.assertIn(b"captured", out.read())
+
+
+class TestTargetIsAsan(unittest.TestCase):
+    """target_is_asan best-effort probe. lru_cache is cleared between cases."""
+
+    def setUp(self):
+        tools.target_is_asan.cache_clear()
+
+    def test_empty_program_is_not_asan(self):
+        # The `if not program` short-circuit — no subprocess spawned.
+        self.assertFalse(tools.target_is_asan(""))
+
+    def test_bogus_program_is_not_asan(self):
+        # Both the CONFIG_ARGS probe and the ldd fallback fail -> False.
+        self.assertFalse(tools.target_is_asan("/nonexistent/interpreter/xyz"))
+
+    def test_config_args_reporting_sanitizer_is_detected(self):
+        # Patch subprocess.run so the first probe reports a sanitizer build.
+        fake = mock.Mock(stdout="--with-address-sanitizer\n")
+        with mock.patch.object(tools, "run", return_value=fake) as m_run:
+            self.assertTrue(tools.target_is_asan("/some/python"))
+        m_run.assert_called_once()  # ldd fallback not reached
+
+    def test_ldd_fallback_detects_asan(self):
+        # First probe returns clean config; ldd fallback mentions asan.
+        outputs = [mock.Mock(stdout=""), mock.Mock(stdout="libasan.so.6 => ...")]
+        with mock.patch.object(tools, "run", side_effect=outputs):
+            self.assertTrue(tools.target_is_asan("/some/python"))
+
+    @unittest.skipUnless(os.path.exists(sys.executable), "needs a real interpreter")
+    def test_real_interpreter_is_not_asan(self):
+        # The dev interpreter is a normal (non-ASan) build; exercises both real probes.
+        self.assertFalse(tools.target_is_asan(sys.executable))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_watch.py
+++ b/tests/test_process_watch.py
@@ -1,0 +1,265 @@
+"""Unit tests for fusil.process.watch.WatchProcess — the exit-status crash scorer.
+
+WatchProcess is the ProjectAgent that turns a fuzzed child's *termination* into a session
+score: a signal death or non-zero exit is interesting, a timeout is maximally interesting,
+and a clean exit is boring. It had almost no direct coverage. WHY it matters: this is the
+non-textual half of crash detection (WatchStdout is the textual half), so its status→score
+mapping decides whether a real segfault/abort is surfaced.
+
+Runtime-free: a real MTA-backed FakeProject constructs the agent, ``send`` is intercepted to
+capture emitted ``session_stop`` events, the process is a lightweight fake (weakref-able,
+exposing ``poll()`` / ``timeout_reached`` / ``process.pid``), and the CpuProbe is swapped for
+a recorder so no ``/proc`` reads happen. WatchProcess is imported through python-ptrace
+(``cpu_probe`` → ``ptrace.linux_proc``), so the tests skip-guard on that import.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from tests.mas_harness import FakeProject
+
+try:
+    from fusil.process.watch import (
+        DEFAULT_EXITCODE_SCORE,
+        DEFAULT_SIGNAL_SCORE,
+        DEFAULT_TIMEOUT_SCORE,
+        WatchProcess,
+    )
+
+    HAVE_WATCH = True
+except Exception:  # pragma: no cover - env without python-ptrace
+    HAVE_WATCH = False
+
+
+class _RecordingCpu:
+    """Stand-in for CpuProbe: truthy (so ``if self.cpu:`` passes) and records setPid()."""
+
+    def __init__(self):
+        self.set_pids = []
+
+    def setPid(self, pid):
+        self.set_pids.append(pid)
+
+
+class _FakeProcess:
+    """Minimal CreateProcess stand-in: weakref-able and exposing the attributes WatchProcess
+    reads — ``project()``, ``name``, ``process.pid``, ``poll()`` and ``timeout_reached``."""
+
+    def __init__(self, project, name="target", pid=4321, timeout_reached=False, poll_status=None):
+        self._project = project
+        self.name = name
+        self.process = SimpleNamespace(pid=pid)
+        self.timeout_reached = timeout_reached
+        self.poll_status = poll_status
+
+    def project(self):
+        return self._project
+
+    def poll(self):
+        return self.poll_status
+
+
+def _make(*, stub_cpu=True, **proc_kwargs):
+    """Build an initialized WatchProcess plus its fake process.
+
+    Score-tuning kwargs (exitcode_score/signal_score/default_score/timeout_score) are peeled
+    off and forwarded to the constructor; the rest configure the fake process. The process is
+    pinned onto the agent (``_keepalive``) so the internal weakref stays live for the test.
+    """
+    score_kwargs = {
+        k: proc_kwargs.pop(k)
+        for k in ("exitcode_score", "signal_score", "default_score", "timeout_score")
+        if k in proc_kwargs
+    }
+    project = FakeProject()
+    proc = _FakeProcess(project, **proc_kwargs)
+    w = WatchProcess(proc, **score_kwargs)
+    w._keepalive = proc
+    if stub_cpu:
+        w.cpu = _RecordingCpu()
+    w.init()
+    w.sent = []
+    w.send = lambda event, *args: w.sent.append((event, args))
+    return w, proc
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestConstruction(unittest.TestCase):
+    def test_name_derived_from_process(self):
+        w, _ = _make(name="json")
+        self.assertEqual(w.name, "watch:json")
+
+    def test_default_scores(self):
+        w, _ = _make()
+        self.assertEqual(w.exitcode_score, DEFAULT_EXITCODE_SCORE)
+        self.assertEqual(w.signal_score, DEFAULT_SIGNAL_SCORE)
+        self.assertEqual(w.timeout_score, DEFAULT_TIMEOUT_SCORE)
+        self.assertEqual(w.default_score, 0.0)
+
+    def test_custom_scores_stored(self):
+        w, _ = _make(exitcode_score=0.2, signal_score=0.9, default_score=0.1, timeout_score=0.7)
+        self.assertEqual(w.exitcode_score, 0.2)
+        self.assertEqual(w.signal_score, 0.9)
+        self.assertEqual(w.default_score, 0.1)
+        self.assertEqual(w.timeout_score, 0.7)
+
+    def test_registers_agent_and_cpu_probe(self):
+        # The watch registers itself, and its CpuProbe also registers, both on the project.
+        project = FakeProject()
+        proc = _FakeProcess(project)
+        w = WatchProcess(proc)
+        self.assertIn(w, project.registered)
+        # Two agents were registered: the watch and its cpu probe.
+        self.assertEqual(len(project.registered), 2)
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestInit(unittest.TestCase):
+    def test_init_resets_score_and_pid(self):
+        w, _ = _make()
+        w.score = 0.5
+        w.pid = 99
+        w.init()
+        self.assertIsNone(w.score)
+        self.assertIsNone(w.pid)
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestComputeScore(unittest.TestCase):
+    def test_positive_exit_code_returns_exitcode_score(self):
+        w, _ = _make(exitcode_score=0.5)
+        self.assertEqual(w.computeScore(1), 0.5)
+        self.assertEqual(w.computeScore(42), 0.5)
+
+    def test_negative_status_is_signal_death(self):
+        # A signal death is reported as a negative status (-signum), e.g. -11 for SIGSEGV.
+        w, _ = _make(signal_score=1.0)
+        self.assertEqual(w.computeScore(-11), 1.0)
+        self.assertEqual(w.computeScore(-6), 1.0)
+
+    def test_zero_status_returns_default_score(self):
+        # Clean exit: distinguish from 0.0 by using a non-zero default_score sentinel.
+        w, _ = _make(default_score=0.3)
+        self.assertEqual(w.computeScore(0), 0.3)
+
+    def test_none_status_returns_none(self):
+        w, _ = _make()
+        self.assertIsNone(w.computeScore(None))
+
+    def test_timeout_reached_returns_timeout_score(self):
+        w, _ = _make(timeout_reached=True, timeout_score=1.0)
+        self.assertEqual(w.computeScore(0), 1.0)
+
+    def test_timeout_takes_priority_over_signal(self):
+        # Timeout is checked before the status branches: even a signal death scores as timeout.
+        w, _ = _make(timeout_reached=True, timeout_score=0.8, signal_score=1.0)
+        self.assertEqual(w.computeScore(-11), 0.8)
+
+    def test_timeout_takes_priority_over_none_status(self):
+        w, _ = _make(timeout_reached=True, timeout_score=0.8)
+        self.assertEqual(w.computeScore(None), 0.8)
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestProcessDone(unittest.TestCase):
+    def test_sets_score_emits_session_stop_and_clears_pid(self):
+        w, _ = _make(exitcode_score=0.5)
+        w.pid = 4321
+        w.processDone(7)
+        self.assertEqual(w.score, 0.5)
+        self.assertEqual(w.sent, [("session_stop", ())])
+        self.assertIsNone(w.pid)
+
+    def test_uses_signal_score_for_signal_death(self):
+        w, _ = _make(signal_score=1.0)
+        w.pid = 4321
+        w.processDone(-11)
+        self.assertEqual(w.score, 1.0)
+
+    def test_getscore_reflects_processDone(self):
+        w, _ = _make(exitcode_score=0.5)
+        self.assertIsNone(w.getScore())
+        w.pid = 1
+        w.processDone(1)
+        self.assertEqual(w.getScore(), 0.5)
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestLive(unittest.TestCase):
+    def test_no_pid_is_noop(self):
+        w, _ = _make(poll_status=1)
+        w.pid = None
+        w.live()
+        self.assertIsNone(w.score)
+        self.assertEqual(w.sent, [])
+
+    def test_process_still_running_does_not_score(self):
+        # poll() returning None means "still alive": no processDone, pid retained.
+        w, _ = _make(poll_status=None)
+        w.pid = 4321
+        w.live()
+        self.assertIsNone(w.score)
+        self.assertEqual(w.pid, 4321)
+        self.assertEqual(w.sent, [])
+
+    def test_process_done_scores_and_stops(self):
+        w, _ = _make(poll_status=5, exitcode_score=0.5)
+        w.pid = 4321
+        w.live()
+        self.assertEqual(w.score, 0.5)
+        self.assertIsNone(w.pid)
+        self.assertEqual(w.sent, [("session_stop", ())])
+
+    def test_process_killed_by_signal_scores_signal(self):
+        w, _ = _make(poll_status=-9, signal_score=1.0)
+        w.pid = 4321
+        w.live()
+        self.assertEqual(w.score, 1.0)
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestEventHandlers(unittest.TestCase):
+    def test_on_process_create_matching_agent_captures_pid_and_prepares(self):
+        w, proc = _make(pid=1234)
+        w.on_process_create(proc)
+        self.assertEqual(w.pid, 1234)
+        # prepareProcess wired the pid through to the cpu probe.
+        self.assertEqual(w.cpu.set_pids, [1234])
+
+    def test_on_process_create_other_agent_is_ignored(self):
+        w, _ = _make(pid=1234)
+        other = SimpleNamespace(process=SimpleNamespace(pid=777))
+        w.on_process_create(other)
+        self.assertIsNone(w.pid)
+        self.assertEqual(w.cpu.set_pids, [])
+
+    def test_on_session_start_with_pid_prepares(self):
+        w, _ = _make(pid=1234)
+        w.pid = 4321
+        w.on_session_start()
+        self.assertEqual(w.cpu.set_pids, [4321])
+
+    def test_on_session_start_without_pid_is_noop(self):
+        w, _ = _make()
+        w.pid = None
+        w.on_session_start()
+        self.assertEqual(w.cpu.set_pids, [])
+
+    def test_prepare_process_without_cpu_probe_is_safe(self):
+        w, _ = _make()
+        w.cpu = None
+        w.pid = 4321
+        w.prepareProcess()  # must not raise
+
+
+@unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
+class TestDeinit(unittest.TestCase):
+    def test_deinit_clears_pid(self):
+        w, _ = _make()
+        w.pid = 4321
+        w.deinit()
+        self.assertIsNone(w.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_replay_python.py
+++ b/tests/test_replay_python.py
@@ -1,0 +1,285 @@
+"""Unit tests for fusil.process.replay_python — the replay-script generator.
+
+`createReplayPythonScript` writes a standalone `replay.py` that re-runs a crashing session's
+command (optionally under gdb/valgrind/ptrace, with the same env/limits/uid). The module is
+pure code generation over the WriteCode primitives, so it tests without the runtime stack: we
+drive each emitter into an in-memory stream and assert on the produced source, and the
+end-to-end test compiles the full generated script to prove it is syntactically valid Python.
+Runtime-free.
+"""
+
+import io
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from fusil.process import replay_python
+from fusil.process.replay_python import (
+    WriteReplayScript,
+    createReplayPythonScript,
+    formatPath,
+    formatValue,
+)
+
+
+class TestFormatValue(unittest.TestCase):
+    def test_run_of_five_or_more_identical_is_collapsed(self):
+        self.assertEqual(formatValue("aaaaa"), "'a' * 5")
+        self.assertEqual(formatValue("a" * 20), "'a' * 20")
+
+    def test_short_run_is_plain_repr(self):
+        self.assertEqual(formatValue("aaaa"), repr("aaaa"))  # len 4 < 5
+
+    def test_mixed_content_is_plain_repr(self):
+        self.assertEqual(formatValue("abcde"), repr("abcde"))
+
+    def test_bytes_run_collapsed(self):
+        self.assertEqual(formatValue(b"\x00\x00\x00\x00\x00"), repr(b"\x00") + " * 5")
+
+    def test_bytes_mixed_repr(self):
+        self.assertEqual(formatValue(b"ab\x00"), repr(b"ab\x00"))
+
+
+class TestFormatPath(unittest.TestCase):
+    def test_str_prefixed_by_cwd(self):
+        self.assertEqual(formatPath("<path>b", "<path>", b"<path>"), "cwd + 'b'")
+
+    def test_str_exactly_cwd(self):
+        self.assertEqual(formatPath("<path>", "<path>", b"<path>"), "cwd")
+
+    def test_bytes_cwd_in_middle(self):
+        self.assertEqual(
+            formatPath(b"a<path>b", "<path>", b"<path>"),
+            "b'a' + cwd_bytes + b'b'",
+        )
+
+    def test_no_match_returns_plain_value(self):
+        self.assertEqual(formatPath("nothing", "<path>", b"<path>"), repr("nothing"))
+
+    def test_bytes_suffix_is_cwd(self):
+        self.assertEqual(formatPath(b"a<path>", "<path>", b"<path>"), "b'a' + cwd_bytes")
+
+
+def _writer():
+    w = WriteReplayScript()
+    w.useStream(io.StringIO())
+    return w
+
+
+class TestEmitters(unittest.TestCase):
+    """Each fixed-content emitter produces non-empty, representative source."""
+
+    def test_python_imports(self):
+        w = _writer()
+        w.pythonImports()
+        out = w.output.getvalue()
+        self.assertIn("from os import", out)
+        self.assertIn("execvpe", out)
+        self.assertTrue(out.startswith("#!"))
+
+    def test_set_sys_path_lists_entries(self):
+        w = _writer()
+        w.setSysPath()
+        out = w.output.getvalue()
+        self.assertIn("sys.path = [", out)
+
+    def test_limit_resources_guards(self):
+        w = _writer()
+        w.limitResources()
+        out = w.output.getvalue()
+        self.assertIn("if options.limit:", out)
+        self.assertIn("limitMemory", out)
+        self.assertIn("limitCpuTime", out)
+
+    def test_parse_options_defines_all_flags(self):
+        w = _writer()
+        w.parseOptions()
+        out = w.output.getvalue()
+        for flag in (
+            "--quiet",
+            "--user",
+            "--limit",
+            "--environ",
+            "--gdb",
+            "--valgrind",
+            "--ptrace",
+        ):
+            self.assertIn(flag, out)
+
+    def test_gdb_commands_and_run(self):
+        w = _writer()
+        w.writeGdbCommands()
+        w.runGdb()
+        out = w.output.getvalue()
+        self.assertIn("gdb.cmds", out)
+        self.assertIn("execvpe", out)
+
+    def test_run_command_handles_modes(self):
+        w = _writer()
+        w.runCommand()
+        out = w.output.getvalue()
+        self.assertIn("options.gdb", out)
+        self.assertIn("options.valgrind", out)
+        self.assertIn("options.ptrace", out)
+
+    def test_write_main(self):
+        w = _writer()
+        w.writeMain()
+        out = w.output.getvalue()
+        self.assertIn("parseOptions()", out)
+        self.assertIn("changeUserGroup", out)
+        self.assertIn("runCommand", out)
+
+    def test_safety_confirmation(self):
+        w = _writer()
+        w.safetyConfirmation()
+        out = w.output.getvalue()
+        self.assertIn("!!!WARNING!!!", out)
+        self.assertIn("yes", out)
+
+    def test_call_main(self):
+        w = _writer()
+        w.callMain()
+        self.assertIn("__main__", w.output.getvalue())
+
+    def test_debug_function(self):
+        w = _writer()
+        w.writeDebugFunction()
+        self.assertIn("stderr", w.output.getvalue())
+
+
+class TestDebugAndPrintHelpers(unittest.TestCase):
+    def test_debug_no_args(self):
+        w = _writer()
+        w.debug(0, "hello")
+        self.assertEqual(w.output.getvalue(), 'debug("hello")\n')
+
+    def test_debug_single_arg(self):
+        w = _writer()
+        w.debug(0, "value %s", "x")
+        self.assertEqual(w.output.getvalue(), 'debug("value %s" % x)\n')
+
+    def test_debug_multiple_args_tupled(self):
+        w = _writer()
+        w.debug(0, "%s and %s", "a", "b")
+        self.assertEqual(w.output.getvalue(), 'debug("%s and %s" % (a, b))\n')
+
+    def test_write_print_plain(self):
+        w = _writer()
+        w.writePrint(0, "hi")
+        self.assertEqual(w.output.getvalue(), 'print ("hi")\n')
+
+    def test_write_print_with_arguments_and_file(self):
+        w = _writer()
+        w.writePrint(0, "x=%s", "x", file="stderr")
+        self.assertEqual(w.output.getvalue(), 'print ("x=%s" % (x), file=stderr)\n')
+
+    def test_write_function_wraps_def_and_indents_body(self):
+        w = _writer()
+        w.writeFunction("foo()", lambda: w.write(0, "body"))
+        self.assertEqual(w.output.getvalue(), "def foo():\n    body\n\n")
+
+
+class TestGlobalVariables(unittest.TestCase):
+    def _emit(self, *, arguments, env, **process_kw):
+        w = _writer()
+        process = SimpleNamespace(
+            stdin=process_kw.get("stdin", True),
+            core_dump=process_kw.get("core_dump", False),
+            max_user_process=process_kw.get("max_user_process", 0),
+            max_memory=process_kw.get("max_memory", 0),
+            timeout=process_kw.get("timeout", 0.0),
+        )
+        config = SimpleNamespace(
+            process_uid=process_kw.get("uid", 1000),
+            process_gid=process_kw.get("gid", 1000),
+            process_user=process_kw.get("process_user", False),
+        )
+        w.globalVariables(process, config, "/work", arguments, env)
+        return w.output.getvalue()
+
+    def test_emits_uid_gid_and_limits(self):
+        out = self._emit(arguments=["prog"], env={}, uid=1000, gid=42, max_memory=2048)
+        self.assertIn("uid = 1000", out)
+        self.assertIn("gid = 42", out)
+        self.assertIn("max_memory = 2048", out)
+        self.assertIn("env = {}", out)
+
+    def test_timeout_and_user_process_none_when_unset(self):
+        out = self._emit(arguments=["prog"], env={})
+        self.assertIn("timeout = None", out)
+        self.assertIn("max_user_process = None", out)
+
+    def test_env_dict_rendered(self):
+        out = self._emit(arguments=["prog"], env={"KEY": "value"})
+        self.assertIn('"KEY":', out)
+
+    def test_need_cwd_bytes_when_argument_contains_cwd(self):
+        # A bytes argument containing the cwd triggers the cwd_bytes helper line.
+        out = self._emit(arguments=[b"/work/sub"], env={})
+        self.assertIn("cwd_bytes = cwd.encode(getfilesystemencoding())", out)
+
+
+class TestWriteCodeIntegration(unittest.TestCase):
+    def _generate(self, *, arguments, env, **process_kw):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(lambda: _rmtree(tmpdir))
+        config = SimpleNamespace(
+            process_uid=process_kw.get("uid", 1000),
+            process_gid=process_kw.get("gid", 1000),
+            process_user=process_kw.get("process_user", False),
+        )
+        session = SimpleNamespace(createFilename=lambda name: os.path.join(tmpdir, name))
+        project = SimpleNamespace(session=session, config=config)
+        process = SimpleNamespace(
+            project=lambda: project,
+            getWorkingDirectory=lambda: tmpdir,
+            stdin=process_kw.get("stdin", True),
+            core_dump=process_kw.get("core_dump", False),
+            max_user_process=process_kw.get("max_user_process", 0),
+            max_memory=process_kw.get("max_memory", 0),
+            timeout=process_kw.get("timeout", 0.0),
+        )
+        createReplayPythonScript(process, arguments, {"env": env})
+        path = os.path.join(tmpdir, "replay.py")
+        with open(path) as fh:
+            return path, fh.read()
+
+    def test_generated_script_is_valid_python(self):
+        path, source = self._generate(arguments=["/bin/true", "arg"], env={"PATH": "/usr/bin"})
+        # The whole point: the emitted replay script must be syntactically valid.
+        compile(source, path, "exec")
+        self.assertIn("def main():", source)
+        self.assertIn("if __name__ == '__main__':", source)
+
+    def test_generated_script_is_executable_file(self):
+        path, _ = self._generate(arguments=["/bin/true"], env={})
+        self.assertTrue(os.access(path, os.X_OK))
+
+    def test_generated_script_valid_with_limits_and_bytes_args(self):
+        path, source = self._generate(
+            arguments=[b"/bin/true", b"data"],
+            env={"HOME": "/root"},
+            max_memory=4096,
+            timeout=30.0,
+            core_dump=True,
+            process_user=True,
+            max_user_process=64,
+        )
+        compile(source, path, "exec")
+        self.assertIn("max_memory = 4096", source)
+        self.assertIn("timeout = 30", source)
+
+    def test_module_level_wrapper_exists(self):
+        self.assertTrue(callable(replay_python.createReplayPythonScript))
+
+
+def _rmtree(path):
+    import shutil
+
+    shutil.rmtree(path, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_system_calm.py
+++ b/tests/test_system_calm.py
@@ -1,0 +1,174 @@
+"""Unit tests for fusil.system_calm.SystemCalm — the "wait until the box is idle" gate.
+
+Before spawning a fuzzed child, the fuzzer blocks in ``SystemCalm.wait`` until the system CPU
+load drops under a threshold, escalating log messages (info once, then repeated errors) and
+giving up with a ``FusilError`` after ``max_wait`` seconds. The decision logic (break/continue,
+message escalation, timeout) is what matters; the actual load reading and wall-clock sleeping
+are side effects. Runtime-free: ``SystemCpuLoad`` is replaced with an injected fake load queue,
+``time`` is a fake clock, and ``sleep`` advances that clock, so the loop is fully deterministic
+with no real I/O or waiting.
+"""
+
+import os
+import unittest
+from unittest import mock
+
+from fusil.error import FusilError
+from fusil.system_calm import SystemCalm
+
+
+class FakeClock:
+    """A monotonic fake clock; ``advance`` is wired to the patched ``sleep`` so time only
+    passes when the loop sleeps (as it does in reality)."""
+
+    def __init__(self, start=1000.0):
+        self.now = start
+
+    def time(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class FakeLoad:
+    """Stand-in for ``SystemCpuLoad``: returns queued load values (the last value repeats so a
+    persistently-busy system can be modelled), and records the ``estimate`` kwarg per call."""
+
+    def __init__(self, loads):
+        self._loads = list(loads)
+        self.calls = []
+
+    def get(self, estimate=False):
+        self.calls.append(estimate)
+        if len(self._loads) > 1:
+            return self._loads.pop(0)
+        return self._loads[0]
+
+
+class FakeAgent:
+    """Captures the info/error log calls ``wait`` makes on the driving agent."""
+
+    def __init__(self):
+        self.infos = []
+        self.errors = []
+
+    def info(self, message):
+        self.infos.append(message)
+
+    def error(self, message):
+        self.errors.append(message)
+
+
+class _CalmTest(unittest.TestCase):
+    def make_calm(self, loads, *, max_load=0.5, sleep_second=1.0, start=1000.0):
+        """Build a SystemCalm with SystemCpuLoad/time/sleep patched; returns (sc, clock, load)."""
+        clock = FakeClock(start)
+        fake_load = FakeLoad(loads)
+        for target, new in (
+            ("fusil.system_calm.SystemCpuLoad", mock.Mock(return_value=fake_load)),
+            ("fusil.system_calm.time", clock.time),
+            ("fusil.system_calm.sleep", clock.advance),
+        ):
+            patcher = mock.patch(target, new)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        sc = SystemCalm(max_load, sleep_second)
+        return sc, clock, fake_load
+
+
+class TestConstruction(_CalmTest):
+    def test_init_stores_parameters_and_defaults(self):
+        sc, _clock, fake_load = self.make_calm([0.1], max_load=0.7, sleep_second=2.5)
+        self.assertEqual(sc.max_load, 0.7)
+        self.assertEqual(sc.sleep, 2.5)
+        self.assertIs(sc.load, fake_load)
+        self.assertEqual(sc.first_message, 3.0)
+        self.assertEqual(sc.repeat_message, 5.0)
+        self.assertEqual(sc.max_wait, 60 * 5)
+
+
+class TestWaitImmediateCalm(_CalmTest):
+    def test_returns_immediately_when_load_under_threshold(self):
+        sc, clock, _load = self.make_calm([0.1], max_load=0.5)
+        agent = FakeAgent()
+        sc.wait(agent)
+        self.assertEqual(agent.infos, [])
+        self.assertEqual(agent.errors, [])
+        # No sleeping happened, so the clock did not move.
+        self.assertEqual(clock.now, 1000.0)
+
+    def test_load_equal_to_threshold_counts_as_calm(self):
+        # `load <= self.max_load`, so the boundary value must not block.
+        sc, _clock, _load = self.make_calm([0.5], max_load=0.5)
+        agent = FakeAgent()
+        sc.wait(agent)
+        self.assertEqual(agent.infos, [])
+        self.assertEqual(agent.errors, [])
+
+    def test_load_read_with_estimate_false(self):
+        sc, _clock, fake_load = self.make_calm([0.1], max_load=0.5)
+        sc.wait(FakeAgent())
+        # wait() must poll the *real* (non-estimated) load exactly once here.
+        self.assertEqual(fake_load.calls, [False])
+
+
+class TestWaitEscalation(_CalmTest):
+    def test_info_then_calm_message_on_transient_load(self):
+        # High once, then calm: one "waiting" info up front, one "now calm" info at the end.
+        sc, _clock, _load = self.make_calm([0.9, 0.1], max_load=0.5, sleep_second=1.0)
+        agent = FakeAgent()
+        sc.wait(agent)
+        self.assertEqual(len(agent.infos), 2)
+        self.assertIn("Wait until system load is under", agent.infos[0])
+        self.assertIn("System is now calm", agent.infos[1])
+        self.assertEqual(agent.errors, [])
+
+    def test_error_repeated_when_load_persists_past_first_message(self):
+        # sleep advances 4s/iter and first_message is 3.0s, so the 2nd iteration crosses the
+        # threshold and escalates from info to error before the load finally drops.
+        sc, _clock, _load = self.make_calm([0.9, 0.9, 0.1], max_load=0.5, sleep_second=4.0)
+        agent = FakeAgent()
+        sc.wait(agent)
+        self.assertEqual(len(agent.errors), 1)
+        self.assertIn("Wait until system load is under", agent.errors[0])
+        self.assertIn("since", agent.errors[0])
+        # Still ends with the "now calm" info once the load drops.
+        self.assertIn("System is now calm", agent.infos[-1])
+
+
+class TestWaitTimeout(_CalmTest):
+    def test_raises_fusilerror_after_max_wait(self):
+        sc, _clock, _load = self.make_calm([0.9], max_load=0.5, sleep_second=5.0)
+        sc.max_wait = 10  # keep the deterministic loop short
+        agent = FakeAgent()
+        with self.assertRaises(FusilError) as ctx:
+            sc.wait(agent)
+        self.assertIn("Unable to calm down system load", str(ctx.exception))
+
+    def test_timeout_still_logs_before_raising(self):
+        sc, _clock, _load = self.make_calm([0.9], max_load=0.5, sleep_second=5.0)
+        sc.max_wait = 10
+        agent = FakeAgent()
+        with self.assertRaises(FusilError):
+            sc.wait(agent)
+        # The first waiting message is emitted before the timeout fires.
+        self.assertTrue(agent.infos or agent.errors)
+
+
+@unittest.skipUnless(
+    os.path.exists("/proc/stat"), "real SystemCpuLoad needs /proc/stat (Linux only)"
+)
+class TestRealConstructionSmoke(unittest.TestCase):
+    """One unpatched construction to prove the real SystemCpuLoad wiring imports and runs; the
+    load *value* is real system state, so nothing about it is asserted."""
+
+    def test_constructs_with_real_cpu_load(self):
+        from fusil.linux.cpu_load import SystemCpuLoad
+
+        sc = SystemCalm(0.5, 0.5)
+        self.assertIsInstance(sc.load, SystemCpuLoad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds **~302 unit tests** across the previously-untested core (`fusil/*`, `fusil/mas/`, `fusil/process/`, `fusil/linux/`) — the biggest coverage gap called out in `CLAUDE.md`. Overall line coverage of the `fusil` package rises **60% → 76%** (coverage.py, `--omit=fusil/notworking/*`). Tests-only; no non-test source changed.

## Per-module coverage (before → after)

| Module | Before | After |
|---|---|---|
| `file_watch.py` (stdout crash-scoring engine) | 13% | **91%** |
| `process/replay_python.py` (replay-script generator) | 8% | **99%** |
| `process/env.py` | 33% | **100%** |
| `process/tools.py` | 38% | **95%** |
| `process/watch.py` (exit-status crash scorer) | 31% | **100%** |
| `process/cmdline.py` | 57% | **100%** |
| `application_logger.py` | 21% | **100%** |
| `config.py` | 22% | **100%** |
| `system_calm.py` | 18% | **100%** |
| `linux/cpu_load.py` | 28% | **100%** |
| `process/cpu_probe.py` | 24% | **100%** |
| `mas/agent_list.py` | 33% | **100%** |

## Approach

- **New shared scaffolding — `tests/mas_harness.py`**: a real-`MTA`-backed `FakeProject` / `StubApplication` / `StubLogger` so `ProjectAgent` subclasses (`FileWatch`, `WatchProcess`, `CpuProbe`, `Environment`, …) can be constructed and driven without the `Univers` loop. Mirrors the stub-app approach already in `tests/test_mas.py`.
- **Runtime-free where possible**: system reads (`/proc/stat`, `getrlimit`/`setrlimit`, `nice`, subprocess launches, `time`/`sleep`) are patched or injected; file I/O uses temp files; `send` is intercepted to capture emitted events. Anything that transitively imports python-ptrace is `@unittest.skipUnless`-guarded (it still runs in the dev/verify venvs where ptrace is installed).
- `process/replay_python.py` is exercised end-to-end by generating the full replay script and `compile()`-ing it to prove it's syntactically valid Python.

## Latent bugs found (characterization-tested; **follow-up fix PR to come**)

The new tests pin these current behaviors with clearly-named tests so a fix is a deliberate, reviewable change:
1. **`_setrlimit` (`process/tools.py`)** raises `UnboundLocalError` if `getrlimit(key)` raises `ValueError` (`soft` never bound before `setrlimit((soft, hard))`). Safety-relevant — this is the child memory cap. Fix: init `soft`/`hard` before the `try`.
2. **`splitCommand` (`process/tools.py`)** treats a tab as an opening quote char (tab is in the separator regex but only `' '` is handled as whitespace) → unterminated-quote `SyntaxError`. Fix: `sep in " \t"`.
3. **`Environment.set()` (`process/env.py`)** silently returns the existing variable *without* updating its value — surprising for a `set`.
4. Several **read-`/proc`-in-`__init__`** couplings (`cpu_load.py`, `cpu_probe.py`, `system_calm.py`) and `WatchProcess`/`CpuProbe` constructing their probe eagerly — cleaner with an injected reader/clock/probe. Documented as testability notes.

## Verification

- `~/venvs/fusil_np_verify/bin/python -m unittest discover -s tests` → **722 tests, OK**.
- `ruff check` + `ruff format --check` over `fusil/ tests/ fuzzers/fusil-python-threaded` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
