### PR TITLE
oom_dedup: detector-skip accuracy — GC-bits readers + negref assert face

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -333,7 +333,13 @@ _BT_SKIP = re.compile(
     # ASan trace exposes these frames where Clang inlines them away.
     r"|hook_fmalloc|hook_fcalloc|hook_frealloc|hook_ffree"
     r"|PyMem_Free|PyMem_RawFree|PyObject_Free|PyMem_Realloc|PyMem_RawRealloc|PyObject_Realloc"
-    r"|tracemalloc_(raw_)?(alloc|calloc|realloc|free))$"
+    r"|tracemalloc_(raw_)?(alloc|calloc|realloc|free)"
+    # Inlined GC-bits readers (pycore_gc.h): when a bad/NULL object's ob_gc_bits is read they
+    # show as the innermost frame, masking the real .c caller (e.g. copy_lock_held_untracked =
+    # OOM-0044, a NULL-deref in the empty-dict copy assert under OOM). Analog of the
+    # refcount.h/object.h header skips below. NOT _PyObject_GC_TRACK/_UNTRACK (real sites, e.g.
+    # the OOM-0006 untrack), only the pure readers. Lockstep with catalog ingest.py NATIVE_SKIP.
+    r"|_PyObject_HAS_GC_BITS|_PyObject_GC_IS_TRACKED)$"
 )
 # Inlined refcount/atomic helpers live in these headers and show up as the innermost frame
 # of a "DECREF a freed object" segv -- skip them so the site is the real .c caller (e.g.

--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -73,7 +73,18 @@ GENERIC_FATAL = ("_PyObject_AssertFailed", "_Py_NegativeRefcount")
 # it, and validate_list's every assert is a GC-invariant check, never the defect) -> resolve past it
 # to the producer / oomSEGV. Whole FUNC (all its asserts are detectors); does not collide OOM-0017,
 # which keys gc_decref/gc_get_refs/gc.c:96, not validate_list/gc.c:380.
