### PR TITLE
python: add --oom-start-min (OOM sweep lower bound / targeted replay)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,8 +163,10 @@ Entry: `fuzzers/fusil-python-threaded` → `fusil.python.Fuzzer(Application)`.
 Drives allocation-failure error paths to crash CPython / C-extensions. `WritePythonCode`
 emits an OOM harness (`write_python_code.py`): `faulthandler.enable()`, a guarded
 `from _testcapi import set_nomemory, remove_mem_hooks`, and an `oom_call(label, func,
-*args, **kwargs)` wrapper that sweeps `set_nomemory(start, 0)` over `range(0, --oom-max-start)`
-(default 1000) per call. Each call prints an `[OOM] <label>` marker (and `start=` per
+*args, **kwargs)` wrapper that sweeps `set_nomemory(start, 0)` over
+`range(--oom-start-min, --oom-max-start)` (defaults `range(0, 1000)`; `--oom-start-min` skips
+shallow starts or enables fast targeted replay near a known crash's trigger `start`, and must be
+`< --oom-max-start` or startup aborts) per call. Each call prints an `[OOM] <label>` marker (and `start=` per
 iteration with `--oom-verbose`) so the crashing invocation/allocation is pinpointable on
 replay; `MemoryError` is swallowed — it's the expected boring outcome, so `WatchStdout.kill_words`
 drops "MemoryError" in OOM mode — while `SystemError` is surfaced. Real crashes (segfault/abort)

--- a/doc/oom-fuzzing.md
+++ b/doc/oom-fuzzing.md
@@ -87,8 +87,9 @@ A new `OOM Fuzzing` option group:
 | Option | Type | Default | Meaning |
 |--------|------|---------|---------|
 | `--oom-fuzz` | bool | `False` | Enable OOM mode. |
-| `--oom-max-start` | int | `1000` | Dense sweep upper bound (exclusive): each call sweeps `range(0, N)`. |
-| `--oom-calls` | int | `10` | Number of OOM-wrapped function calls per script (replaces `--functions-number` in OOM mode, bounding `oom_calls × oom_max_start` total iterations). |
+| `--oom-max-start` | int | `1000` | Dense sweep upper bound (exclusive): each call sweeps `range(--oom-start-min, N)`. |
+| `--oom-start-min` | int | `0` | Dense sweep lower bound (inclusive): sweep `range(M, --oom-max-start)` instead of from 0. Skips shallow failure points; with a small window below `--oom-max-start` it enables fast **targeted replay** of a known crash near its trigger `start`. Must be `< --oom-max-start` (an empty range is rejected at startup). |
+| `--oom-calls` | int | `10` | Number of OOM-wrapped function calls per script (replaces `--functions-number` in OOM mode, bounding `oom_calls × (oom_max_start − oom_start_min)` total iterations). |
 | `--oom-verbose` | bool | `False` | Also print the sweep `start` index before each injection, so the exact failing allocation can be pinpointed on replay (verbose; ~`oom_max_start` lines per call). |
 
 Options thread automatically via `self.options` → `PythonSource` →
@@ -113,6 +114,7 @@ except ImportError:
 
 ```python
 _OOM_MAX_START = <oom_max_start>
+_OOM_MIN_START = <oom_start_min>   # default 0
 _OOM_VERBOSE = <oom_verbose>
 
 def oom_call(label, func, *args, **kwargs):
@@ -126,7 +128,7 @@ def oom_call(label, func, *args, **kwargs):
     if not _OOM_AVAILABLE:
         return
     print("[OOM] " + label, file=stderr)
-    for _start in range(_OOM_MAX_START):
+    for _start in range(_OOM_MIN_START, _OOM_MAX_START):
         if _OOM_VERBOSE:
             print("[OOM]   start=" + str(_start), file=stderr)
         _set_nomemory(_start, 0)

--- a/doc/python-fuzzer.md
+++ b/doc/python-fuzzer.md
@@ -119,7 +119,8 @@ historically paid off, so it is opt-in via `--deep-dive`.
 Drives allocation-failure error paths to crash CPython / C-extensions. `WritePythonCode` emits
 an OOM harness: `faulthandler.enable()`, a guarded `from _testcapi import set_nomemory,
 remove_mem_hooks`, and an `oom_call(label, func, *args)` wrapper that sweeps
