### PR TITLE
fleet: don't count live running sessions as kept crashes

### DIFF
--- a/fleet/fleet
+++ b/fleet/fleet
@@ -29,9 +29,15 @@ inst_dir(){ printf '%s/inst-%02d' "$FLEET_DIR" "$1"; }
 units(){  # active/loaded fusil@N units, one per line
     systemctl list-units --all --no-legend --plain 'fusil@*.service' 2>/dev/null | awk '{print $1}'
 }
-list_crashes(){  # every kept crash dir under an instance (layout-agnostic: has source.py)
+list_crashes(){  # kept crash dirs under an instance (layout-agnostic: has source.py).
+                 # A kept crash dir is *renamed* to "<module>-<kind>-<label>"; a dir still
+                 # named "session-N" is a LIVE running session (its source.py is written at
+                 # session start, before it's kept-or-rmtree'd), so exclude those -- else, on
+                 # a run with few/no real crashes, the ~1 in-flight session per instance is
+                 # miscounted as a kept crash.
     [ -d "$1" ] || return 0                     # dir may not exist yet -> don't trip set -e
-    find "$1" -maxdepth 3 -name source.py -printf '%h\n' 2>/dev/null | sort -u || true
+    find "$1" -maxdepth 3 -name source.py -printf '%h\n' 2>/dev/null \
+        | grep -vE '/session-[0-9]+$' | sort -u || true
 }
 
 cmd_check(){  # validate fleet.conf before we start anything (catches the #1 footgun:

--- a/fusil/python/fleet_report.py
+++ b/fusil/python/fleet_report.py
@@ -61,8 +61,18 @@ def classify_crash_dir(name: str) -> tuple[str, str, str]:
     return module, (kind.group(1) if kind else "other"), (label.group(1) if label else "other")
 
 
+_RUNNING_SESSION_RE = re.compile(r"^session-\d+$")
+
+
 def iter_crash_dirs(inst_dir: str) -> list[str]:
-    """Basenames of kept crash dirs (those holding a source.py) under inst-NN/python*/ ."""
+    """Basenames of kept crash dirs (those holding a source.py) under inst-NN/python*/ .
+
+    A kept crash dir is *renamed* by ``session_rename`` to ``<module>-<kind>-<label>``. A dir
+    still named ``session-<N>`` is a **live running session** -- its ``source.py`` is written
+    at session start, before the session is kept-as-a-crash or ``rmtree``'d -- so exclude those.
+    Otherwise, on a run with few or no real crashes, the ~1 in-flight session per instance is
+    miscounted as a kept crash dir (both here and in the shell ``list_crashes``).
+    """
     out = []
     for run in sorted(_run_dirs(inst_dir)):
         try:
@@ -70,6 +80,8 @@ def iter_crash_dirs(inst_dir: str) -> list[str]:
         except OSError:
             continue
         for entry in entries:
+            if _RUNNING_SESSION_RE.match(entry.name):
+                continue  # live session, not a kept crash
             if entry.is_dir() and os.path.exists(os.path.join(entry.path, "source.py")):
                 out.append(entry.name)
     return out

--- a/tests/python/test_fleet_report.py
+++ b/tests/python/test_fleet_report.py
@@ -126,6 +126,19 @@ class TestCollectAndAggregate(unittest.TestCase):
             insts = fr.discover_instances(os.path.join(tmp, "inst-01"))
             self.assertEqual(len(insts), 1)
 
+    def test_live_session_dirs_not_counted_as_crashes(self):
+        # A still-named "session-N" dir holds a source.py while it runs, but it's a live
+        # session, not a kept crash (kept crashes are renamed <module>-<kind>-<label>).
+        # Regression: on a run with 0 real crashes these were miscounted as kept crashes.
+        with tempfile.TemporaryDirectory() as tmp:
+            r = os.path.join(tmp, "inst-01", "python")
+            os.makedirs(r)
+            _crash(r, "session-377")  # live running session
+            _crash(r, "session-378")  # another, mid-restart
+            _crash(r, "json-sigsegv-oomNEW")  # a genuine kept crash
+            names = fr.iter_crash_dirs(os.path.join(tmp, "inst-01"))
+            self.assertEqual(names, ["json-sigsegv-oomNEW"])
+
 
 class TestAnomaliesAndRender(unittest.TestCase):
     def test_churn_flag(self):


### PR DESCRIPTION
## Problem

`fleet status` / `fleet report` reported "6 crashes kept" on the new h5py fleet even though **zero sessions had crashed** (every session scored `0.0%`). The 6 were the live, in-flight sessions.

## Root cause

Both crash-dir enumerators count **any** directory that holds a `source.py`:
- shell `list_crashes` (used by `fleet status` / `fleet finds`)
- Python `iter_crash_dirs` (used by `fleet report`)

A *currently-running* session dir also holds a `source.py` — it's written at session start, before fusil decides to keep it as a crash (renaming to `<module>-<kind>-<label>`) or `rmtree` it. On a fast run with few/no real crashes, the ~1 in-flight session per instance is the whole count (h5py sessions run ~0.6s, so `2,1,1,1,1 = 6`; inst-01 showed 2 mid-restart).

## Fix

A kept crash dir is always *renamed* — only live/un-kept sessions keep the bare `session-<N>` name. Exclude `session-<N>` from both enumerators:
- `fleet/fleet` `list_crashes`: `| grep -vE '/session-[0-9]+$'`
- `fusil/python/fleet_report.py` `iter_crash_dirs`: skip `^session-\d+$`

Plus a `test_live_session_dirs_not_counted_as_crashes` regression test.

Verified live: both `fleet status` and `fleet_report` now report `0 crashes / 0 oomNEW` on the clean h5py fleet. Touches only the read-only query commands, so a running fleet is unaffected. `test_fleet_report` green (12 tests); `ruff check`/`ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)