-GENERIC_ASSERT_FUNCS = ("Py_DECREF_MORTAL", "validate_list")
+#
+# `_Py_NegativeRefcount` (Objects/object.c) is the ASSERT face of the negative-refcount detector: on a
+# Py_DEBUG build an over-decref trips its `object has negative ref count` assert at a LATER decref. Two
+# shapes reach it -- (a) the producer is INLINE, right under the refcount frames (OOM-0019 = a double
+# `Py_XDECREF` inside `_PyPegen_raise_error_known_location`), and (b) the producer already RETURNED and
+# the negref surfaces during unrelated frame/exception teardown (the OOM-0036 stackref family). Marking
+# the FUNC generic makes the negref assert itself carry no site -- but decide() STILL resolves the chain
+# (so (a) folds to its inline producer, e.g. OOM-0019's pegen frame), and only when that resolution
+# fails to hit the catalog is the crash routed to oomSEGV (case (b), producer needs rr). Same detector
+# as the `_Py_NegativeRefcount` FATAL in GENERIC_FATAL; mirrors gen_known_sites.GENERIC_DETECTOR_FUNCS
+# (which already emits no keys for a `_Py_NegativeRefcount` assert) and catalog ingest.GENERIC_ASSERT_FUNCS.
+GENERIC_ASSERT_FUNCS = ("Py_DECREF_MORTAL", "validate_list", "_Py_NegativeRefcount")
 GENERIC_ASSERT_EXPRS = (
     "!_Py_IsStaticImmortal(op)",
     "mp == NULL || Py_IS_TYPE(mp, &PyDict_Type)",
@@ -640,12 +651,20 @@ class Deduper:
         # Faulthandler-only fallback: a SEGV/generic-fatal with no ASan file:line frames and
         # no gdb resolution still carries func names in the faulthandler C stack -- match the
         # innermost catalog-keyed func by name (e.g. PyList_New -> OOM-0004) before giving up.
-        # NOT done for a generic-detector assert (Py_DECREF_MORTAL/!_Py_IsStaticImmortal): its
-        # producer is an over-decref that already returned, so the visible stack is only frame
-        # teardown + innocent-bystander call frames -- matching one by name mis-folds the UAF
-        # into an unrelated bug (e.g. a generic _PyObject_MakeTpCall frame -> OOM-0026). Those
-        # need rr to pin the producer, so leave them needs-resolution.
-        if not matched and not chain and not generic_site and (has_segv or generic_fatal):
+        # NOT done for a generic-detector assert (Py_DECREF_MORTAL/_Py_NegativeRefcount/
+        # !_Py_IsStaticImmortal): its producer is an over-decref that already returned, so the
+        # visible stack is only frame teardown + innocent-bystander call frames -- matching one by
+        # name mis-folds the UAF into an unrelated bug (e.g. a generic _PyObject_MakeTpCall frame ->
+        # OOM-0026). These aborts carry a generic fatal, so gate on ``not generic_assert`` (else the
+        # ``generic_fatal`` arm would let fh_match run). Those need rr to pin the producer, so leave
+        # them needs-resolution.
+        if (
+            not matched
+            and not chain
+            and not generic_site
+            and not generic_assert
+            and (has_segv or generic_fatal)
+        ):
             matched |= fh_match(stdout_text, self.snap)[0]
 
         if matched:
@@ -657,12 +676,15 @@ class Deduper:
             return True, oid
 
         # Nothing matched the catalog.
-        if (has_segv or generic_assert or generic_site) and not chain and not real_asserts:
-            # A pure segv, a generic-detector over-decref assert (Py_DECREF_MORTAL/
-            # !_Py_IsStaticImmortal), or a segv/fatal resolved only to a generic freelist/steal
-            # site (tuple_alloc / _PyTuple_FromStackRefStealOnSuccess) we couldn't tie to a real
-            # caller: it's the over-decref/UAF family (needs rr to fold), NOT a discriminating new
-            # site. Keep it as needs-resolution, never oomNEW -- mirrors ingest's needs_gdb bucket.
+        if generic_assert or ((has_segv or generic_site) and not chain and not real_asserts):
+            # A generic-detector over-decref assert (Py_DECREF_MORTAL/_Py_NegativeRefcount/
+            # !_Py_IsStaticImmortal) whose chain didn't fold, a pure segv, or a segv/fatal resolved
+            # only to a generic freelist/steal site (tuple_alloc / _PyTuple_FromStackRefStealOnSuccess)
+            # we couldn't tie to a real caller: it's the over-decref/UAF family (needs rr to fold),
+            # NOT a discriminating new site. The generic-assert arm fires even when a chain resolved,
+            # because that chain[0] is a bystander teardown frame (e.g. frame_dealloc) -- the inline-
+            # producer negref aborts (OOM-0019) already returned above via a catalog match. Keep it as
+            # needs-resolution, never oomNEW -- mirrors ingest's needs_gdb bucket.
             self.seen["segv:unresolved" if (has_segv or generic_site) else "assert:unresolved"] += 1
             return True, "oomSEGV"  # couldn't resolve a site -> always keep
         prim = candidates[0] if candidates else {}

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -107,6 +107,44 @@ ABORT_VALIDATE_LIST = "\n".join(
         '  Binary file "/build/python", at _PyGC_Collect+0x41 [0x4]',
     ]
 )
