### PR TITLE
python: --tsan symbolize in-loop (clear DEBUGINFOD_URLS)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -287,13 +287,19 @@ Getting TSan to *actually report* took several non-obvious fixes — each one si
   nothing. fusil applies a ~4 PiB `RLIMIT_AS` by default (fine for ASan, which fits); under
   `--tsan` the cap is dropped entirely (`create.py` zeroes `max_memory`, and `setupProject`
   skips the 4 PiB override so `limitResources` resets `RLIMIT_AS` to unlimited).
-- **`TSAN_OPTIONS=halt_on_error=1:symbolize=0:exitcode=66:history_size=4`.** `symbolize=0`
-  because **at present** the symbolizer hangs the child on the first race — a **regression under
-  investigation** (it did not used to happen, even on debug builds), not an inherent property.
-  Sidestepping it is safe because the `WARNING: ThreadSanitizer: data race` header prints
-  *before* the frames, so textual detection is unaffected; resolve frames offline for triage.
-  Flip back to `symbolize=1` in-loop once the hang is fixed. `halt_on_error=1` + `exitcode=66`
-  stop at the first race with a clean exit.
+- **`TSAN_OPTIONS=halt_on_error=1:symbolize=1:exitcode=66:history_size=4` + `DEBUGINFOD_URLS=`
+  (cleared in the child).** The earlier "symbolizer hang" was **diagnosed, not a TSan/build
+  fault**: `llvm-symbolizer` honours `DEBUGINFOD_URLS`, which Ubuntu sets to
+  `https://debuginfod.ubuntu.com` in every login shell (`/etc/profile.d/debuginfod.sh`), and
+  that endpoint is currently blackholed (TCP connect gets no SYN-ACK/RST → libcurl spins in a
+  ~forever `poll()` retry). Clearing `DEBUGINFOD_URLS` in the child makes symbolization return in
+  ~0.3s with full frames from the target's own (complete) local debug info — so we **symbolize
+  in-loop**, and the racing site lands in the crash dir for triage/dedup. (`DEBUGINFOD_TIMEOUT=1`
+  is a gentler alternative but pays ~1s per module; the empty form is better for crash sessions.
+  gdb was immune because Ubuntu's gdb defaults debuginfod off in batch mode.) fusil's child env
+  is minimal and doesn't copy `DEBUGINFOD_URLS`, but it's set empty explicitly so symbolization
+  stays fast regardless of the parent env. `halt_on_error=1` + `exitcode=66` stop at the first
+  race with a clean exit.
 - **`PYTHON_GIL=0`** (set explicitly even though the build defaults to it).
 - **`--no-numpy` is required today.** The `fusil_numpy_plugin` (installed in the fuzzer venv)
   injects `import numpy` into *every* generated script's boilerplate; the TSan target has no

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -588,17 +588,22 @@ class Fuzzer(Application):
                     "with `--disable-gil --with-thread-sanitizer` and point --python at it."
                     % (free_threaded, thread_sanitizer, self.options.python)
                 )
-            # symbolize=0: at present the symbolizer hangs the child on the first race (a
-            # regression under investigation -- this did not used to happen, even on debug builds).
-            # Sidestepping it is safe because the `WARNING: ThreadSanitizer: data race` line prints
-            # BEFORE the frames, so textual detection is unaffected -- resolve frames offline for
-            # triage. Revisit (symbolize=1 in-loop) once the hang is fixed. halt_on_error=1/
-            # exitcode=66: stop at the first race with a clean exit.
-            tsan_opts = ["halt_on_error=1", "symbolize=0", "exitcode=66", "history_size=4"]
+            # symbolize=1: the "symbolizer hang" was NOT a TSan/build fault -- llvm-symbolizer
+            # honours DEBUGINFOD_URLS (Ubuntu sets it to debuginfod.ubuntu.com in every login
+            # shell) and blocks ~forever on that currently-blackholed endpoint. With it cleared in
+            # the child (below), symbolization returns in ~0.3s with full file:line frames -- worth
+            # having in-loop, since the racing site then lands in the crash dir for triage/dedup.
+            # halt_on_error=1/exitcode=66: stop at the first race with a clean exit.
+            tsan_opts = ["halt_on_error=1", "symbolize=1", "exitcode=66", "history_size=4"]
             if self.options.tsan_suppressions:
                 tsan_opts.append("suppressions=%s" % self.options.tsan_suppressions)
             process.env.set("TSAN_OPTIONS", ":".join(tsan_opts))
             process.env.set("PYTHON_GIL", "0")
+            # Clear DEBUGINFOD_URLS so llvm-symbolizer resolves frames from the target's own (full)
+            # debug info instead of blocking on the unreachable Ubuntu debuginfod server. fusil's
+            # child env is minimal and does not copy DEBUGINFOD_URLS, but set it empty explicitly so
+            # symbolization stays fast regardless of how the parent env is configured.
+            process.env.set("DEBUGINFOD_URLS", "")
             self.error(
                 "TSan: target verified free-threaded + ThreadSanitizer; ASLR disabled via "
                 "`setarch -R`; TSAN_OPTIONS=%s" % ":".join(tsan_opts)


### PR DESCRIPTION
Follow-up to #199. Phase 1 used `symbolize=0` to dodge a "symbolizer hang". **Root cause
diagnosed** (thanks to the maintainer's investigation): `llvm-symbolizer` honours
`DEBUGINFOD_URLS`, which Ubuntu sets to `https://debuginfod.ubuntu.com` in every login shell
(`/etc/profile.d/debuginfod.sh`), and that endpoint is **currently blackholed** — the TCP
connect gets no SYN-ACK/RST, so libcurl inside the symbolizer spins in a ~forever `poll()`
retry. Never a TSan/build fault.

**Fix:** clear `DEBUGINFOD_URLS` in the child and flip `TSAN_OPTIONS` to `symbolize=1`.
Symbolization then returns in ~0.3s from the target's own local debug info, so the racing
site now lands **in the crash dir** — which is exactly what Phase 2 dedup needs. (fusil's
child env is minimal and doesn't copy `DEBUGINFOD_URLS`, but it's set empty explicitly so
symbolization stays fast regardless of the parent env. gdb was immune because Ubuntu's gdb
defaults debuginfod off in batch mode.)

**Verified** on `builds/debug-ft-nojit-tsan` with `DEBUGINFOD_URLS` set in the parent (as on
a real Ubuntu login): no hang, `SUMMARY: ThreadSanitizer: data race … in memset`, whole
3-session run ~3s. Doc (`doc/tsan-mode-plan.md`) updated with the diagnosis + fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)