### PR TITLE
python: add --tsan concurrency data-race fuzzing mode (Phase 1)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -1,0 +1,353 @@
+# `--tsan` mode: concurrency data-race fuzzing under ThreadSanitizer
+
+**Status:** design/plan (not implemented). Sibling of `doc/oom-fuzzing.md` /
+`doc/oom-dedup-plan.md`; this mode is modelled on the OOM subsystem's structure (a
+generator-side harness + parent-side wiring + a pure-Python noise-dedup engine).
+
+## 1. Goal & scope
+
+Drive **C-level data races** in CPython extension modules (and, secondarily, CPython
+core) by generating source that hammers **shared objects from many threads at once**,
+run under a **free-threaded, ThreadSanitizer-instrumented** interpreter, and score a
+`WARNING: ThreadSanitizer: data race` report as a finding.
+
+**Why this is worth building (not just noise):**
+
+- **Free-threading is the gate.** Under the GIL, bytecode is serialized; TSan sees the
+  GIL as one giant happens-before edge and finds essentially nothing at the Python
+  level (only C code that explicitly drops the GIL can race). Under free-threading
+  (`PYTHON_GIL=0`, a `--disable-gil` build) concurrent Python operations become
+  concurrent C memory accesses — shared refcounts, container resizes, type/method
+  caches, module state. **Non-FT TSan is out of scope** (it would be pure noise).
+- **Core is fair game, not just extensions.** `Tools/tsan/suppressions_free_threading.txt`
+  is currently **empty** — CPython expects *zero* known races on the free-threaded build, so
+  any race we surface in core is a real finding, not pre-suppressed noise. Free-threading is
+  still an active research area: cpython#149816 alone catalogs 22 races (in `_random`,
+  `typeobject`, `call.c` kwargs growth, `listobject`, `dictobject`, `_pickle`,
+  `gc_free_threading`, …), several with reproducers — a ready-made corpus to validate the
+  harness against. Extension modules that haven't been made FT-safe are additional fresh
+  ground (and where this project's recent finds live), but the empty core suppressions mean
+  the CPython interpreter itself is squarely in scope. (Reality check: the builtin containers
+  `list`/`dict`/`set` are now protected by per-object critical sections, so the races live in
+  the less-travelled C paths, not the obvious ones — which is exactly why a fuzzer helps.)
+- **It directly targets the bug class we already hit by harder means.** The cereggii
+  finds — `AtomicDict` double-`DECREF` when a colliding key's `__eq__` raises, and
+  `_Py_SetWeakrefAndIncref` corrupting deferred-refcount objects under *concurrent stores
+  of a deferred key* — are textbook data races. They were pinned via rare OOM/GC crashes
+  plus `rr`. TSan surfaces that same class **directly and deterministically as a race
+  warning**, before it corrupts into a crash. That is the core motivation.
+
+**Non-goals:** deadlock detection (TSan does it, but our generated code rarely takes two
+locks); non-FT builds; combining with `--oom-fuzz` (see §5.1); making CPython-core races
+actionable (they are upstream's job and largely suppressed).
+
+## 2. Why the current generator is a weak TSan driver
+
+Today `--threads` (on by default) wraps *every* generated call in a
+`Thread(target=bound_method, args=fresh_args)` appended to `fuzzer_threads_alive`, then
+`_write_concurrency_finalization` starts them all in one loop and joins them in another
+(`write_python_code.py` `_write_thread_call_wrapper` / `_write_concurrency_finalization`).
+So threads **do** overlap, and because `target_func` is a bound method of a **pooled,
+shared** object, multiple threads already touch the same receiver concurrently (concurrent
+`INCREF`/`DECREF` on it and its type). That is a nonzero TSan driver.
+
+But it is tuned for *"does calling this in a thread crash"*, not *"do concurrent ops on one
+object race"*:
+
+| Weakness | Effect on TSan |
+|---|---|
+| One thread per call site, spread across many different objects | Low probability two threads pound the **same** object's **same** internal state — the thing that trips a race |
+| Threaded args are freshly built per thread (`create_simple_argument`) | No **shared mutable argument** races (two threads mutating one list/dict/buffer passed in — a huge FT bug class) |
+| One call per thread | Races usually need the op **repeated** in a loop to manifest the unordered access on a shared line |
+| Threads trickle out of the start loop; `join(timeout=1.0)` abandons slow ones | Weak temporal overlap; an abandoned thread still racing at interpreter shutdown is itself noise |
+| The `set_nomemory` swap is thread-unsafe (the documented `_thread-…-oomNEW` harness artifact in `non_bugs.md`) | `--oom-fuzz` + threads is a *harness* race — must be mutually exclusive with `--tsan` |
+
+## 3. Design overview
+
+Three pieces, each mirroring an existing subsystem:
+
+- **(A) A concurrency-stress emitter** in `WritePythonCode`, gated on `self.options.tsan`,
+  that replaces the per-call one-thread-per-callsite pattern with a **concentrated**
+  shape: a few shared objects, K worker threads, each doing M iterations of a randomized
+  op-mix on the *same* shared object(s), released together by a `threading.Barrier`.
+- **(B) Parent-side wiring** in `Fuzzer.createFuzzerOptions` / `setupProject`: the option
+  group, mutual exclusion with OOM, child-env setup (`TSAN_OPTIONS`, suppressions,
+  `PYTHON_GIL=0`), a target-build preflight, and the TSan detection words on `WatchStdout`.
+- **(C) A race-report dedup/suppression engine** `fusil/python/tsan_dedup.py`, pure-Python
+  and unit-testable in isolation, mirroring `oom_dedup.py` / `hit_suppression.py`.
+
+## 4. Generated harness (the emitter)
+
+### 4.1 Shape
+
+Instead of `fuzzer_threads_alive.append(Thread(...))` per call, the TSan harness emits, at
+the end of `_write_main_fuzzing_logic`:
+
+```python
+# --- TSan concurrency-stress region (emitted only under --tsan) ---
+import threading
+_tsan_shared = [obj_3, obj_7, module_alias]         # S objects drawn from the pool
+_tsan_ops = [                                        # thunks, each a closure over a shared obj
+    lambda: obj_3.append(payload_a),                 # mutators/readers on the SAME objects,
+    lambda: obj_3.pop() if obj_3 else None,          # incl. dunder/attr churn and shared args
+    lambda: obj_7.update(shared_dict),               # shared_dict passed to MULTIPLE threads
+    lambda: len(obj_3),
+    lambda: setattr(obj_7, 'x', obj_3),
+    ...
+]
+_tsan_barrier = threading.Barrier(TSAN_THREADS)
+def _tsan_worker(wid):
+    _tsan_barrier.wait()                             # release all workers hot, together
+    for _ in range(TSAN_ITERS):
+        op = _tsan_ops[(wid + _) % len(_tsan_ops)]   # deterministic per-wid schedule
+        try:
+            op()
+        except Exception:
+            pass                                     # a Python-level exc is not the signal
+_tsan_threads = [threading.Thread(target=_tsan_worker, args=(i,), name=f'tsan{i}')
+                 for i in range(TSAN_THREADS)]
+for t in _tsan_threads: t.start()
+for t in _tsan_threads: t.join()                     # clean join, NO timeout (see §11)
+```
+
+Key properties vs today: **the same objects and the same argument objects are shared by
+multiple workers** (concurrent mutation is the point), **the op is repeated M times** to
+manifest the race, and **the `Barrier` starts workers simultaneously** to maximize overlap.
+
+### 4.2 Reuse of existing machinery
+
+- Shared objects come from the existing object pool that `WritePythonCode` already builds
+  (`obj_N`) plus the module alias; the emitter picks `--tsan-shared-objects` of them.
+- The op thunks are built from the same call/method selection the synchronous path uses
+  (`ArgumentGenerator`, method discovery, `tricky_weird`/`samples` hostile inputs) — a TSan
+  op is just an existing call closed over a *shared* receiver/arg instead of a fresh one.
+- Emission goes through the indentation API (`with self.indented():`) like the rest of the
+  generator; no new output primitive.
+
+### 4.3 Free-threading preflight (in the generated harness)
+
+The harness must fail loudly if it is not actually running free-threaded (otherwise the
+whole run is silent GIL-serialized noise):
+
+```python
+import sys
+if getattr(sys, "_is_gil_enabled", lambda: True)():
+    print("[TSAN] FATAL: GIL is enabled; free-threading required", file=stderr)
+    raise SystemExit(3)
+```
+
+Parent-side we *also* preflight the target build (§5.2), but the in-harness check is the
+authoritative guard and is cheap.
+
+### 4.4 Relationship to `--threads` / `--async`
+
+`--tsan` **replaces** the per-call thread wrapper (they would just dilute the stress region
+and double-run everything). Implementation: when `options.tsan` is set, pass `threads=False`
+to `WritePythonCode` (the async path can stay off too) and emit the stress region instead.
+`--tsan` implies free-threading and is mutually exclusive with `--oom-fuzz`/`--oom-foreign`.
+
+## 5. Parent-side wiring (`fusil/python/__init__.py`)
+
+### 5.1 Options (new "TSan Fuzzing" `OptionGroup`, added like the OOM group)
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--tsan` | off | Enable TSan concurrency-stress mode (implies FT; excludes `--oom-*`) |
+| `--tsan-threads N` | 8 | Worker threads in the stress region |
+| `--tsan-iterations N` | 200 | Op iterations per worker (repetition = race manifestation) |
+| `--tsan-shared-objects N` | 3 | How many pooled objects are shared across workers |
+| `--tsan-suppressions FILE` | auto | TSan suppressions file (defaults to the target's CPython `Tools/tsan/suppressions_free_threading.txt` if discoverable) |
+| `--tsan-halt` | off | `halt_on_error=1` (stop at first race) vs report-and-continue |
+
+`setupProject` validates: `--tsan` + `--oom-fuzz` → hard error (the `set_nomemory` swap is a
+harness race, §2); `--tsan` with a non-FT `--python` → hard error from the preflight (§5.2).
+
+### 5.2 Child environment & build preflight
+
+`TSAN_OPTIONS` reaches the child through the **same** `process.env.set(...)` path that
+`--oom-foreign` uses for `LD_PRELOAD`/`PYTHONMALLOC`:
+
+```python
+tsan_opts = [
+    "halt_on_error=%d" % (1 if options.tsan_halt else 0),
+    "history_size=4",              # deeper race histories; extensions have deep stacks
+    "second_deadlock_stack=1",
+    "exitcode=99",                 # distinct, so WatchProcess can also see it if halting
+]
+if suppressions: tsan_opts.append("suppressions=%s" % suppressions)
+process.env.set("TSAN_OPTIONS", ":".join(tsan_opts))
+process.env.set("PYTHON_GIL", "0")     # env.py already copies PYTHON_GIL to the child
+```
+
+Preflight the target build once at startup (mirrors `probe_shim_effective` for
+`--oom-foreign`): run `python -c "import sys, sysconfig; print(sys._is_gil_enabled(),
+sysconfig.get_config_var('CONFIG_ARGS'))"` and require **both** `_is_gil_enabled()==False`
+(or GIL-disable-able) **and** a `--with-thread-sanitizer` build. If TSan is not compiled in,
+the race instrumentation is absent and the whole run silently finds nothing — fail fast with
+a clear message rather than run a no-op campaign.
+
+### 5.3 Detection (the crucial gap)
+
+Today `WatchStdout.words` has `AddressSanitizer: 1.0` but **no** TSan entry, and TSan
+defaults to *report-and-continue* — so a race today would print to stderr, the process would
+exit 0, and the session would be discarded as "no crash." Add:
+
+```python
+stdout.addRegex(r"WARNING: ThreadSanitizer: data race", 1.0)
+stdout.addRegex(r"ThreadSanitizer: .*(heap-use-after-free|lock-order-inversion)", 1.0)
+```
+
+Because detection is textual, we catch the race **even when `halt_on_error=0`** (the process
+keeps running and exits clean, but the warning is already in the captured stdout and scores).
+`--tsan-halt`/`exitcode=99` is offered for runs that prefer a hard stop (then `WatchProcess`
+sees the exit code too).
+
+## 6. Noise control: `tsan_dedup.py` (race dedup + suppression)
+
+TSan is noisy: the same race fires every run, and many races are known/benign. Mirror the
+OOM subsystem's split — a **pure-Python engine** (`fusil/python/tsan_dedup.py`, no
+python-ptrace import, unit-tested in isolation) that:
+
+- **Parses** a TSan report into a signature: the pair of `(func@file:line)` access sites in
+  the `Write`/`Read`/`Previous` stanzas, plus the mutex/thread-creation context. Canonicalize
+  the two racing locations as an unordered pair so `A vs B` and `B vs A` dedupe together.
+- **Suppresses** three sources, unioned like `hit_suppression.py`:
+  1. CPython's `suppressions_free_threading.txt` (passed to TSan itself via `TSAN_OPTIONS`,
+     but we also filter post-hoc so a suppressed race never scores).
+  2. Per-target project suppressions (a race in the *extension* we accept / have filed).
+  3. **fusil's own harness races** — anything whose both frames are in the generated harness
+     scaffolding (`_tsan_worker`, the barrier, the thread registry) rather than target code.
+- **Dedupes in-loop** against a catalog snapshot, exactly like `--oom-dedup-catalog`: a known
+  race past `--tsan-dedup-keep N` is pruned; a new race self-labels the crash dir (`TSAN-00NN`
+  / `tsanNEW`) via the `application.session_keep_policy` hook `SessionDirectory.checkKeepDirectory`
+  already consults.
+
+This composes with the existing hooks — no new keep/prune plumbing, just a third policy.
+
+## 7. Build & target requirements
+
+- **Interpreter:** CPython built `--disable-gil --with-thread-sanitizer` (TSan and ASan are
+  mutually exclusive — this is a *separate* build from the ASan matrix builds). Point
+  `--python` at it. The build matrix (`~/projects/python_build_matrix`) needs a new
+  `{debug,release}-ft-tsan` cell.
+- **Extensions:** must be compiled with `-fsanitize=thread` to instrument their C. An
+  un-instrumented extension only races visibly through CPython's own (mostly suppressed) core
+  — so the target extension **must** be a TSan build (document this; it is the #1 "why did I
+  get nothing" gotcha, analogous to the `--oom-foreign` static-ASan shadowing note).
+- **numpy default off** under `--tsan` (numpy is not FT-clean → it would flood); the numpy
+  plugin's inject-everywhere behavior should honor a TSan opt-out.
+
+## 8. Scoring / dir labeling / fleet integration
+
+- A matched TSan word scores 1.0 → the session is kept (like any crash word).
+- `tsan_dedup` self-labels the kept dir via `session_rename` parts (module, `TSAN-00NN` /
+  `tsanNEW`) exactly as `oom_dedup` does.
+- `StatsAgent` needs no change (it already records `PYTHON_GIL`); `fleet report` will show
+  TSan-mode instances by their kept-dir taxonomy once the labels exist.
+
+## 9. Phasing
+
+- **Phase 1 (minimal end-to-end): IMPLEMENTED (2026-07-15).** Option group
+  (`--tsan`/`--tsan-threads`/`--tsan-iterations`/`--tsan-shared-objects`/`--tsan-suppressions`)
+  + mutual-exclusion with `--oom-*` + a target-build preflight (free-threaded **and**
+  `--with-thread-sanitizer`, else fail fast) + the stress emitter
+  (`WritePythonCode._write_tsan_stress_region`, which also disables the per-call thread/async
+  wrappers) + the `WARNING: ThreadSanitizer: data race` detection regex + the child env. **See
+  the "Phase 1 as-built" section below** for the environment recipe that made detection
+  actually work (it took several non-obvious fixes). Validated end-to-end against a purpose-built
+  racy `ctypes.memset` module on the `debug-ft-nojit-tsan` build: the race is generated,
+  detected, scored, and the crash dir self-labels
+  `…-exitcode66-warning_threadsanitizer_data_race`. Manual suppressions only (Phase 2 adds the
+  dedup engine). Tests: `tests/python/test_tsan_generation.py` (6, gated so goldens are
+  unchanged).
+- **Phase 2:** `tsan_dedup.py` engine + catalog snapshot + the `session_keep_policy` wiring +
+  unit tests. Turns a noisy stream into deduped, labeled, prunable findings.
+- **Phase 3:** richer op-mix (shared-argument container races, dunder/`__eq__`-raising churn,
+  weakref/GC interplay), barrier/iteration tuning, per-target suppression management, a fleet
+  profile, and folding the operational knobs below into `--tsan` itself (imply numpy-off; an
+  offline `symbolize=1` re-run to resolve frames for triage).
+
+## Phase 1 as-built: the environment recipe (hard-won)
+
+Getting TSan to *actually report* took several non-obvious fixes — each one silently produced
+"runs clean, finds nothing." Recorded here so they aren't rediscovered:
+
+- **Build:** `~/projects/python_build_matrix/builds/debug-ft-nojit-tsan/python` — CPython 3.16
+  `--disable-gil --with-thread-sanitizer` (GIL off by default). A `release-ft-nojit-tsan` cell
+  also exists.
+- **ASLR must be disabled — `setarch -R`.** Modern high-entropy ASLR is incompatible with TSan's
+  shadow layout (`WARNING: ThreadSanitizer: memory layout is incompatible … high-entropy ASLR`),
+  after which TSan detects nothing. `setarch -R` (`ADDR_NO_RANDOMIZE`) fixes it and is a thin
+  exec wrapper (PID preserved, so process monitoring is unaffected). fusil prepends it to the
+  target command under `--tsan`. (`mmap_rnd_bits` can't be lowered without root here, so
+  per-process `setarch` is the portable fix.)
+- **`RLIMIT_AS` must be unlimited.** TSan reserves terabytes of shadow and, if it sees a finite
+  virtual-address cap, *re-execs itself* to raise it — and a finite **hard** cap makes that
+  re-exec's `setrlimit()` fail with `EINVAL (22)`, after which TSan runs degraded and finds
+  nothing. fusil applies a ~4 PiB `RLIMIT_AS` by default (fine for ASan, which fits); under
+  `--tsan` the cap is dropped entirely (`create.py` zeroes `max_memory`, and `setupProject`
+  skips the 4 PiB override so `limitResources` resets `RLIMIT_AS` to unlimited).
+- **`TSAN_OPTIONS=halt_on_error=1:symbolize=0:exitcode=66:history_size=4`.** `symbolize=0`
+  because **at present** the symbolizer hangs the child on the first race — a **regression under
+  investigation** (it did not used to happen, even on debug builds), not an inherent property.
+  Sidestepping it is safe because the `WARNING: ThreadSanitizer: data race` header prints
+  *before* the frames, so textual detection is unaffected; resolve frames offline for triage.
+  Flip back to `symbolize=1` in-loop once the hang is fixed. `halt_on_error=1` + `exitcode=66`
+  stop at the first race with a clean exit.
+- **`PYTHON_GIL=0`** (set explicitly even though the build defaults to it).
+- **`--no-numpy` is required today.** The `fusil_numpy_plugin` (installed in the fuzzer venv)
+  injects `import numpy` into *every* generated script's boilerplate; the TSan target has no
+  numpy, so the child dies with `ModuleNotFoundError` before reaching the stress region. Pass
+  `--no-numpy` (Phase 3: `--tsan` should imply it — numpy isn't FT-clean anyway).
+- **Module discovery vs. the target's stdlib.** The fuzzer imports the target module to
+  enumerate members; do **not** put the whole 3.16t `Lib` on the (3.14) fuzzer's `PYTHONPATH`
+  (it will try to import 3.16's `encodings` against its own `_codecs` and die at startup). Give
+  the fuzzer the test module via a *clean* directory; the target finds it on its own `sys.path`.
+
+**Detection path:** a matched `WARNING: ThreadSanitizer: data race` scores the session 1.0
+(`WatchStdout` regex, added unconditionally — it only fires on a real TSan report); the child
+also exits 66. The kept dir self-labels `…-exitcode66-warning_threadsanitizer_data_race`.
+
+**Validation fixture (throwaway):** a module whose class method / module function both do an
+unsynchronized `ctypes.memset` on a process-global buffer — concurrent calls are a guaranteed
+C-level race TSan reports. Dropping it in the target's `Lib` and pointing
+`fusil --tsan --no-numpy --modules <mod>` at the `debug-ft-nojit-tsan` build yields
+`Total: 1 success`. (A real campaign points at CPython core / an FT-unsafe extension instead.)
+
+## 10. Testing
+
+- **Golden emitter tests:** the stress region is deterministic given a seed → add a golden
+  like the existing generator goldens (no golden regen for non-`--tsan` output — the emitter
+  is gated, so default output is unchanged).
+- **Pure-engine tests** for `tsan_dedup.py` (parse a canned TSan report → signature; unordered
+  pair canonicalization; suppression union; catalog dedupe) — no runtime stack, like
+  `test_oom_dedup.py`.
+- **Smoke target:** a tiny hand-written FT-unsafe C extension (unguarded shared counter) as a
+  deterministic "TSan must fire" fixture, kept out of CI if no TSan build is available there.
+
+## 11. Open questions & risks
+
+- **Throughput.** TSan is slower and more memory-hungry than ASan; sessions will run fewer
+  ops/sec. Mitigate with smaller `--tsan-iterations` and by concentrating on a targeted module
+  set rather than discover-all.
+- **Nondeterminism.** A race may not fire every run even with repetition; this is a
+  *statistical* fuzzer — lean on many sessions (fleet) rather than expecting per-session hits.
+  (Contrast with OOM, which is deterministic on a given binary.)
+- **Clean shutdown.** Drop the `join(timeout=1.0)` abandonment in the stress region — a thread
+  still racing while the interpreter tears down produces shutdown-phase races that are noise.
+  Workers are bounded by `--tsan-iterations`, so a plain `join()` terminates.
+- **Suppression maintenance.** The CPython suppressions file drifts per version; pin it to the
+  target build's copy (discover via `sysconfig`), and keep fusil-harness suppressions minimal
+  by construction (the scaffolding should never itself race).
+- **Attribution.** Distinguishing target-extension races from CPython-core races (mostly
+  suppressed) from fusil-harness races is exactly what `tsan_dedup`'s three suppression sources
+  are for; getting the harness-frame filter right is the main correctness risk.
+
+## 12. Summary
+
+`--tsan` reuses the OOM subsystem's proven skeleton — a gated generator harness, parent-side
+env/detection wiring, and a pure-Python noise-dedup engine — but points it at a different
+failure class (data races) on a different build (FT + TSan). The generator change is the
+substance: swap the diluted one-thread-per-call pattern for a concentrated, repeated,
+barrier-released stress region over **shared** objects and arguments. The payoff is a direct
+lens on the FT-unsafe-extension bug class this project already finds the hard way.

--- a/fusil/process/create.py
+++ b/fusil/process/create.py
@@ -50,13 +50,19 @@ class CreateProcess(ProjectAgent):
         self.cmdline = CommandLine(self, arguments)
         self.timeout = timeout
         self.max_memory = config.process_max_memory
-        # ASan targets reserve a huge virtual address space; applying RLIMIT_AS would
-        # kill them on startup (this is why the memory cap was historically disabled
-        # wholesale). Drop the cap for ASan builds (auto-detected) or when the user
-        # passes --no-memory-limit; the external cgroup cap (e.g. the fleet's systemd
-        # MemoryMax) is the real limit in that setup.
+        # ASan/TSan targets reserve a huge virtual address space (TSan mmaps terabytes of
+        # shadow memory); applying RLIMIT_AS would kill them on startup (this is why the
+        # memory cap was historically disabled wholesale). Drop the cap for ASan builds
+        # (auto-detected), for --tsan (whose command is `setarch -R <python> ...`, so the
+        # program isn't arguments[0] to auto-detect), or when the user passes
+        # --no-memory-limit; the external cgroup cap (e.g. the fleet's systemd MemoryMax)
+        # is the real limit in that setup.
         program = arguments[0] if arguments else None
-        if getattr(options, "no_memory_limit", False) or target_is_asan(program):
+        if (
+            getattr(options, "no_memory_limit", False)
+            or getattr(options, "tsan", False)
+            or target_is_asan(program)
+        ):
             self.max_memory = 0
         self.max_user_process = config.process_max_user_process
         self.core_dump = config.process_core_dump

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -397,11 +397,52 @@ class Fuzzer(Application):
             default=False,
         )
 
+        tsan_options = OptionGroup(parser, "TSan Fuzzing")
+        tsan_options.add_option(
+            "--tsan",
+            help="Enable ThreadSanitizer concurrency-stress mode: generate code that hammers "
+            "SHARED objects from many threads at once to surface C-level data races. Requires "
+            "a free-threaded, --with-thread-sanitizer target interpreter (see --python) run "
+            "under disabled ASLR (fusil wraps it in `setarch -R`). Mutually exclusive with "
+            "--oom-fuzz/--oom-foreign. Default: False",
+            action="store_true",
+            default=False,
+        )
+        tsan_options.add_option(
+            "--tsan-threads",
+            help="Worker threads per shared object in the stress region (>=2 so each shared "
+            "object is hit concurrently). Default: 4",
+            type="int",
+            default=4,
+        )
+        tsan_options.add_option(
+            "--tsan-iterations",
+            help="Op iterations each worker runs over its shared object (repetition = race "
+            "manifestation). Default: 200",
+            type="int",
+            default=200,
+        )
+        tsan_options.add_option(
+            "--tsan-shared-objects",
+            help="How many module objects are instantiated and shared across workers. Default: 3",
+            type="int",
+            default=3,
+        )
+        tsan_options.add_option(
+            "--tsan-suppressions",
+            help="Path to a ThreadSanitizer suppressions file (passed to the target via "
+            "TSAN_OPTIONS=suppressions=...). Default: none (CPython's "
+            "suppressions_free_threading.txt is currently empty, so core races are in scope).",
+            type="str",
+            default=None,
+        )
+
         options = (
             input_options,
             running_options,
             fuzzing_options,
             oom_options,
+            tsan_options,
         )
         for option in options:
             parser.add_option_group(option)
@@ -433,6 +474,16 @@ class Fuzzer(Application):
                 % (self.options.oom_start_min, self.options.oom_max_start)
             )
 
+        # --tsan is a different failure class (data races) on a different build (free-threaded +
+        # ThreadSanitizer) and cannot share a run with OOM injection: the _testcapi.set_nomemory
+        # allocator swap is itself thread-unsafe (the documented _thread-*-oomNEW harness race), so
+        # combining them just manufactures harness races. Fail fast.
+        if self.options.tsan and (self.options.oom_fuzz or self.options.oom_foreign):
+            raise ValueError(
+                "--tsan is mutually exclusive with --oom-fuzz/--oom-foreign (the set_nomemory "
+                "allocator swap is not thread-safe; combining them races the harness itself)"
+            )
+
         project = self.project
         if not self.project:
             project = self.project = Project(self)
@@ -451,13 +502,28 @@ class Fuzzer(Application):
         from fusil.python.stats_agent import StatsAgent
 
         StatsAgent(project, self.source)
+        # Under --tsan the target MUST run with ASLR disabled: ThreadSanitizer's shadow-memory
+        # layout is incompatible with modern high-entropy ASLR ("memory layout is incompatible"
+        # -> it silently detects nothing). `setarch -R` (ADDR_NO_RANDOMIZE) is a thin exec wrapper
+        # -- it sets the personality then execs the target, so the PID (and thus process
+        # monitoring) is unaffected. Keeping the source file last preserves on_python_source's
+        # `arguments[-1] = filename` substitution.
+        target_cmd = [self.options.python, "-u", "<source.py>"]
+        if self.options.tsan:
+            target_cmd = ["setarch", "-R"] + target_cmd
         process = PythonProcess(
             project,
             self.options,
-            [self.options.python, "-u", "<source.py>"],
+            target_cmd,
             timeout=self.options.timeout,
         )
-        process.max_memory = 4000 * 1024 * 1024 * 1024 * 1024
+        # ThreadSanitizer reserves more virtual address space than any finite RLIMIT_AS allows and
+        # re-execs itself to raise the cap; a finite hard cap makes that re-exec fail (setrlimit
+        # EINVAL) and TSan then runs DEGRADED, detecting nothing. So leave the cap OFF under --tsan
+        # -- CreateProcess already zeroed max_memory for it, and limitResources resets RLIMIT_AS to
+        # unlimited. (This ~4 PiB cap is fine for ASan, which fits within it.)
+        if not self.options.tsan:
+            process.max_memory = 4000 * 1024 * 1024 * 1024 * 1024
 
         # Foreign-allocator OOM: preload the malloc-failure shim so the generated harness can
         # inject failures at the C malloc() layer (reaching foreign C libraries). Fail fast if
@@ -491,6 +557,52 @@ class Fuzzer(Application):
             if self.options.oom_foreign_pythonmalloc:
                 process.env.set("PYTHONMALLOC", "malloc")
                 self.error("Foreign-OOM: PYTHONMALLOC=malloc (CPython allocs route through shim)")
+
+        # ThreadSanitizer mode: verify the target build and set the child environment. Fail fast if
+        # the interpreter is not free-threaded + TSan-instrumented -- otherwise the whole run
+        # silently finds nothing (mirrors the --oom-foreign shim-shadow self-check).
+        if self.options.tsan:
+            import os
+            import subprocess
+
+            probe = (
+                "import sys, sysconfig; ca = sysconfig.get_config_var('CONFIG_ARGS') or ''; "
+                "print(int(not sys._is_gil_enabled()), int('thread-sanitizer' in ca))"
+            )
+            try:
+                out = subprocess.run(
+                    [self.options.python, "-c", probe],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    env={**os.environ, "PYTHON_GIL": "0"},
+                ).stdout.split()
+            except (OSError, subprocess.SubprocessError, ValueError):
+                out = []
+            free_threaded = out[:1] == ["1"]
+            thread_sanitizer = out[1:2] == ["1"]
+            if not (free_threaded and thread_sanitizer):
+                raise ValueError(
+                    "--tsan requires a free-threaded, --with-thread-sanitizer interpreter as "
+                    "--python (probed free_threaded=%s thread_sanitizer=%s for %s). Build CPython "
+                    "with `--disable-gil --with-thread-sanitizer` and point --python at it."
+                    % (free_threaded, thread_sanitizer, self.options.python)
+                )
+            # symbolize=0: at present the symbolizer hangs the child on the first race (a
+            # regression under investigation -- this did not used to happen, even on debug builds).
+            # Sidestepping it is safe because the `WARNING: ThreadSanitizer: data race` line prints
+            # BEFORE the frames, so textual detection is unaffected -- resolve frames offline for
+            # triage. Revisit (symbolize=1 in-loop) once the hang is fixed. halt_on_error=1/
+            # exitcode=66: stop at the first race with a clean exit.
+            tsan_opts = ["halt_on_error=1", "symbolize=0", "exitcode=66", "history_size=4"]
+            if self.options.tsan_suppressions:
+                tsan_opts.append("suppressions=%s" % self.options.tsan_suppressions)
+            process.env.set("TSAN_OPTIONS", ":".join(tsan_opts))
+            process.env.set("PYTHON_GIL", "0")
+            self.error(
+                "TSan: target verified free-threaded + ThreadSanitizer; ASLR disabled via "
+                "`setarch -R`; TSAN_OPTIONS=%s" % ":".join(tsan_opts)
+            )
 
         options = {"exitcode_score": self.options.exitcode_score}
         if not self.options.record_timeouts:
@@ -549,6 +661,11 @@ class Fuzzer(Application):
         stdout.addRegex("^XXX undetected error", 1.0)
         stdout.addRegex("Fatal Python error", 1.0)
         # Match "Cannot allocate memory"?
+
+        # ThreadSanitizer data-race report (--tsan). The `WARNING:` header is printed before the
+        # (possibly unsymbolized) frames, so this scores the session even with symbolize=0. Added
+        # unconditionally: it only matches when a TSan-instrumented target actually reports a race.
+        stdout.addRegex("WARNING: ThreadSanitizer: data race", 1.0)
 
         # PyPy messages
         stdout.addRegex("Fatal RPython error", 1.0)

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -151,8 +151,11 @@ class PythonSource(ProjectAgent):
             self.filename,
             self.module,
             self.module_name,
-            threads=not self.options.no_threads,
-            _async=not self.options.no_async,
+            # --tsan replaces the per-call one-thread-per-callsite wrappers with a concentrated
+            # concurrency-stress region (WritePythonCode._write_tsan_stress_region), so disable
+            # them here -- otherwise they would dilute the stress and double-run every call.
+            threads=(not self.options.no_threads) and not self.options.tsan,
+            _async=(not self.options.no_async) and not self.options.tsan,
             plugin_manager=self.plugin_manager,
         )
 

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -622,6 +622,13 @@ class WritePythonCode(WriteCode):
         """Writes the core fuzzing loops for functions, classes, and objects."""
         self._write_fuzzing_logic_preamble()
 
