### PR TITLE
python: fail fast when the --oom-foreign shim is shadowed (no-op injection)

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -443,11 +443,31 @@ class Fuzzer(Application):
         # inject failures at the C malloc() layer (reaching foreign C libraries). Fail fast if
         # requested but unbuildable -- the user asked for it and needs a working compiler.
         if self.options.oom_foreign:
-            from fusil.python.foreign_oom import get_shim_path
+            from fusil.python.foreign_oom import (
+                ShimShadowedError,
+                get_shim_path,
+                probe_shim_effective,
+            )
 
             shim = get_shim_path()
             process.env.set("LD_PRELOAD", shim)
             self.error("Foreign-OOM: LD_PRELOAD=%s" % shim)
+            # Fail fast if the shim is loaded but doesn't actually intercept the target's
+            # malloc (e.g. a statically-linked ASan build shadows it) -- otherwise the whole
+            # run silently injects nothing. `None` (couldn't verify) is non-fatal.
+            effective = probe_shim_effective(self.options.python, shim)
+            if effective is False:
+                raise ShimShadowedError(
+                    "--oom-foreign: the malloc shim is preloaded but does NOT intercept "
+                    "allocations in the target interpreter (%s) -- allocations bypass it, so "
+                    "NO failures would be injected. The usual cause is a statically-linked "
+                    "AddressSanitizer target whose own malloc shadows the LD_PRELOAD shim. Use "
+                    "a non-ASan target, or rebuild with -shared-libasan and set "
+                    "ASAN_OPTIONS=verify_asan_link_order=0. Aborting rather than running a "
+                    "no-op OOM campaign." % self.options.python
+                )
+            if effective:
+                self.error("Foreign-OOM: shim interception verified on %s" % self.options.python)
             if self.options.oom_foreign_pythonmalloc:
                 process.env.set("PYTHONMALLOC", "malloc")
                 self.error("Foreign-OOM: PYTHONMALLOC=malloc (CPython allocs route through shim)")

--- a/fusil/python/foreign_oom.py
+++ b/fusil/python/foreign_oom.py
@@ -46,7 +46,105 @@ def _make_child_readable(cache_dir: Path, so_path: Path) -> None:
 
 
 class ForeignOOMError(Exception):
