### PR TITLE
fix: latent bugs (_setrlimit/splitCommand/Environment.set) + testability injection

### DIFF
--- a/fusil/process/cpu_probe.py
+++ b/fusil/process/cpu_probe.py
@@ -7,11 +7,17 @@ from fusil.project_agent import ProjectAgent
 
 
 class CpuProbe(ProjectAgent):
-    def __init__(self, project, name, max_load=0.75, max_duration=10.0, max_score=1.0):
+    def __init__(
+        self, project, name, max_load=0.75, max_duration=10.0, max_score=1.0, load_factory=None
+    ):
         ProjectAgent.__init__(self, project, name)
         self.max_load = max_load
         self.max_duration = max_duration
         self.max_score = max_score
+        # Factory that builds the per-PID load reader in setPid(). Defaults to ProcessCpuLoad
+        # (which reads /proc/<pid>/stat in its constructor); injectable so setPid can be tested
+        # without a live process. None -> the module-global ProcessCpuLoad (stays monkeypatchable).
+        self.load_factory = load_factory
 
     def init(self):
         self.score = None
@@ -19,7 +25,8 @@ class CpuProbe(ProjectAgent):
         self.load = None
 
     def setPid(self, pid):
-        self.load = ProcessCpuLoad(pid)
+        factory = self.load_factory or ProcessCpuLoad
+        self.load = factory(pid)
 
     def live(self):
         # Read CPU load

--- a/fusil/process/env.py
+++ b/fusil/process/env.py
@@ -139,6 +139,9 @@ class Environment(ProjectAgent):
                     "Variable %s is already set but the type is not EnvVarValue but %s"
                     % (name, variable.__class__.__name__)
                 )
+            # A "set" must set: update the existing variable's value rather than silently
+            # returning the stale one.
+            variable.value = value
         except KeyError:
             variable = EnvVarValue(name, value, max_count)
             self.add(variable)

--- a/fusil/process/tools.py
+++ b/fusil/process/tools.py
@@ -22,6 +22,11 @@ except ImportError:
 
 
 def _setrlimit(key, value, change_hard):
+    # Defaults so a ValueError from getrlimit() (e.g. an unsupported resource) degrades to
+    # "apply the requested value, leave the hard limit alone" instead of raising
+    # UnboundLocalError from the setrlimit() below (soft/hard would otherwise be unbound).
+    soft = value
+    hard = -1
     try:
         soft, hard = getrlimit(key)
         # Change soft limit
@@ -220,7 +225,10 @@ def splitCommand(command):
         if in_quote == sep:
             write = True
             in_quote = None
-        elif sep == " ":
+        elif sep in " \t":
+            # Whitespace (space or tab) separates arguments; tab is in the finditer charset
+            # too, so treat it as whitespace here rather than falling through to the
+            # open-a-quote branch (which left a lone tab as an unterminated quote).
             if not in_quote:
                 write = True
         elif not in_quote:

--- a/fusil/process/watch.py
+++ b/fusil/process/watch.py
@@ -16,11 +16,14 @@ class WatchProcess(ProjectAgent):
         signal_score=DEFAULT_SIGNAL_SCORE,
         default_score=0.0,
         timeout_score=DEFAULT_TIMEOUT_SCORE,
+        cpu_probe=None,
     ):
         self.process = weakref_ref(process)
         project = process.project()
         ProjectAgent.__init__(self, project, "watch:%s" % process.name)
-        self.cpu = CpuProbe(project, "%s:cpu" % self.name)
+        # The CPU-load probe; injectable so the agent can be tested without constructing a real
+        # CpuProbe (which reaches /proc via setPid). None -> the default CpuProbe.
+        self.cpu = cpu_probe if cpu_probe is not None else CpuProbe(project, "%s:cpu" % self.name)
 
         # Score if process exited normally
         self.default_score = default_score

