### PR TITLE
python: --tsan Phase 3 — richer op-mix + imply --no-numpy

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -263,10 +263,14 @@ This composes with the existing hooks — no new keep/prune plumbing, just a thi
 - **Phase 2: IMPLEMENTED (2026-07-15).** `fusil/python/tsan_dedup.py` (pure engine) + the sibling
   `cpython-tsan-findings` catalog repo + the `session_keep_policy` wiring + unit tests. See
   "Phase 2 as-built" below. Turns a noisy stream into deduped, labeled, prunable findings.
-- **Phase 3:** richer op-mix (shared-argument container races, dunder/`__eq__`-raising churn,
-  weakref/GC interplay), barrier/iteration tuning, per-target suppression management, a fleet
-  profile, and folding the operational knobs below into `--tsan` itself (imply numpy-off; an
-  offline `symbolize=1` re-run to resolve frames for triage).
+- **Phase 3: op-mix enrichment IMPLEMENTED (2026-07-15).** The worker now also exercises the
+  FT-race-rich classes: concurrent `gc.collect()`, attribute-dict churn (`setattr`/`getattr`/
+  `delattr` on one shared instance — the managed-dict race class), `weakref.ref` creation, and
+  shared-container mutation (every sibling worker hammers one `list`/`dict`/`set`/`bytearray`).
+  And **`--tsan` now implies `--no-numpy`** (the numpy plugin injected `import numpy` the TSan
+  target lacks). See "Phase 3 as-built" below. **Still open (future):** per-target suppression
+  management, barrier/iteration auto-tuning, a fleet profile, and pointing it at real CPython
+  core / an FT-unsafe extension (cereggii) rather than the synthetic fixture.
 
 ## Phase 1 as-built: the environment recipe (hard-won)
 
@@ -350,6 +354,29 @@ C-level race TSan reports. Dropping it in the target's `Lib` and pointing
   and can't drift. Empty today (no races catalogued).
 - Tests: `tests/python/test_tsan_dedup.py` (14) — parse, unordered-pair canonicalisation,
   interceptor/plumbing skip, catalog match, prune-past-cap, suppression, framework, no-race.