-    """Raised when the foreign-OOM shim cannot be built (no compiler / compile failure)."""
+    """Raised when the foreign-OOM shim cannot be built or is ineffective.
+
+    Covers both "no compiler / compile failure" (see ``get_shim_path``) and "the shim loads but
+    does not actually intercept ``malloc`` in the target" (see ``probe_shim_effective`` /
+    ``ShimShadowedError``) -- either way ``--oom-foreign`` cannot inject anything.
+    """
+
+
+class ShimShadowedError(ForeignOOMError):
+    """The shim is preloaded but the target's ``malloc`` bypasses it, so no failure is injected.
+
+    The usual cause is a **statically-linked AddressSanitizer** target: ASan defines/exports its
+    own ``malloc`` in the executable, which sits ahead of ``LD_PRELOAD`` in the global symbol
+    scope and shadows the shim. ``--oom-foreign`` then silently injects *nothing*. Remedy: use a
+    non-ASan target, or rebuild the target (and its C libs) with ``-shared-libasan`` and set
+    ``ASAN_OPTIONS=verify_asan_link_order=0`` so the preloaded shim wins over the shared runtime.
+    """
+
+
+# A tiny program run in the *target* interpreter (with the shim LD_PRELOAD'd) to check that the
+# shim's malloc is actually on the allocation path. ``fusil_malloc_count`` only increments while
+# armed and only from *inside the shim's own malloc*, so a nonzero count after some allocations
+# proves interposition; zero means the shim is shadowed. Armed with an unreachable failure window
+# (fail nothing) so the probe itself can't be killed by an injected failure.
+_PROBE_SRC = (
+    "import ctypes\n"
+    "l = ctypes.CDLL(None)\n"
+    "l.fusil_malloc_count.restype = ctypes.c_long\n"
+    "l.malloc.restype = ctypes.c_void_p\n"
+    "l.malloc.argtypes = [ctypes.c_size_t]\n"
+    "l.free.argtypes = [ctypes.c_void_p]\n"
+    "l.fusil_malloc_arm(ctypes.c_long(1 << 40), ctypes.c_long((1 << 40) + 1))\n"
+    "ps = [l.malloc(1 << 20) for _ in range(8)]\n"
+    "n = l.fusil_malloc_count()\n"
+    "l.fusil_malloc_disarm()\n"
+    "[l.free(ctypes.c_void_p(p)) for p in ps if p]\n"
+    "print('FUSIL_SHIM_COUNT=%d' % n)\n"
+)
+
+_PROBE_MARKER = "FUSIL_SHIM_COUNT="
+
+
+def _parse_probe_count(stdout):
+    """Extract the shim allocation counter from probe stdout; None if the marker is absent.
+
+    Returns the integer count (>0 means the shim intercepted, 0 means it was shadowed), or None
+    when the probe did not report a count at all (e.g. the control symbol wasn't found, so the
+    shim isn't preloaded -- an inconclusive result, not a definitive shadow).
+    """
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if line.startswith(_PROBE_MARKER):
+            try:
+                return int(line[len(_PROBE_MARKER) :])
+            except ValueError:  # pragma: no cover - malformed marker line
+                return None
+    return None
+
+
+def probe_shim_effective(python_exe, shim_path, timeout=30):
+    """Return whether the malloc shim actually intercepts allocations in ``python_exe``.
+
+    Runs a short probe in the target interpreter with the shim ``LD_PRELOAD``'d. Returns:
+
+    * ``True``  -- the shim intercepts (nonzero allocation count): ``--oom-foreign`` will work;
+    * ``False`` -- the shim is shadowed (count 0): injection is a **no-op** (see
+      ``ShimShadowedError``);
+    * ``None``  -- inconclusive: the probe couldn't run or reported no count (don't block on it).
+
+    This never raises: the caller decides what to do with each verdict.
+    """
+    env = dict(os.environ)
+    # Prepend the shim; keep any existing LD_PRELOAD (e.g. the shared ASan runtime) after it.
+    existing = env.get("LD_PRELOAD", "")
+    env["LD_PRELOAD"] = shim_path + ((" " + existing) if existing else "")
+    # Leak detection would fire on the probe's tiny leaks and muddy stderr on ASan targets.
+    env["ASAN_OPTIONS"] = (env.get("ASAN_OPTIONS", "") + ":detect_leaks=0").lstrip(":")
+    try:
+        proc = subprocess.run(
+            [python_exe, "-c", _PROBE_SRC],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError) as err:  # pragma: no cover - env-dependent
+        logger.warning(
+            "foreign-OOM shim probe could not run (%s); skipping effectiveness check", err
+        )
+        return None
+    count = _parse_probe_count(proc.stdout)
+    if count is None:
+        logger.warning(
+            "foreign-OOM shim probe reported no count (rc=%s, stderr=%r); skipping check",
+            proc.returncode,
+            (proc.stderr or "")[-200:],
+        )
+        return None
+    return count > 0
 
 
 def get_shim_path() -> str:

--- a/tests/python/test_foreign_oom.py
+++ b/tests/python/test_foreign_oom.py
@@ -15,7 +15,12 @@ import unittest
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
 
-from fusil.python.foreign_oom import _cache_dir, get_shim_path
+from fusil.python.foreign_oom import (
+    _cache_dir,
+    _parse_probe_count,
+    get_shim_path,
+    probe_shim_effective,
+)
 
 _HAVE_CC = bool(shutil.which("cc") or shutil.which("gcc") or shutil.which("clang"))
 
