### PR TITLE
fleet: --tsan fleet preflight + triage how-to (Phase 4)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -269,8 +269,14 @@ This composes with the existing hooks — no new keep/prune plumbing, just a thi
   shared-container mutation (every sibling worker hammers one `list`/`dict`/`set`/`bytearray`).
   And **`--tsan` now implies `--no-numpy`** (the numpy plugin injected `import numpy` the TSan
   target lacks). See "Phase 3 as-built" below. **Still open (future):** per-target suppression
-  management, barrier/iteration auto-tuning, a fleet profile, and pointing it at real CPython
-  core / an FT-unsafe extension (cereggii) rather than the synthetic fixture.
+  management, barrier/iteration auto-tuning, and pointing it at real CPython core / an FT-unsafe
+  extension (cereggii) rather than the synthetic fixture.
+- **Phase 4 — fleet-triage readiness (2026-07-15).** The `cpython-tsan-findings` catalog is
+  published (`github.com/devdanzin/cpython-tsan-findings`), its `ingest.py` verified against real
+  fusil `--tsan` crash-dir stdout (it parses the race out of the full session output, not just a
+  clean report), the `fleet` preflight validates a `--tsan` fleet's TSan target + `known_races.tsv`
+  catalog, and `fleet/README.md` documents the `--tsan` fleet config + the ingest → report →
+  `gen_known_races` triage loop. Ready to point at a real target and catalog real races.
 
 ## Phase 1 as-built: the environment recipe (hard-won)
 

--- a/fleet/README.md
+++ b/fleet/README.md
@@ -74,6 +74,32 @@ Because systemd `enable`s them, they also come back **after a reboot**.
   it can still grow within a run; set `LOG=none` in `fleet.conf` to discard fusil's
   stdout (you still get crash dirs + `session.log` + systemd's start/stop in journald).
 
+## TSan fleets (data-race fuzzing)
+
+To hunt ThreadSanitizer data races instead of OOM crashes, point the fleet at a
+free-threaded **`--with-thread-sanitizer`** interpreter and swap the flags in `fleet.conf`:
+
+```sh
+TARGET_PYTHON=~/projects/python_build_matrix/builds/debug-ft-nojit-tsan/python
+GIL_MODES="0"                                  # --tsan requires free-threading
+CATALOG=~/projects/cpython-tsan-findings/catalog/known_races.tsv
+FUSIL_FLAGS="--tsan --tsan-dedup-prune --tsan-dedup-catalog=$CATALOG"
+```
+
+`fleet check` validates the TSan target and the catalog for you. fusil handles the rest
+(`setarch -R`, unlimited `RLIMIT_AS`, `TSAN_OPTIONS`, `DEBUGINFOD_URLS=`, implied `--no-numpy`);
+see `doc/tsan-mode-plan.md`. Crash dirs self-label `…-warning_threadsanitizer_data_race-…`
+(and their race id / `tsanNEW` / `tsanFRAME` under `--tsan-dedup-catalog`).
+
+**Triage loop** (in the sibling `cpython-tsan-findings` catalog):
+
+```sh
+FUSIL_TSAN_DEDUP=../fusil/fusil/python/tsan_dedup.py \
+  python3 scripts/ingest.py <fleet-dir>/inst-*/python/*   # bucket by race signature; NEW ones need a report
+# write reports/TSAN-NNNN-.../meta.json for each new signature, then:
+python3 scripts/gen_known_races.py                        # regenerate known_races.tsv; fleet restart picks it up
+```
+
 ## Under the hood (so it's not a black box)
 
 - **`fusil@.service.in`** — a systemd *template* unit. `%i` is the instance number;

--- a/fleet/fleet
+++ b/fleet/fleet
@@ -52,6 +52,20 @@ cmd_check(){  # validate fleet.conf before we start anything (catches the #1 foo
         *--oom-dedup-catalog*) [ -f "$CATALOG" ] || {
             echo "  CATALOG not found but --oom-dedup-catalog is set: '$CATALOG'"; ok=0; } ;;
     esac
+    case "$FUSIL_FLAGS" in
+        *--tsan-dedup-catalog*) [ -f "$CATALOG" ] || {
+            echo "  CATALOG not found but --tsan-dedup-catalog is set: '$CATALOG'"
+            echo "    -> point CATALOG at cpython-tsan-findings/catalog/known_races.tsv"; ok=0; } ;;
+    esac
+    # A --tsan fleet needs a free-threaded + ThreadSanitizer TARGET (fusil's own preflight fails
+    # fast otherwise, wasting the instance). Check here so the whole fleet doesn't start doomed.
+    case "$FUSIL_FLAGS" in
+        *--tsan*) [ -x "$TARGET_PYTHON" ] && "$TARGET_PYTHON" -c \
+            'import sys,sysconfig; ca=sysconfig.get_config_var("CONFIG_ARGS") or ""; sys.exit(0 if (not sys._is_gil_enabled() and "thread-sanitizer" in ca) else 1)' \
+            2>/dev/null || {
+            echo "  --tsan is set but TARGET_PYTHON is not free-threaded + --with-thread-sanitizer: '$TARGET_PYTHON'"
+            echo "    -> use a builds/*-ft-*-tsan interpreter"; ok=0; } ;;
+    esac
     if [ -x "$RUNNER_PY" ] && [ -f "$FUSIL_PY" ]; then
         PYTHONPATH="$repo${PYTHONPATH:+:$PYTHONPATH}" "$RUNNER_PY" -c 'import fusil, ptrace' 2>/dev/null \
             || { echo "  RUNNER_PY cannot 'import fusil, ptrace': '$RUNNER_PY'"


### PR DESCRIPTION
Phase 4 of `--tsan` (follows #199–#202): **fleet-triage readiness** — make the fleet harness
`--tsan`-aware and document the race-triage loop, so a data-race fleet run is validated up front
and its output is straightforward to catalog.

- **`fleet check`**: mirror the `--oom-dedup-catalog` preflight for `--tsan-dedup-catalog`
  (`CATALOG` must exist), and verify `TARGET_PYTHON` is free-threaded + `--with-thread-sanitizer`
  when `--tsan` is set — fusil's own preflight fails fast otherwise, so catch it before the whole
  fleet starts doomed. (Probe verified: TSan build → pass, non-TSan → fail.)
- **`fleet/README.md`**: a "TSan fleets" section — the `fleet.conf` swap (FT+TSan `TARGET_PYTHON`,
  `GIL_MODES="0"`, `CATALOG=known_races.tsv`, `--tsan --tsan-dedup-prune --tsan-dedup-catalog`) plus
  the ingest → report → `gen_known_races` triage loop.
- **`doc/tsan-mode-plan.md`**: record Phase 4. The catalog repo is published
  (**github.com/devdanzin/cpython-tsan-findings**) and its `ingest.py` is verified against **real**
  `--tsan` crash-dir stdout — it parses the race out of the full session output (past fusil's
  `[TSAN]` markers / faulthandler), not just a clean report.

No Python changed (shell + docs); goldens/suite unaffected; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)