--- a/fusil/system_calm.py
+++ b/fusil/system_calm.py
@@ -5,26 +5,34 @@ from fusil.linux.cpu_load import SystemCpuLoad
 
 
 class SystemCalm:
-    def __init__(self, max_load, sleep_second):
-        self.load = SystemCpuLoad()
+    def __init__(self, max_load, sleep_second, load=None, clock=None, sleeper=None):
+        # `load`/`clock`/`sleeper` are injectable for testing (a fake load source, monotonic
+        # clock, and no-op sleep). Defaults preserve the original behaviour: a real
+        # SystemCpuLoad (reads /proc/stat in its constructor) and the module-global time()/
+        # sleep() -- resolved inside wait(), so both stay monkeypatchable too.
+        self.load = load if load is not None else SystemCpuLoad()
         self.max_load = max_load
-        self.sleep = sleep_second
+        self.sleep_second = sleep_second
+        self._clock = clock
+        self._sleeper = sleeper
         self.first_message = 3.0
         self.repeat_message = 5.0
         self.max_wait = 60 * 5  # seconds (5 minutes)
 
     def wait(self, agent):
+        clock = self._clock or time
+        sleeper = self._sleeper or sleep
         first_message = False
-        start = time()
-        next_message = time() + self.first_message
+        start = clock()
+        next_message = clock() + self.first_message
         while True:
             load = self.load.get(estimate=False)
             if load <= self.max_load:
                 break
-            duration = time() - start
-            if next_message < time():
+            duration = clock() - start
+            if next_message < clock():
                 first_message = True
-                next_message = time() + self.repeat_message
+                next_message = clock() + self.repeat_message
                 agent.error(
                     "Wait until system load is under %.1f%% since %.1f seconds (current: %.1f%%)..."
                     % (self.max_load * 100, duration, load * 100)
@@ -41,9 +49,9 @@ class SystemCalm:
                     "%.1f seconds (current load: %.1f%% > max: %.1f%%)"
                     % (duration, load * 100, self.max_load * 100)
                 )
-            sleep(self.sleep)
+            sleeper(self.sleep_second)
         if first_message:
-            duration = time() - start
+            duration = clock() - start
             agent.info(
                 "System is now calm after %.1f seconds (current load: %.1f%%)"
                 % (duration, load * 100)

--- a/tests/test_cpu_probe.py
+++ b/tests/test_cpu_probe.py
@@ -101,6 +101,21 @@ class TestSetPid(unittest.TestCase):
         self.assertIs(probe.load, sentinel)
         self.assertEqual(seen["pid"], 31337)
 
+    def test_injected_load_factory_is_used(self):
+        # An injected load_factory is preferred over the default ProcessCpuLoad, so setPid
+        # can be exercised without touching /proc (no module patching needed).
+        seen = {}
+        sentinel = object()
+
+        def factory(pid):
+            seen["pid"] = pid
+            return sentinel
+
+        probe = CpuProbe(FakeProject(), "cpu", load_factory=factory)
+        probe.setPid(4242)
+        self.assertIs(probe.load, sentinel)
+        self.assertEqual(seen["pid"], 4242)
+
 
 @unittest.skipUnless(HAS_PTRACE, _SKIP)
 class TestLive(unittest.TestCase):

--- a/tests/test_process_env.py
+++ b/tests/test_process_env.py
@@ -287,12 +287,12 @@ class TestEnvironmentSetAndGetItem(unittest.TestCase):
         self.assertIs(env["FOO"], var)
         self.assertEqual(var.value, "bar")
 
-    def test_set_existing_returns_same_object_without_updating_value(self):
+    def test_set_existing_updates_value_in_place(self):
         env, _ = _make_env()
         first = env.set("FOO", "bar")
         second = env.set("FOO", "baz")
-        self.assertIs(first, second)
-        self.assertEqual(first.value, "bar")  # the second value is ignored
+        self.assertIs(first, second)  # same EnvVarValue object, reused
+        self.assertEqual(first.value, "baz")  # ...but its value is updated ("set" sets)
 
     def test_set_over_incompatible_type_raises(self):
         env, _ = _make_env()

--- a/tests/test_process_tools.py
+++ b/tests/test_process_tools.py
@@ -76,17 +76,17 @@ class TestSetrlimitLogic(unittest.TestCase):
         self.assertEqual(ret, 50)
         self.assertEqual(rec["limits"], (50, 50))
 
-    def test_valueerror_from_getrlimit_hits_buggy_except_branch(self):
-        # Characterization test (documents a latent bug, see testability notes):
-        # when getrlimit raises ValueError, `soft` is never bound, so the final
-        # setrlimit((soft, hard)) raises UnboundLocalError rather than degrading
-        # gracefully. Pinned here so the behaviour can't change silently.
+    def test_valueerror_from_getrlimit_degrades_gracefully(self):
+        # If getrlimit raises ValueError (e.g. an unsupported resource), _setrlimit no longer
+        # crashes with UnboundLocalError: it applies the requested value with an unchanged
+        # (-1) hard limit and returns it.
         with (
             mock.patch.object(tools, "getrlimit", side_effect=ValueError("bad key")),
-            mock.patch.object(tools, "setrlimit"),
+            mock.patch.object(tools, "setrlimit") as m_set,
         ):
-            with self.assertRaises((UnboundLocalError, NameError)):
-                tools._setrlimit(tools.RLIMIT_CPU, 10, False)
+            ret = tools._setrlimit(tools.RLIMIT_CPU, 10, False)
+        self.assertEqual(ret, 10)
+        m_set.assert_called_once_with(tools.RLIMIT_CPU, (10, -1))
 
 
 class TestResourceLimitWrappers(unittest.TestCase):
@@ -260,12 +260,12 @@ class TestSplitCommandErrorPaths(unittest.TestCase):
         # Characterization: back-to-back separators emit an empty token.
         self.assertEqual(tools.splitCommand("a  b"), ["a", "", "b"])
 
-    def test_tab_is_treated_as_a_quote_char(self):
-        # Characterization (documents a quirk, see testability notes): a tab is in the
-        # separator set but only ' ' is handled as whitespace, so a lone tab is parsed
-        # as an *opening quote* and left unclosed -> SyntaxError.
-        with self.assertRaises(SyntaxError):
-            tools.splitCommand("a\tb")
+    def test_tab_is_treated_as_whitespace(self):
+        # A tab separates arguments just like a space (it no longer opens a quote).
+        self.assertEqual(tools.splitCommand("a\tb"), ["a", "b"])
+        self.assertEqual(tools.splitCommand("ls\t-l"), ["ls", "-l"])
+        # ...but a tab inside quotes is preserved as part of the token.
+        self.assertEqual(tools.splitCommand("'a\tb'"), ["a\tb"])
 
 
 @unittest.skipUnless(_TRUE and _SH, "needs real 'true'/'sh' binaries")

--- a/tests/test_process_watch.py
+++ b/tests/test_process_watch.py
@@ -112,6 +112,16 @@ class TestConstruction(unittest.TestCase):
         # Two agents were registered: the watch and its cpu probe.
         self.assertEqual(len(project.registered), 2)
 
+    def test_injected_cpu_probe_is_used_and_no_probe_constructed(self):
+        # An injected cpu_probe is used verbatim; the default CpuProbe (which reaches /proc via
+        # setPid) is not constructed, so only the watch itself registers on the project.
+        project = FakeProject()
+        proc = _FakeProcess(project)
+        stub = _RecordingCpu()
+        w = WatchProcess(proc, cpu_probe=stub)
+        self.assertIs(w.cpu, stub)
+        self.assertEqual(project.registered, [w])
+
 
 @unittest.skipUnless(HAVE_WATCH, "fusil runtime stack (python-ptrace) not importable")
 class TestInit(unittest.TestCase):

--- a/tests/test_system_calm.py
+++ b/tests/test_system_calm.py
@@ -81,11 +81,27 @@ class TestConstruction(_CalmTest):
     def test_init_stores_parameters_and_defaults(self):
         sc, _clock, fake_load = self.make_calm([0.1], max_load=0.7, sleep_second=2.5)
         self.assertEqual(sc.max_load, 0.7)
-        self.assertEqual(sc.sleep, 2.5)
+        self.assertEqual(sc.sleep_second, 2.5)
         self.assertIs(sc.load, fake_load)
         self.assertEqual(sc.first_message, 3.0)
         self.assertEqual(sc.repeat_message, 5.0)
         self.assertEqual(sc.max_wait, 60 * 5)
+
+
+class TestConstructorInjection(unittest.TestCase):
+    """The load source / clock / sleeper can be injected directly (no module patching),
+    exercising the non-default branches of __init__ and wait()."""
+
+    def test_injected_load_clock_and_sleeper_drive_wait(self):
+        clock = FakeClock(0.0)
+        load = FakeLoad([0.9, 0.1])  # busy once, then calm
+        sc = SystemCalm(0.5, 2.0, load=load, clock=clock.time, sleeper=clock.advance)
+        self.assertIs(sc.load, load)
+        agent = FakeAgent()
+        sc.wait(agent)
+        # One sleep of 2.0s happened between the busy and calm reads.
+        self.assertEqual(clock.now, 2.0)
+        self.assertIn("System is now calm", agent.infos[-1])
 
 
 class TestWaitImmediateCalm(_CalmTest):


### PR DESCRIPTION
Fixes the three latent bugs the core-coverage push (#185) uncovered — flipping their characterization tests to assert the *correct* behavior — and removes the read-`/proc`-in-`__init__` / eager-probe couplings behind them via additive, behavior-preserving injection.

## Bugs fixed
1. **`_setrlimit` (`process/tools.py`) — `UnboundLocalError`.** A `ValueError` from `getrlimit()` (e.g. an unsupported resource) left `soft` unbound, so the trailing `setrlimit((soft, hard))` crashed instead of degrading. Now `soft`/`hard` are initialized before the `try`, so it applies the requested value with an unchanged (`-1`) hard limit. **Safety-relevant** — this is the fuzzed child's memory cap.
2. **`splitCommand` (`process/tools.py`) — tab parsed as a quote.** A tab was in the separator charset but only `' '` was handled as whitespace, so a lone tab opened a quote that was never closed → unterminated-quote `SyntaxError`. Now `sep in " \t"` treats tab as whitespace (and it's still preserved inside quotes).
3. **`Environment.set()` (`process/env.py`) — a `set` that didn't set.** On an existing variable it returned the stale object without applying the new value. Now updates `variable.value` in place.

## Testability injection (item 4)
Optional constructor params, **defaults preserve behavior exactly**. The `None` default is resolved to the module global *inside* the method, so existing monkeypatch-based tests keep passing and runtime is unchanged:
- `CpuProbe(..., load_factory=None)` — inject the per-PID load reader rather than always building `ProcessCpuLoad` (which reads `/proc`) in `setPid`.
- `WatchProcess(..., cpu_probe=None)` — inject the probe instead of eagerly constructing a real `CpuProbe`.
- `SystemCalm(..., load=None, clock=None, sleeper=None)` — inject the load source / clock / sleep fn; `wait()` resolves `None` to module-global `time`/`sleep`. (`self.sleep`, a *duration*, renamed to `self.sleep_second` so it no longer shadows the sleep function.)

New tests exercise each injected branch (no monkeypatching needed). The deeper `cpu_load.py` sample-class read/parse split is intentionally deferred — those leaf data-holders are already fully covered via patching, and splitting them is a larger refactor.

## Verification
- Full suite **731 tests, green**; changed modules stay 96–100% covered (`process/tools` 96%, `process/env` 100%, `system_calm` 100%, `process/cpu_probe` 100%, `process/watch` 100%).
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