+        # TSan mode: skip the single-threaded function/class/object sweeps and emit only the
+        # concurrency-stress region -- it instantiates its own shared objects and hammers them
+        # from many threads, which is the whole point (and keeps the instrumented script small).
+        if self.options.tsan:
+            self._write_tsan_stress_region()
+            return
+
         self._write_function_fuzzing_loop()
         self.emptyLine()
 
@@ -662,6 +669,103 @@ class WritePythonCode(WriteCode):
             """
             ),
         )
+        self.emptyLine()
+
+    def _write_tsan_stress_region(self) -> None:
+        """Emit the --tsan concurrency-stress region.
+
+        Instantiates a few SHARED objects and hammers each from multiple worker threads
+        (barrier-released so they start hot, each repeating an op-mix `--tsan-iterations` times),
+        so concurrent C-level access to one object's state -- and to shared mutable arguments --
+        surfaces data races under ThreadSanitizer. Unlike the per-call thread wrapper (disabled
+        under --tsan), the concurrency here is CONCENTRATED on shared state, which is what trips
+        a race. The worker is type-agnostic (introspects `dir(obj)` at runtime) so one emitted
+        body drives any shared object.
+        """
+        from random import sample
+
+        workers_per_obj = max(2, self.options.tsan_threads)
+        iters = max(1, self.options.tsan_iterations)
+        n_shared = max(1, self.options.tsan_shared_objects)
+
+        classes = self.module_classes or []
+        shared_classes = sample(classes, min(n_shared, len(classes))) if classes else []
+        funcs = list(self.module_functions or [])[:40]
+
+        self.emptyLine()
+        self.write(0, "# --- TSan concurrency-stress region (--tsan) ---")
+        self.write(0, "import threading as _tsan_threading")
+        self.write_print_to_stderr(0, '"[TSAN] entering concurrency-stress region"')
+        # Free-threading is mandatory: without it the whole region is GIL-serialised noise.
+        self.write(0, 'if getattr(sys, "_is_gil_enabled", lambda: True)():')
+        with self.indented():
+            self.write_print_to_stderr(
+                0, '"[TSAN] FATAL: GIL enabled; need PYTHON_GIL=0 + a --disable-gil build"'
+            )
+            self.write(0, "raise SystemExit(3)")
+        # Mutable containers shared BY REFERENCE across every worker (shared-argument races).
+        self.write(0, '_tsan_shared_args = [[1, 2, 3], {"k": 1}, {1, 2, 3}, bytearray(b"fusil")]')
+        self.write(0, "_tsan_funcs = %r" % (funcs,))
+        # Build the shared objects: instantiate a few module classes (guarded), plus the module.
+        self.write(0, "_tsan_shared = []")
+        for class_name in shared_classes:
+            self.write(0, "try:")
+            with self.indented():
+                self.write(0, "_tsan_shared.append(getattr(fuzz_target_module, %r)())" % class_name)
+            self.write(0, "except Exception:")
+            with self.indented():
+                self.write(0, "pass")
+        self.write(0, "_tsan_shared.append(fuzz_target_module)")
+        self.write(0, "if not _tsan_shared:")
+        with self.indented():
+            self.write(0, "_tsan_shared = [fuzz_target_module]")
+        self.write(0, "_WORKERS_PER_OBJ = %d" % workers_per_obj)
+        self.write(0, "_ITERS = %d" % iters)
+        self.write(0, "_tsan_total = len(_tsan_shared) * _WORKERS_PER_OBJ")
+        self.write(0, "_tsan_barrier = _tsan_threading.Barrier(_tsan_total)")
+        self.write_block(
+            0,
+            """
+            def _tsan_worker(_idx, _wid):
+                _obj = _tsan_shared[_idx]
+                _names = [n for n in dir(_obj) if not n.startswith("_")]
+                _tsan_barrier.wait()
+                for _i in range(_ITERS):
+                    for _op in (repr, hash, list, len, bool, iter, str):
+                        try:
+                            _op(_obj)
+                        except Exception:
+                            pass
+                    if _names:
+                        try:
+                            _m = getattr(_obj, _names[(_wid + _i) % len(_names)])
+                            if callable(_m):
+                                _m(*_tsan_shared_args[: (_i % 3)])
+                        except Exception:
+                            pass
+                    if _tsan_funcs:
+                        try:
+                            getattr(fuzz_target_module,
+                                    _tsan_funcs[(_wid + _i) % len(_tsan_funcs)])(_obj)
+                        except Exception:
+                            pass
+            """,
+        )
+        self.write_block(
+            0,
+            """
+            _tsan_threads = []
+            for _idx in range(len(_tsan_shared)):
+                for _wid in range(_WORKERS_PER_OBJ):
+                    _tsan_threads.append(_tsan_threading.Thread(
+                        target=_tsan_worker, args=(_idx, _wid), name="tsan_%d_%d" % (_idx, _wid)))
+            for _t in _tsan_threads:
+                _t.start()
+            for _t in _tsan_threads:
+                _t.join()
+            """,
+        )
+        self.write_print_to_stderr(0, '"[TSAN] concurrency-stress region complete"')
         self.emptyLine()
 
     def _write_function_fuzzing_loop(self) -> None:

--- a/tests/python/test_golden_output.py
+++ b/tests/python/test_golden_output.py
@@ -63,6 +63,7 @@ class _Options:
     oom_window = 1
     oom_foreign = False
     oom_foreign_pythonmalloc = False
+    tsan = False
 
 
 class _Parent:

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -45,6 +45,8 @@ def _make_options(oom_fuzz, oom_verbose=False):
     o.gc_aggressive = False
     o.oom_foreign = False
     o.oom_foreign_pythonmalloc = False
+    # TSan mode OFF (explicit: a bare MagicMock attr would be truthy and divert generation).
+    o.tsan = False
     o.test_private = False
     o.no_numpy = True
     o.no_tstrings = True

--- a/tests/python/test_python_source_more.py
+++ b/tests/python/test_python_source_more.py
@@ -34,6 +34,7 @@ _DEFAULT_OPTIONS = dict(
     verbose=False,
     no_threads=False,
     no_async=False,
+    tsan=False,
     filenames="",
 )
 

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -1,0 +1,124 @@
+"""Unit tests for the --tsan concurrency-stress code generation (WritePythonCode).
+
+Pure generation tests (no target execution): build an options stand-in with tsan on, generate
+a script, and assert the emitted stress region is present, valid, and parameterised -- and that
+the single-threaded function/class/object sweeps are replaced by it. Mirrors test_oom_fuzz.
+"""
+
+import ast
+import os
+import tempfile
+import unittest
+from types import ModuleType
+from unittest.mock import MagicMock
+
+from fusil.python.write_python_code import WritePythonCode
+
+
+def _tsan_module():
+    """A tiny module with a class and a function so the generator has objects to share."""
+    mod = ModuleType("tsanmod")
+
+    class Widget:
+        def op(self, *a):
+            return a
+
+    def helper(*a):
+        return a
+
+    mod.Widget = Widget
+    mod.helper = helper
+    return mod
+
+
+def _make_tsan_options(threads=4, iterations=200, shared_objects=3):
+    o = MagicMock()
+    o.tsan = True
+    o.tsan_threads = threads
+    o.tsan_iterations = iterations
+    o.tsan_shared_objects = shared_objects
+    # OOM off (mutually exclusive); real values so any range()/comparison is well-defined.
+    o.oom_fuzz = False
+    o.oom_foreign = False
+    o.oom_seq = False
+    # General generation knobs the header/definitions/argument-generator paths read.
+    o.fuzz_exceptions = False
+    o.gc_aggressive = False
+    o.test_private = False
+    o.no_numpy = True
+    o.no_tstrings = True
+    o.external_references = True
+    o.functions_number = 5
+    o.classes_number = 0
+    o.objects_number = 0
+    o.methods_number = 2
+    return o
+
+
+def _generate_tsan(**opt_overrides):
+    parent = MagicMock()
+    parent.options = _make_tsan_options(**opt_overrides)
+    parent.filenames = ["/bin/sh"]
+    fd, path = tempfile.mkstemp(suffix="_tsan_test.py")
+    os.close(fd)
+    try:
+        writer = WritePythonCode(
+            parent,
+            path,
+            _tsan_module(),
+            "tsanmod",
+            threads=False,
+            _async=False,
+            plugin_manager=None,
+        )
+        writer.generate_fuzzing_script()
+        with open(path) as fp:
+            return fp.read()
+    finally:
+        os.unlink(path)
+
+
+class TestTSanGeneration(unittest.TestCase):
+    def test_emitted_script_is_valid_python(self):
+        ast.parse(_generate_tsan())
+
+    def test_stress_region_present(self):
+        src = _generate_tsan()
+        self.assertIn("TSan concurrency-stress region", src)
+        self.assertIn("_tsan_threading.Barrier", src)
+        self.assertIn("def _tsan_worker(", src)
+        # workers share objects and start together, then join (clean, no timeout).
+        self.assertIn("_tsan_barrier.wait()", src)
+        self.assertIn("_t.start()", src)
+        self.assertIn("_t.join()", src)
+        self.assertNotIn("join(timeout", src)
+
+    def test_free_threading_preflight_emitted(self):
+        # The harness must refuse to run GIL-enabled (else it is serialised noise).
+        src = _generate_tsan()
+        self.assertIn("_is_gil_enabled", src)
+        self.assertIn("raise SystemExit(3)", src)
+
+    def test_shares_objects_and_module_functions(self):
+        src = _generate_tsan()
+        # a module class is instantiated into the shared pool, plus the module itself.
+        self.assertIn("_tsan_shared.append(getattr(fuzz_target_module, 'Widget')())", src)
+        self.assertIn("_tsan_shared.append(fuzz_target_module)", src)
+        # module functions are called concurrently with the shared object as an argument.
+        self.assertIn("'helper'", src)
+        self.assertIn("_tsan_shared_args", src)
+
+    def test_knobs_are_parameterised(self):
+        src = _generate_tsan(threads=7, iterations=42)
+        self.assertIn("_WORKERS_PER_OBJ = 7", src)
+        self.assertIn("_ITERS = 42", src)
+
+    def test_replaces_single_threaded_sweeps(self):
+        # Under --tsan the normal function-fuzzing sweep is skipped in favour of the stress
+        # region, so its banner must be absent.
+        src = _generate_tsan()
+        self.assertNotIn("functions in tsanmod", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 1 of a ThreadSanitizer data-race fuzzing mode. Generate code that hammers
**shared** objects from many threads at once, run it under a free-threaded,
`--with-thread-sanitizer` interpreter, and score a `WARNING: ThreadSanitizer: data race`
as a finding. Detection + generation + env only; dedup/catalog is Phase 2. Full design +
as-built notes in **`doc/tsan-mode-plan.md`**.

## What it does

`fusil-python-threaded --tsan --no-numpy --python <ft+tsan build> --modules <m>` emits a
**concurrency-stress region** (`WritePythonCode._write_tsan_stress_region`) in place of the
single-threaded sweeps: a few instantiated module objects (plus the module) shared across
`--tsan-threads` workers each, each worker repeating a type-agnostic op-mix
`--tsan-iterations` times over the shared object and shared mutable arguments,
barrier-released and cleanly joined. The per-call thread/async wrappers are disabled under
`--tsan` so concurrency concentrates on shared state (what actually trips a race). Options:
`--tsan`, `--tsan-threads/-iterations/-shared-objects/-suppressions`. Mutually exclusive with
`--oom-*`; a preflight fails fast if the target isn't free-threaded **and** TSan-instrumented.

## The environment recipe (the non-obvious part)

Each of these silently produced *"runs clean, finds nothing"*:

- **`setarch -R`** — modern high-entropy ASLR is incompatible with TSan's shadow layout;
  fusil wraps the target command (thin exec wrapper, PID preserved).
- **Unlimited `RLIMIT_AS`** — TSan re-execs to raise a finite cap and a finite *hard* cap
  makes that `setrlimit` fail (`EINVAL`), degrading TSan silently. The ~4 PiB default cap is
  dropped under `--tsan` (`create.py` + `setupProject`).
- **`TSAN_OPTIONS=halt_on_error=1:symbolize=0:exitcode=66:history_size=4` + `PYTHON_GIL=0`.**
  `symbolize=0` sidesteps a *current* symbolizer hang (regression, under investigation); the
  `WARNING:` header prints before frames so textual detection is unaffected.
- **`--no-numpy`** — the numpy plugin injects `import numpy`, which the TSan target lacks
  (`--tsan` should imply numpy-off in a later phase).

## Validation

End-to-end on `builds/debug-ft-nojit-tsan` against a throwaway racy `ctypes.memset` module:
`Total: 1 success`, dir self-labeled `…-exitcode66-warning_threadsanitizer_data_race`. The
empty `suppressions_free_threading.txt` means CPython core is in scope, not just extensions;
cpython#149816 (22 catalogued races) is a validation corpus for later.

## Tests

`tests/python/test_tsan_generation.py` (6 tests, gated → goldens unchanged). Three existing
option fixtures gained `tsan=False` (the `MagicMock` oom fixture needed it explicitly, else a
truthy auto-attr diverts generation). Full suite 1064 OK; `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