+# The negative-refcount DETECTOR assert (`_Py_NegativeRefcount: ... object has negative ref count`)
+# has TWO shapes. DEFERRED: the over-decref'd object is detected during unrelated frame/exception
+# teardown (the OOM-0036 stackref family), so the ASan backtrace is the dealloc-detection cascade and
+# every real frame under the refcount plumbing (PyStackRef_XCLOSE, frame_dealloc, tb_dealloc, ...) is a
+# bystander -- the producer already returned. Must fold to needs-resolution (oomSEGV), never a distinct
+# oomNEW keyed on the useless negref assert expr or a bystander dealloc frame.
+ABORT_NEGREF_DEFERRED = "\n".join(
+    [
+        "./Include/internal/pycore_stackref.h:726: _Py_NegativeRefcount: "
+        "Assertion failed: object has negative ref count",
+        "Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed",
+        "    #8 0x5b61fdfbb838 in _PyObject_AssertFailed Objects/object.c:3278",
+        "    #9 0x5b61fdfbbb22 in _Py_NegativeRefcount Objects/object.c:275",
+        "    #10 0x5b61fdf34272 in Py_DECREF Include/refcount.h:354",
+        "    #11 0x5b61fdf34b93 in PyStackRef_XCLOSE Include/internal/pycore_stackref.h:726",
+        "    #12 0x5b61fdf3ad42 in frame_dealloc Objects/frameobject.c:1949",
+        "    #13 0x5b61fdfba573 in _Py_Dealloc Objects/object.c:3319",
+        "    #14 0x5b61fe33a297 in tb_dealloc Python/traceback.c:246",
+    ]
+)
+# INLINE: the producer over-decref's in place and the very next decref trips the negref assert, so the
+# producer frame sits right under the refcount plumbing (this is OOM-0019 = a double `Py_XDECREF` inside
+# `_PyPegen_raise_error_known_location`). decide() must still resolve past the detectors and FOLD it to
+# the known bug -- NOT swallow it as an unresolved oomSEGV. Here the inline producer is `code_dealloc`
+# (an OOM-0003 catalog site) to reuse the base snapshot.
+ABORT_NEGREF_INLINE = "\n".join(
+    [
+        "./Include/refcount.h:520: _Py_NegativeRefcount: "
+        "Assertion failed: object has negative ref count",
+        "Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed",
+        "    #8 0x5b61fdfbb838 in _PyObject_AssertFailed Objects/object.c:3278",
+        "    #9 0x5b61fdfbbb22 in _Py_NegativeRefcount Objects/object.c:275",
+        "    #10 0x5b61fdf34272 in Py_DECREF Include/refcount.h:354",
+        "    #11 0x5b61fdf34b93 in Py_XDECREF Include/refcount.h:520",
+        "    #12 0x5b61fdf3ad42 in code_dealloc Objects/codeobject.c:2440",
+        "    #13 0x5b61fdfba573 in _PyEval_EvalFrameDefault Python/ceval.c:1000",
+    ]
+)
 
 
 class TestClassify(unittest.TestCase):
@@ -328,6 +366,43 @@ class TestGenericDetectorAssert(unittest.TestCase):
         keep, label = d.decide(ABORT_VALIDATE_LIST, source_path=None)
         self.assertEqual((keep, label), (True, "oomSEGV"))
         self.assertFalse(any("validate_list" in k or "gc.c:380" in k for k in d.seen))
+
+
+class TestNegrefDetectorAssert(unittest.TestCase):
+    """`_Py_NegativeRefcount`'s `object has negative ref count` assert is the negref DETECTOR face
+    of the over-decref family. Its DEFERRED shape (producer already returned; the OOM-0036 stackref
+    family) must fold to needs-resolution (oomSEGV), while its INLINE shape (OOM-0019: producer right
+    under the refcount plumbing) must STILL resolve past the detectors and fold to the known bug."""
+
+    def _deduper(self, keep=5, prune=False):
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(SNAPSHOT)
+        self.addCleanup(os.unlink, path)
+        return oom_dedup.Deduper(path, keep=keep, prune=prune)
+
+    def test_deferred_negref_is_segv_not_new(self):
+        # A full ASan dealloc-detection cascade whose only real frames under the refcount plumbing are
+        # bystanders (frame_dealloc/tb_dealloc) -> the producer returned -> oomSEGV, never oomNEW.
+        d = self._deduper()
+        keep, label = d.decide(ABORT_NEGREF_DEFERRED, source_path=None)
+        self.assertEqual((keep, label), (True, "oomSEGV"))
+        # never keyed on the useless negref assert expr nor a bystander teardown frame.
+        self.assertFalse(any("negative ref count" in k for k in d.seen))
+        self.assertFalse(any("frame_dealloc" in k or "pycore_stackref" in k for k in d.seen))
+
+    def test_deferred_negref_never_pruned(self):
+        d = self._deduper(keep=1, prune=True)
+        for _ in range(3):
+            self.assertEqual(d.decide(ABORT_NEGREF_DEFERRED)[0], True)
+
+    def test_inline_negref_folds_to_known_producer(self):
+        # regression guard for OOM-0019: the negref assert is generic, but its chain resolves to the
+        # inline producer (code_dealloc = an OOM-0003 site) -> must fold there, NOT be swallowed as
+        # an unresolved oomSEGV.
+        d = self._deduper()
+        keep, label = d.decide(ABORT_NEGREF_INLINE, source_path=None)
+        self.assertEqual((keep, label), (True, "OOM-0003"))
 
 
 class TestHardening(unittest.TestCase):