-`set_nomemory(start, 0)` over `range(0, --oom-max-start)` per call. Each call prints an
+`set_nomemory(start, 0)` over `range(--oom-start-min, --oom-max-start)` (default `range(0,
+1000)`; `--oom-start-min` skips shallow starts / enables fast targeted replay) per call. Each call prints an
 `[OOM] <label>` marker so the crashing allocation is pinpointable on replay; `MemoryError` is
 swallowed (the boring outcome) while `SystemError`/segv/abort are surfaced. **Phase 2** also
 sweeps class constructors + methods (`--oom-classes` / `--oom-methods`). Stateful **sequences**

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -270,9 +270,18 @@ class Fuzzer(Application):
         oom_options.add_option(
             "--oom-max-start",
             help="Dense OOM sweep upper bound (exclusive): each call sweeps "
-            "range(0, N) (default: 1000)",
+            "range(--oom-start-min, N) (default: 1000)",
             type="int",
             default=1000,
+        )
+        oom_options.add_option(
+            "--oom-start-min",
+            help="Dense OOM sweep lower bound (inclusive): each call sweeps "
+            "range(M, --oom-max-start) instead of range(0, ...). Skips shallow "
+            "failure points, and (with a small window below --oom-max-start) enables "
+            "fast targeted replay of a known crash near its trigger start (default: 0)",
+            type="int",
+            default=0,
         )
         oom_options.add_option(
             "--oom-calls",
@@ -412,6 +421,17 @@ class Fuzzer(Application):
         # LD_PRELOAD malloc shim as the arming backend instead of _testcapi.set_nomemory.
         if self.options.oom_foreign:
             self.options.oom_fuzz = True
+
+        # Each OOM sweep is range(--oom-start-min, --oom-max-start); an empty range would make
+        # every oom_call/oom_run a silent no-op (labels printed, no injection). Fail fast rather
+        # than run a useless campaign -- e.g. `--oom-start-min 30` with the default max-start is
+        # fine, but `--oom-start-min 30 --oom-max-start 30` injects nothing.
+        if self.options.oom_fuzz and self.options.oom_start_min >= self.options.oom_max_start:
+            raise ValueError(
+                "--oom-start-min (%d) must be < --oom-max-start (%d); the sweep range "
+                "range(min, max) would otherwise be empty and inject nothing"
+                % (self.options.oom_start_min, self.options.oom_max_start)
+            )
 
         project = self.project
         if not self.project:

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -534,6 +534,7 @@ class WritePythonCode(WriteCode):
                 0,
                 f"""
                 _OOM_MAX_START = {self.options.oom_max_start}
+                _OOM_MIN_START = {getattr(self.options, "oom_start_min", 0)}
                 _OOM_VERBOSE = {bool(self.options.oom_verbose)}
 
                 def oom_call(label, func, *args, **kwargs):
@@ -552,7 +553,7 @@ class WritePythonCode(WriteCode):
                     if not _OOM_AVAILABLE or func is None:
                         return
                     print("[OOM] " + label, file=stderr)
-                    for _start in range(_OOM_MAX_START):
+                    for _start in range(_OOM_MIN_START, _OOM_MAX_START):
                         if _OOM_VERBOSE:
                             print("[OOM]   start=" + str(_start), file=stderr)
                         _set_nomemory(_start, 0)
@@ -595,7 +596,7 @@ class WritePythonCode(WriteCode):
                             pass
                         return
                     print("[OOM-SEQ] " + label + " window=" + str(window), file=stderr)
-                    for _start in range(_OOM_MAX_START):
+                    for _start in range(_OOM_MIN_START, _OOM_MAX_START):
                         if _OOM_VERBOSE:
                             print("[OOM-SEQ]   start=" + str(_start) + " window=" + str(window), file=stderr)
                         if window > 0:

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -37,6 +37,7 @@ def _make_options(oom_fuzz, oom_verbose=False):
     # OOM mode
     o.oom_fuzz = oom_fuzz
     o.oom_max_start = OOM_MAX_START
+    o.oom_start_min = 0
     o.oom_calls = OOM_CALLS
     o.oom_verbose = oom_verbose
     # General generation knobs
@@ -80,6 +81,7 @@ def _generate(
     oom_window=1,
     oom_seq_randomize=False,
     oom_foreign=False,
+    oom_start_min=0,
 ):
     """Generate a fuzzing script against ``module`` and return its source."""
     parent = MagicMock()
@@ -92,6 +94,7 @@ def _generate(
     options.oom_window = oom_window
     options.oom_seq_randomize = oom_seq_randomize
     options.oom_foreign = oom_foreign
+    options.oom_start_min = oom_start_min
     parent.options = options
     parent.filenames = ["/bin/sh"]
     fd, path = tempfile.mkstemp(suffix="_oom_test.py")
@@ -128,7 +131,8 @@ class TestOOMFuzzGeneration(unittest.TestCase):
         # The dense-sweep harness, parameterised by --oom-max-start, now takes a label.
         self.assertIn("def oom_call(label, func", src)
         self.assertIn(f"_OOM_MAX_START = {OOM_MAX_START}", src)
-        self.assertIn("range(_OOM_MAX_START)", src)
+        self.assertIn("_OOM_MIN_START = 0", src)
+        self.assertIn("range(_OOM_MIN_START, _OOM_MAX_START)", src)
         # The allocation hook is installed ONCE (disarmed) and the loop re-arms/disarms the
         # failure window without swapping the allocator -- swapping (remove_mem_hooks) inside
         # the loop races fuzzed worker threads and corrupts the heap. So the per-iteration
@@ -157,6 +161,17 @@ class TestOOMFuzzGeneration(unittest.TestCase):
         self.assertIn("_OOM_VERBOSE = True", src)
         self.assertIn('print("[OOM]   start=" + str(_start)', src)
 
+    def test_oom_start_min_sets_sweep_lower_bound(self):
+        # --oom-start-min emits _OOM_MIN_START and makes each sweep range(min, max) --
+        # skipping shallow failure points (e.g. for fast targeted replay near a known start).
+        src = _generate(oom_fuzz=True, oom_start_min=30)
+        ast.parse(src)
+        self.assertIn("_OOM_MIN_START = 30", src)
+        self.assertIn("range(_OOM_MIN_START, _OOM_MAX_START)", src)
+        # default (0) is the unchanged full sweep from the bottom.
+        src0 = _generate(oom_fuzz=True)
+        self.assertIn("_OOM_MIN_START = 0", src0)
+
     def test_non_oom_mode_has_no_oom_artifacts(self):
         src = _generate(oom_fuzz=False)
 
@@ -166,6 +181,7 @@ class TestOOMFuzzGeneration(unittest.TestCase):
             "set_nomemory",
             "_OOM_AVAILABLE",
             "_OOM_MAX_START",
+            "_OOM_MIN_START",
             "_OOM_VERBOSE",
             "remove_mem_hooks",
         ):


### PR DESCRIPTION
## What

The OOM harness sweeps each call over `range(0, --oom-max-start)`. This adds **`--oom-start-min M`** so it sweeps `range(M, --oom-max-start)` instead. Default `0` — output and behaviour unchanged.

## Why

Two uses:
- **Skip shallow failure points** — a failure at `start=3` usually just raises a clean `MemoryError`; the interesting HDF5/CPython corruption often needs the failure to land deep in a multi-allocation operation.
- **Fast targeted replay** — a known crash's trigger `start` is printed in its stdout (`[OOM] start=N`). Replaying with `--oom-start-min <near-trigger>` + a small `--oom-max-start` reproduces it in seconds instead of re-sweeping from 0. (This came out of diagnosing an HDF5 OOM double-free where the trigger was at a specific deep `start`.)

## How

- Emit `_OOM_MIN_START` next to `_OOM_MAX_START`; both the `oom_call` and `oom_run` sweeps become `range(_OOM_MIN_START, _OOM_MAX_START)`.
- `setupProject` **fails fast** if `oom_start_min >= oom_max_start` — an empty range would print the `[OOM]` labels but inject nothing (same "no silent no-op" guard as the `--oom-foreign` shim self-check).

## Verified

- Emitted range with `--oom-start-min 5 --oom-max-start 10` → `range(_OOM_MIN_START, _OOM_MAX_START)` with `_OOM_MIN_START = 5`.
- Empty-range guard aborts: `--oom-start-min 10 --oom-max-start 10` → `ValueError: --oom-start-min (10) must be < --oom-max-start (10) …`.
- +3 tests; golden unaffected (default 0, and the golden doesn't emit OOM code); full suite green; `ruff check` + `ruff format --check` clean. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)