### PR TITLE
python: emit more robust generated code to avoid self-inflicted crashes

### DIFF
--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -39,7 +39,10 @@ _BOMB_EXCEPTIONS = (
     IndexError,
     StopIteration,
     SystemError,
-    KeyboardInterrupt,
+    # Only Exception subclasses belong here. BaseException types (KeyboardInterrupt,
+    # SystemExit, GeneratorExit) escape the generated `except Exception` handlers, so a bomb
+    # raising one aborts the whole session (SIGINT / nonzero exit) as a false crash rather
+    # than exercising the target's error handling.
 )
 
 

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -254,7 +254,10 @@ class WritePythonCode(WriteCode):
                 # FUSIL_BOILERPLATE_START
 
                 from gc import collect
-                from random import choice, randint, random, sample, seed
+                # NOTE: do NOT import `random` (the function) here -- it would shadow the
+                # `random` module that embedded tricky-object code imports and uses as
+                # `random.randint(...)`, turning those calls into AttributeError at module load.
+                from random import choice, randint, sample, seed
                 from sys import stderr, path as sys_path
                 from os.path import dirname
                 import ast
@@ -651,7 +654,9 @@ class WritePythonCode(WriteCode):
             dedent(
                 """
             import sys
-            from random import choice, randint, random, sample
+            # Do NOT import `random` (the function) -- it shadows the `random` module that
+            # embedded tricky-object code imports and calls as `random.randint(...)`.
+            from random import choice, randint, sample
             from sys import stderr, path as sys_path
             """
             ),
@@ -1322,9 +1327,22 @@ class WritePythonCode(WriteCode):
             else f'callFunc("{prefix}", "{callable_name}"'
         )
 
-        self.write(0, f"res_{prefix} = {call_prefix},")
-        self._write_arguments_for_call_lines(num_args, 1)
-        self.write(0, f"verbose={verbose})")
+        # Wrap the whole statement in try/except. The arguments are constructed inline, BEFORE
+        # callMethod/callFunc runs, so a hostile literal argument -- a set containing an
+        # unhashable object, a dict keyed on a `__hash__` that raises, a bomb object -- raises
+        # during argument construction, which callMethod's own handler can't catch. Unwrapped it
+        # would escape at module level and abort the whole session as a false crash; wrapped, the
+        # call is simply skipped and fuzzing continues.
+        self.write(0, "try:")
+        with self.indented():
+            self.write(0, f"res_{prefix} = {call_prefix},")
+            self._write_arguments_for_call_lines(num_args, 1)
+            self.write(0, f"verbose={verbose})")
+        self.write(0, f"except Exception as _argexc_{prefix}:")
+        with self.indented():
+            self.write_print_to_stderr(
+                0, f'"[{prefix}] call skipped (argument build failed):", repr(_argexc_{prefix})'
+            )
         self.emptyLine()
 
         self._write_result_deep_dive(prefix, callable_name, generation_depth)

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -1,7 +1,10 @@
 # FUSIL_BOILERPLATE_START
 
 from gc import collect
-from random import choice, randint, random, sample, seed
+# NOTE: do NOT import `random` (the function) here -- it would shadow the
+# `random` module that embedded tricky-object code imports and uses as
+# `random.randint(...)`, turning those calls into AttributeError at module load.
+from random import choice, randint, sample, seed
 from sys import stderr, path as sys_path
 from os.path import dirname
 import ast
@@ -416,7 +419,10 @@ _BOMB_EXCEPTIONS = (
     IndexError,
     StopIteration,
     SystemError,
-    KeyboardInterrupt,
+    # Only Exception subclasses belong here. BaseException types (KeyboardInterrupt,
+    # SystemExit, GeneratorExit) escape the generated `except Exception` handlers, so a bomb
+    # raising one aborts the whole session (SIGINT / nonzero exit) as a false crash rather
+    # than exercising the target's error handling.
 )
 
 
@@ -872,22 +878,33 @@ fuzz_target_module = fakemod
 
 
 import sys
-from random import choice, randint, random, sample
+# Do NOT import `random` (the function) -- it shadows the `random` module that
+# embedded tricky-object code imports and calls as `random.randint(...)`.
+from random import choice, randint, sample
 from sys import stderr, path as sys_path
 
 
 print("--- Fuzzing 2 functions in fakemod ---", file=stderr)
-res_f1 = callFunc("f1", "func_a",
-verbose=True)
+try:
+    res_f1 = callFunc("f1", "func_a",
+    verbose=True)
+except Exception as _argexc_f1:
+    print("[f1] call skipped (argument build failed):", repr(_argexc_f1), file=stderr)
 
 
-res_f2 = callFunc("f2", "func_a",
-verbose=True)
+try:
+    res_f2 = callFunc("f2", "func_a",
+    verbose=True)
+except Exception as _argexc_f2:
+    print("[f2] call skipped (argument build failed):", repr(_argexc_f2), file=stderr)
 
 
-res_f3 = callFunc("f3", "func_a",
-    None,
-verbose=True)
+try:
+    res_f3 = callFunc("f3", "func_a",
+        None,
+    verbose=True)
+except Exception as _argexc_f3:
+    print("[f3] call skipped (argument build failed):", repr(_argexc_f3), file=stderr)
 
 
 