### PR DESCRIPTION
Two in-loop `oom_dedup` detector-skip fixes surfaced while triaging the `oom_cloud`
fleet — both keep known over-decref/UAF noise from re-surfacing as `oomNEW`, and both
are the fusil-side mirror of matching `cpython-oom-findings` catalog changes
(`ingest.py` / `known_sites.tsv`), so they should land together with that catalog update.

## `5c94c8b` — skip inlined GC-bits readers (`_BT_SKIP`)

When a bad/NULL object's `ob_gc_bits` is read, the inlined `_PyObject_HAS_GC_BITS` /
`_PyObject_GC_IS_TRACKED` readers show as the innermost frame and mask the real `.c`
caller (e.g. `copy_lock_held_untracked` = OOM-0044). Skip them so the resolved site is
the real caller — the analog of the existing `refcount.h`/`object.h` header skips. NOT
`_PyObject_GC_TRACK`/`_UNTRACK` (those are real sites, e.g. the OOM-0006 untrack).

## `53298b2` — fold the `_Py_NegativeRefcount` assert face (deferred vs inline)

The `object has negative ref count` debug assert is the assert() analog of the
`_Py_NegativeRefcount` FATAL already in `GENERIC_FATAL`, so add `_Py_NegativeRefcount` to
`GENERIC_ASSERT_FUNCS`. It reaches `decide()` in two shapes and the distinction matters:

- **INLINE producer (OOM-0019** = a double `Py_XDECREF` inside
  `_PyPegen_raise_error_known_location`): the producer frame sits right under the refcount
  plumbing, so the resolved chain STILL folds it to the catalog. We must not swallow these.
- **DEFERRED producer** (the OOM-0036 stackref family): the over-decref'd object is detected
  during unrelated frame/exception teardown, so the backtrace is the dealloc-detection
  cascade and `chain[0]` is a bystander (`frame_dealloc`/`tb_dealloc`) that matches nothing.

So instead of suppressing resolution, gate `fh_match` and the `oomSEGV` routing on
`not generic_assert`: a generic-detector assert that fails to fold to the catalog is routed
to `oomSEGV` even when a (bystander) chain resolved, rather than leaking to `oomNEW` keyed on
the useless negref assert expr / teardown frame. Without this a full negref dealloc-cascade
backtrace was mislabelled `oomNEW`.

## Verification

- Over the `oom_cloud` batch, ingest NEW-site groups drop **5 → 3** with a clean 3-dir diff
  (the negref stackref dirs → needs_gdb) and **OOM-0019 stays 5 vehicles** (regression guard).
- `+3 tests` (`TestNegrefDetectorAssert`: deferred → `oomSEGV`, never pruned, never keys a
  bystander; inline → folds to the known producer). Suite 1058 → 1061.
- `ruff check` + `ruff format --check` clean; full suite green.

Lockstep pair: `cpython-oom-findings` `oom-0044-dictcopy` (`e5fe1a8` GC-bits skip + OOM-0044
rows; `ef88c08` negref `GENERIC_ASSERT_FUNCS` + tracemalloc NONBUG row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