@@ -82,6 +87,36 @@ class TestForeignOOMShim(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertEqual(proc.stdout.strip().splitlines()[-1], "PASS", proc.stdout + proc.stderr)
+
+
+class TestParseProbeCount(unittest.TestCase):
+    """Pure parse of the shim-effectiveness probe's stdout (no compiler/subprocess)."""
+
+    def test_intercepted(self):
+        self.assertEqual(_parse_probe_count("noise\nFUSIL_SHIM_COUNT=8\nmore"), 8)
+
+    def test_shadowed(self):
+        self.assertEqual(_parse_probe_count("FUSIL_SHIM_COUNT=0"), 0)
+
+    def test_absent_marker_is_none(self):
+        self.assertIsNone(_parse_probe_count("Traceback ...\nAttributeError"))
+        self.assertIsNone(_parse_probe_count(""))
+        self.assertIsNone(_parse_probe_count(None))
+
+
+@unittest.skipUnless(_HAVE_CC, "needs a C compiler to build the malloc shim")
+class TestProbeShimEffective(unittest.TestCase):
+    def test_intercepts_on_non_asan_python(self):
+        # The test runner is a normal (non-ASan) interpreter, so the preloaded shim is on the
+        # allocation path -> the probe must report interception. (A statically-linked ASan
+        # target would return False; that path is exercised by the wiring, not portably here.)
+        shim = get_shim_path()
+        self.assertIs(probe_shim_effective(sys.executable, shim), True)
+
+    def test_missing_python_is_inconclusive_not_fatal(self):
+        # A probe that can't run at all is inconclusive (None), never a false "shadowed" verdict.
+        shim = get_shim_path()
+        self.assertIsNone(probe_shim_effective("/nonexistent/python-xyz", shim))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`--oom-foreign` preloads a malloc-failure shim (`fusil_malloc_shim.c`) to inject allocation failures at the C `malloc()` layer, reaching foreign C libraries (HDF5, zstd, ...). Against a **statically-linked AddressSanitizer** target this silently does **nothing**: ASan defines/exports its own `malloc` in the executable, which sits ahead of `LD_PRELOAD` in the global symbol scope and shadows the shim. The emitted harness only checks that the shim's *control symbol* resolves (it does), not that interposition actually happens — so the whole run injects **zero** failures with no error.

This bit us for real: an h5py ASan fleet ran thousands of sessions finding nothing, because no OOM was ever injected. Proven empirically — on the ASan target the shim's `malloc` counter stays `0` (never called); on a non-ASan python the identical shim works (4/8 injected failures).

## Fix

Add a startup self-check. `probe_shim_effective(python, shim)` runs a tiny probe in the **target** interpreter (arm the shim, `malloc` a few times, read the shim's own allocation counter, which only increments from *inside the shim's malloc*):

- nonzero count → shim is on the allocation path → `True`
- zero → shadowed → `False`
- couldn't run / no marker → `None` (inconclusive, non-fatal)

The `--oom-foreign` setup aborts with a loud, actionable `ShimShadowedError` on a definitive `False`, instead of running a no-op campaign:

```
ERROR: [ShimShadowedError] --oom-foreign: the malloc shim is preloaded but does NOT
intercept allocations in the target interpreter (...) -- allocations bypass it, so NO
failures would be injected. The usual cause is a statically-linked AddressSanitizer
target whose own malloc shadows the LD_PRELOAD shim. Use a non-ASan target, or rebuild
with -shared-libasan and set ASAN_OPTIONS=verify_asan_link_order=0. Aborting rather than
running a no-op OOM campaign.
```

An inconclusive probe is non-fatal (only a definitive `count==0` blocks), so probe flakiness can't cause a false abort.

## Verification

- End-to-end: aborts on the ASan target; prints `Foreign-OOM: shim interception verified` and proceeds on a non-ASan target.
- +5 tests (pure `_parse_probe_count` + skip-guarded `probe_shim_effective`): `test_foreign_oom` green (8 tests). Full OOM group green (24). `ruff check` (whole tree) + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)