@@ -938,13 +955,19 @@ if instance_c1_widget is not None and instance_c1_widget is not SENTINEL_VALUE:
     if skip_trivial_type(instance_c1_widget):
         print(f'Skipping deep diving on instance_c1_widget {type(instance_c1_widget)}', file=stderr)
     # General method fuzzing for instance_c1_widget
-    res_c1m1 = callMethod("c1m1", instance_c1_widget, "method_two",
-        list[weird_classes['weird_OrderedDict']] | weird_classes['weird_set'] | big_union,
-    verbose=True)
+    try:
+        res_c1m1 = callMethod("c1m1", instance_c1_widget, "method_two",
+            list[weird_classes['weird_OrderedDict']] | weird_classes['weird_set'] | big_union,
+        verbose=True)
+    except Exception as _argexc_c1m1:
+        print("[c1m1] call skipped (argument build failed):", repr(_argexc_c1m1), file=stderr)
 
 
-    res_c1m2 = callMethod("c1m2", instance_c1_widget, "method_one",
-    verbose=True)
+    try:
+        res_c1m2 = callMethod("c1m2", instance_c1_widget, "method_one",
+        verbose=True)
+    except Exception as _argexc_c1m2:
+        print("[c1m2] call skipped (argument build failed):", repr(_argexc_c1m2), file=stderr)
 
 
     print(f"--- Finished fuzzing instance: instance_c1_widget ---", file=stderr)

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -90,6 +90,20 @@ class TestSuperBomb(unittest.TestCase):
             sb.__hash__()  # call 3 > delay 2
 
 
+class TestBombExceptionPool(unittest.TestCase):
+    def test_pool_contains_only_exception_subclasses(self):
+        # BaseException-only types (KeyboardInterrupt/SystemExit/GeneratorExit) escape the
+        # generated `except Exception` handlers and abort the whole session (SIGINT / nonzero
+        # exit) as a false crash instead of exercising error handling. The pool must stay
+        # Exception-only.
+        offenders = [exc.__name__ for exc in B._BOMB_EXCEPTIONS if not issubclass(exc, Exception)]
+        self.assertEqual(offenders, [], f"BaseException-only bomb exceptions: {offenders}")
+
+    def test_bomb_exc_never_returns_baseexception_only(self):
+        drawn = {B._bomb_exc() for _ in range(2000)}
+        self.assertTrue(all(issubclass(e, Exception) for e in drawn))
+
+
 class TestFileBombs(unittest.TestCase):
     def test_read_bomb_delays_then_raises(self):
         rb = B.ReadBomb()


### PR DESCRIPTION
## Problem

Triaging a cereggii fleet, the non-target noise (after the SystemError-ignore change) was dominated by sessions the **generated script kills itself in**, not real target crashes: ~100 `sigint` and ~148 `exitcode1`. All are avoidable by emitting more robust code.

## Fixes

**1. `sigint` — bomb objects drawing `KeyboardInterrupt`.** `_BOMB_EXCEPTIONS` included `KeyboardInterrupt`, a `BaseException` subclass. The generated call sites catch `except Exception`, so a bomb that draws it escapes and aborts the whole session (SIGINT) as a false crash. Dropped it — the pool is now `Exception`-only (bombs exist to exercise error paths, not to kill the interpreter). +regression test.

**2. `exitcode1` (AttributeError subset) — `random` module shadowed.** The generated boilerplate did `from random import …, random, …`, rebinding the bare name `random` to the `random()` *function* and shadowing the `random` module that embedded tricky-object code imports and calls as `random.randint(...)` → `AttributeError` at module load. The name is never used bare in generated scripts, so we stop importing it; `random` now reliably resolves to the module. (Complements the existing `_bomb_random` alias that already hardened the core bomb source.)

**3. `exitcode1` (the rest) — unprotected argument construction.** A call's arguments are constructed inline, *before* `callMethod`/`callFunc` runs — so a hostile literal argument (a set containing an unhashable object, a dict keyed on a `__hash__` that raises, a bomb object) raises during argument construction, which `callMethod`'s own handler can't catch, and escapes at module level. Wrap the whole `res_X = callMethod(...)` statement in try/except so the call is skipped and fuzzing continues. The thread/async call wrappers already protect their own argument construction; this closes the synchronous path.

## Impact / validation

In the sampled fleet, **every `exitcode1` was a `res_X = callMethod/callFunc(...)` whose argument construction raised**, and **every `sigint` was a bomb `KeyboardInterrupt`** — all now avoided. All three fixes verified at runtime; golden output regenerated and validated as parseable Python.

## Tests

- New `TestBombExceptionPool` (pool stays `Exception`-only; `_bomb_exc()` never returns a `BaseException`-only type).
- Golden `fakemod_seed1234.py` regenerated (locks in the call wrapping + the `random` import).
- Full suite green (1038); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)