+
+## Phase 3 as-built: op-mix enrichment + numpy-off
+
+The Phase 1 worker only did read-churn + a method call + a module-function call. Phase 3 adds the
+operation classes where free-threading bugs actually live (the ones the OOM/cereggii campaign
+kept hitting), all guarded and type-agnostic, per worker iteration:
+
+- **Attribute-dict churn** — `setattr(_obj, "_tsan_aN", i)` / `getattr` / periodic `delattr` on a
+  *shared* instance: concurrent `__dict__` materialise/mutate, the managed-dict race class
+  (OOM-0023/`set_keys`, dpdani's cereggii deferred-refcount corruption).
+- **Concurrent `gc.collect()`** (every 16th iteration) while the above churns refcounts and
+  containers — concurrent collection is itself a rich FT-race surface.
+- **`weakref.ref(_obj)`** creation — concurrent weakref-list mutation on the shared object.
+- **Shared-container mutation** — every sibling worker on one `_idx` hammers the same
+  `list`/`dict`/`set`/`bytearray` (`append`/`pop`/`update`/`add`/`discard`), so the container
+  itself is a concurrent-access target, not just an argument.
+
+**`--tsan` implies `--no-numpy`** (`setupProject`): numpy isn't FT-clean and the numpy plugin
+injects `import numpy` into every generated script, which the numpy-less TSan target can't import
+— it died before the stress region. Now auto-forced (guarded: only when that plugin option exists
+and the user didn't already pass it), logged as `TSan: forcing --no-numpy`. Verified end-to-end:
+a run with **no** `--no-numpy` flag now auto-suppresses numpy and still detects + labels the race.
+Test: `test_tsan_generation.py::test_enriched_op_mix_emitted`. Goldens unchanged (emitter gated).
 
 ## 10. Testing
 

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -506,6 +506,14 @@ class Fuzzer(Application):
                 "allocator swap is not thread-safe; combining them races the harness itself)"
             )
 
+        # --tsan implies --no-numpy: numpy isn't free-threading-clean, and the numpy plugin
+        # injects `import numpy` into EVERY generated script -- which the (numpy-less)
+        # ThreadSanitizer target can't import, so the child dies before the stress region. Only
+        # act if the plugin registered its --no-numpy option and the user didn't already pass it.
+        if self.options.tsan and getattr(self.options, "no_numpy", None) is False:
+            self.options.no_numpy = True
+            self.error("TSan: forcing --no-numpy (numpy is not free-threading-clean)")
+
         project = self.project
         if not self.project:
             project = self.project = Project(self)

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -695,6 +695,8 @@ class WritePythonCode(WriteCode):
         self.emptyLine()
         self.write(0, "# --- TSan concurrency-stress region (--tsan) ---")
         self.write(0, "import threading as _tsan_threading")
+        self.write(0, "import gc as _tsan_gc")
+        self.write(0, "import weakref as _tsan_weakref")
         self.write_print_to_stderr(0, '"[TSAN] entering concurrency-stress region"')
         # Free-threading is mandatory: without it the whole region is GIL-serialised noise.
         self.write(0, 'if getattr(sys, "_is_gil_enabled", lambda: True)():')
@@ -729,13 +731,17 @@ class WritePythonCode(WriteCode):
             def _tsan_worker(_idx, _wid):
                 _obj = _tsan_shared[_idx]
                 _names = [n for n in dir(_obj) if not n.startswith("_")]
+                # one shared mutable container this worker (and its siblings on _idx) also hammers
+                _bag = _tsan_shared_args[_idx % len(_tsan_shared_args)]
                 _tsan_barrier.wait()
                 for _i in range(_ITERS):
+                    # (a) dunder / read churn on the shared object
                     for _op in (repr, hash, list, len, bool, iter, str):
                         try:
                             _op(_obj)
                         except Exception:
                             pass
+                    # (b) a method call with shared (mutable) arguments
                     if _names:
                         try:
                             _m = getattr(_obj, _names[(_wid + _i) % len(_names)])
@@ -743,10 +749,48 @@ class WritePythonCode(WriteCode):
                                 _m(*_tsan_shared_args[: (_i % 3)])
                         except Exception:
                             pass
+                    # (c) a module function with the shared object as an argument
                     if _tsan_funcs:
                         try:
                             getattr(fuzz_target_module,
                                     _tsan_funcs[(_wid + _i) % len(_tsan_funcs)])(_obj)
+                        except Exception:
+                            pass
+                    # (d) attribute-dict churn: concurrent __dict__ materialise/mutate on one
+                    # shared instance (the managed-dict race class -- e.g. OOM-0023/set_keys,
+                    # the deferred-refcount corruption dpdani's cereggii hit).
+                    try:
+                        setattr(_obj, "_tsan_a%d" % (_i % 4), _i)
+                        getattr(_obj, "_tsan_a%d" % (_wid % 4), None)
+                        if _i % 8 == 0:
+                            delattr(_obj, "_tsan_a%d" % (_i % 4))
+                    except Exception:
+                        pass
+                    # (e) weakref churn: concurrent weakref creation/clear on the shared object
+                    try:
+                        _tsan_weakref.ref(_obj)
+                    except Exception:
+                        pass
+                    # (f) shared-container mutation: hammer ONE container from every sibling worker
+                    try:
+                        if isinstance(_bag, list):
+                            _bag.append(_i)
+                            _bag[:1]
+                        elif isinstance(_bag, dict):
+                            _bag[_wid] = _i
+                            _bag.get(_i)
+                        elif isinstance(_bag, set):
+                            _bag.add(_wid)
+                            _bag.discard(_i)
+                        elif isinstance(_bag, bytearray):
+                            _bag.append(_i & 0xFF)
+                    except Exception:
+                        pass
+                    # (g) concurrent GC while all the above churns refcounts + containers
+                    # (concurrent collection is itself a rich FT-race surface).
+                    if _i % 16 == 0:
+                        try:
+                            _tsan_gc.collect()
                         except Exception:
                             pass
             """,

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -99,6 +99,16 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("_is_gil_enabled", src)
         self.assertIn("raise SystemExit(3)", src)
 
+    def test_enriched_op_mix_emitted(self):
+        # Phase 3: the worker exercises the FT-race-rich classes, not just method calls.
+        src = _generate_tsan()
+        self.assertIn("import gc as _tsan_gc", src)
+        self.assertIn("import weakref as _tsan_weakref", src)
+        self.assertIn("_tsan_gc.collect()", src)  # concurrent GC
+        self.assertIn("_tsan_weakref.ref(_obj)", src)  # weakref churn
+        self.assertIn("setattr(_obj,", src)  # managed-dict / attribute churn
+        self.assertIn("isinstance(_bag,", src)  # shared-container mutation
+
     def test_shares_objects_and_module_functions(self):
         src = _generate_tsan()
         # a module class is instantiated into the shared pool, plus the module itself.


### PR DESCRIPTION
Phase 3 of `--tsan` (follows #199/#200/#201): **op-mix enrichment** + a footgun fix. Design +
as-built: `doc/tsan-mode-plan.md`.

## Richer op-mix (`_write_tsan_stress_region`)

Phase 1's worker only did read-churn + a method call + a module-function call. Phase 3 adds the
operation classes where free-threading bugs actually live (the ones the OOM/cereggii campaign kept
hitting), all guarded and type-agnostic, per worker iteration:

- **attribute-dict churn** — `setattr`/`getattr`/periodic `delattr` on a *shared* instance:
  concurrent `__dict__` materialise/mutate (the managed-dict race class — OOM-0023/`set_keys`, the
  cereggii deferred-refcount corruption);
- **concurrent `gc.collect()`** (every 16th iter) while the above churns refcounts/containers;
- **`weakref.ref(_obj)`** creation (concurrent weakref-list mutation);
- **shared-container mutation** — every sibling worker on one shared object hammers the same
  `list`/`dict`/`set`/`bytearray`, so the container itself is a concurrent-access target.

## `--tsan` implies `--no-numpy`

numpy isn't FT-clean and the numpy plugin injects `import numpy` into every generated script, which
the numpy-less TSan target can't import — the child died before the stress region. Now auto-forced
in `setupProject` (guarded: only when the plugin option exists and the user didn't already pass it),
logged as `TSan: forcing --no-numpy`. **Verified end-to-end:** a run with **no** `--no-numpy` flag
now auto-suppresses numpy and still detects + labels the race.

Test: `test_tsan_generation.py::test_enriched_op_mix_emitted`. Goldens unchanged (emitter gated).
Suite 1078 → 1079; `ruff check` + `ruff format` clean.

## Still open (future)

Per-target suppression management, barrier/iteration auto-tuning, a fleet profile, and pointing
`--tsan` at real CPython core / an FT-unsafe extension rather than the synthetic fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)