### PR TITLE
process/env: default ASAN_OPTIONS detect_leaks=0 for fuzzed children

### DIFF
--- a/fusil/process/env.py
+++ b/fusil/process/env.py
@@ -16,12 +16,16 @@ def augment_asan_options(value):
     crash is still scored as a signal death (no scoring change) and other ASan errors
     (segv/UAF) likewise abort consistently. The backtrace lands in the captured stdout,
     letting the in-loop OOM dedup resolve the crash site straight from stdout instead of a
-    nondeterministic gdb re-run. Keys the caller already set are preserved; this is a no-op
-    on non-ASan builds, which ignore ASAN_OPTIONS entirely.
+    nondeterministic gdb re-run. ``detect_leaks=0`` disables LeakSanitizer's exit-time report:
+    the interpreter and many C libraries leave one-time allocations unfreed at exit, so LSan
+    would flag a benign "leak" on *every* session and score it as a false AddressSanitizer
+    crash -- and we hunt crashes/corruption, not leaks. Keys the caller already set are
+    preserved (so a run that explicitly wants leak detection can pass ``detect_leaks=1``);
+    this is a no-op on non-ASan builds, which ignore ASAN_OPTIONS entirely.
     """
     opts = [p for p in (value or "").split(":") if p]
     have = {p.split("=", 1)[0] for p in opts}
-    for key, val in (("handle_abort", "1"), ("abort_on_error", "1")):
+    for key, val in (("handle_abort", "1"), ("abort_on_error", "1"), ("detect_leaks", "0")):
         if key not in have:
             opts.append("%s=%s" % (key, val))
     return ":".join(opts)

--- a/tests/python/test_handle_abort.py
+++ b/tests/python/test_handle_abort.py
@@ -17,9 +17,11 @@ class TestAugmentAsanOptions(unittest.TestCase):
     def _keys(self, s):
         return {p.split("=", 1)[0] for p in s.split(":") if p}
 
-    def test_empty_gets_both_defaults(self):
-        self.assertEqual(augment_asan_options(None), "handle_abort=1:abort_on_error=1")
-        self.assertEqual(augment_asan_options(""), "handle_abort=1:abort_on_error=1")
+    def test_empty_gets_all_defaults(self):
+        self.assertEqual(
+            augment_asan_options(None), "handle_abort=1:abort_on_error=1:detect_leaks=0"
+        )
+        self.assertEqual(augment_asan_options(""), "handle_abort=1:abort_on_error=1:detect_leaks=0")
 
     def test_existing_options_preserved_and_extended(self):
         out = augment_asan_options("detect_leaks=0")

--- a/tests/test_process_env.py
+++ b/tests/test_process_env.py
@@ -52,31 +52,34 @@ def _make_env():
 
 
 class TestAugmentAsanOptions(unittest.TestCase):
-    def test_none_fills_both_defaults(self):
-        self.assertEqual(augment_asan_options(None), "handle_abort=1:abort_on_error=1")
+    def test_none_fills_all_defaults(self):
+        self.assertEqual(
+            augment_asan_options(None), "handle_abort=1:abort_on_error=1:detect_leaks=0"
+        )
 
-    def test_empty_string_fills_both_defaults(self):
-        self.assertEqual(augment_asan_options(""), "handle_abort=1:abort_on_error=1")
+    def test_empty_string_fills_all_defaults(self):
+        self.assertEqual(augment_asan_options(""), "handle_abort=1:abort_on_error=1:detect_leaks=0")
 
-    def test_preserves_unrelated_option_and_appends_defaults(self):
+    def test_caller_detect_leaks_survives(self):
+        # A run that explicitly wants leak detection keeps detect_leaks=1 (not overridden to 0).
         self.assertEqual(
             augment_asan_options("detect_leaks=1"),
             "detect_leaks=1:handle_abort=1:abort_on_error=1",
         )
 
     def test_existing_handle_abort_value_is_not_overwritten(self):
-        # A caller-provided handle_abort=0 must survive; only the missing key is added.
+        # A caller-provided handle_abort=0 must survive; only the missing keys are added.
         self.assertEqual(
             augment_asan_options("handle_abort=0"),
-            "handle_abort=0:abort_on_error=1",
+            "handle_abort=0:abort_on_error=1:detect_leaks=0",
         )
 
-    def test_both_present_returns_unchanged(self):
-        val = "handle_abort=1:abort_on_error=1"
+    def test_all_present_returns_unchanged(self):
+        val = "handle_abort=1:abort_on_error=1:detect_leaks=0"
         self.assertEqual(augment_asan_options(val), val)
 
-    def test_both_present_with_custom_values_preserved_in_order(self):
-        val = "abort_on_error=0:handle_abort=5"
+    def test_all_present_with_custom_values_preserved_in_order(self):
+        val = "abort_on_error=0:handle_abort=5:detect_leaks=1"
         self.assertEqual(augment_asan_options(val), val)
 
     def test_empty_segments_are_filtered_out(self):
@@ -89,7 +92,7 @@ class TestAugmentAsanOptions(unittest.TestCase):
         # Key detection splits on '=', so a valueless "handle_abort" is still "present".
         self.assertEqual(
             augment_asan_options("handle_abort"),
-            "handle_abort:abort_on_error=1",
+            "handle_abort:abort_on_error=1:detect_leaks=0",
         )
 
     def test_idempotent(self):
@@ -323,7 +326,7 @@ class TestEnvironmentCreate(unittest.TestCase):
         env, _ = _make_env()
         with mock.patch.dict(os.environ, {}, clear=True):
             result = env.create()
-        self.assertEqual(result, {"ASAN_OPTIONS": "handle_abort=1:abort_on_error=1"})
+        self.assertEqual(result, {"ASAN_OPTIONS": "handle_abort=1:abort_on_error=1:detect_leaks=0"})
 
     def test_present_copy_names_are_copied_from_parent(self):
         env, _ = _make_env()


### PR DESCRIPTION
## Problem

LeakSanitizer runs at process exit and reports any still-reachable allocation as a "leak". The interpreter and many C libraries leave one-time allocations unfreed at exit, so on an **ASan target** LSan flags a benign leak (e.g. a 96-byte allocation during `import`) on **every** session — and since `abort_on_error=1` turns that into a SIGABRT, each session is scored as a **false `addresssanitizer` crash**.

Surfaced while piloting the h5py ASan target: every session landed as `addresssanitizer` noise.

## Fix

Add `detect_leaks=0` to `augment_asan_options`' defaults (alongside `handle_abort=1` / `abort_on_error=1`). We hunt crashes/corruption, not leaks. Caller-set keys are still preserved, so a run that explicitly wants leak detection can pass `detect_leaks=1`. No-op on non-ASan builds.

## Tests

Updated `TestAugmentAsanOptions` (both copies) + the `Environment`-level assertion. Full suite green (1038); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)