### PR TITLE
tsan_dedup: parse non-race TSan reports (SEGV/UAF/deadlock)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -344,7 +344,11 @@ C-level race TSan reports. Dropping it in the target's `Lib` and pointing
   Function-level (lines drift). `TSanDeduper.decide(text) -> (keep, label)`: suppressed →
   `(False, None)`; both-sites-in-thread-scaffolding → `(True, "tsanFRAME")` (framework noise,
   kept out of the NEW bucket); catalog hit → the race id (prune past `--tsan-dedup-keep` with
-  `--tsan-dedup-prune`); else `(True, "tsanNEW")`.
+  `--tsan-dedup-prune`); else `(True, "tsanNEW")`. `parse_report` also handles non-race TSan
+  reports (`SEGV`/`heap-use-after-free`/`lock-order-inversion`/`deadlock`): one crash stack →
+  the top-real-site signature if symbolized, else `SEGV addr=0x.. pc=0x..` (deterministic under
+  `setarch -R`), labeled `tsanSEGV`. Added after fleet 01 turned up unsymbolizable SEGV storms
+  (`nested bug … aborting`) that otherwise lumped as `tsanNOPARSE`.
 - **Wiring** (`__init__.py`): `--tsan-dedup-catalog` / `--tsan-dedup-keep` / `--tsan-dedup-prune`,
   installed as `_tsan_keep_policy` on the same `application.session_keep_policy` hook the OOM/hit
   paths use (hit-suppression still wraps it). The kept dir self-labels e.g.

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -26,6 +26,14 @@ import re
 
 # ---- report parsing ----
 WARNING = re.compile(r"WARNING: ThreadSanitizer: data race")
+# A non-race TSan report: SEGV / heap-use-after-free / lock-order-inversion / deadlock. These
+# carry ONE crash stack (not two access stanzas). `SEGV on unknown address 0xADDR (pc 0xPC ...)`
+# often can't be unwound (TSan prints "nested bug ... aborting" with no frames), so the fault
+# address + pc is the only stable signal; use the symbolized crash site when frames ARE present.
+SEGV = re.compile(
+    r"ThreadSanitizer:\s*(SEGV|heap-use-after-free|lock-order-inversion|deadlock)"
+    r"(?:.*?\baddress 0x0*([0-9a-fA-F]+))?(?:.*?\bpc 0x0*([0-9a-fA-F]+))?"
+)
 # An access stanza header: "[Previous ][Atomic ](Write|Read) of size N at 0xADDR by thread T#:".
 # TSan capitalises the FIRST access ("Write"/"Read") but lowercases the second ("Previous
 # write"/"Previous read"), so match either case. The thread-CREATION stanzas ("Thread T1 '...'
@@ -119,13 +127,48 @@ def _top_site(frames):
 
 
 def parse_report(text):
-    """Parse the first ThreadSanitizer data-race report in ``text``.
+    """Parse the first ThreadSanitizer report in ``text``.
 
-    Returns a dict {signature, sites:[(file,func,line)|None, ...], framework:bool} or None if
-    there is no data-race report (or it can't be reduced to any site).
+    Returns a dict {signature, sites, framework, kind} where kind is "race" (a data race, two
+    access sites) or "segv" (a SEGV/UAF/deadlock, one crash site), or None if there is no TSan
+    report (or it can't be reduced to any signature).
     """
-    if not WARNING.search(text):
-        return None
+    if WARNING.search(text):
+        return _parse_race(text)
+    m = SEGV.search(text)
+    if m:
+        return _parse_segv(text, m)
+    return None
+
+
+def _parse_segv(text, m):
+    """Parse a non-race TSan report (SEGV/UAF/deadlock): one crash stack. Signature is the top
+    real crash site if TSan symbolized it, else the fault address + pc (deterministic under the
+    fixed load address `setarch -R` gives; build-specific -- regenerate the catalog per build)."""
+    kind_word, addr, pc = m.group(1), m.group(2), m.group(3)
+    frames = []
+    started = False
+    for line in text.splitlines():
+        if not started:
+            if SEGV.search(line):
+                started = True
+            continue
+        fm = FRAME.match(line)
+        if fm:
+            frames.append((fm.group(1), fm.group(2)))
+        elif frames:
+            break  # crash stack ended
+    site = _top_site(frames)
+    if site:
+        signature = "%s %s:%s" % (kind_word, site[0], site[1])
+        sites = [site]
+    else:
+        signature = "%s addr=0x%s pc=0x%s" % (kind_word, addr or "?", pc or "?")
+        sites = []
+    return dict(signature=signature, sites=sites, framework=False, kind="segv")
+
+
+def _parse_race(text):
     lines = text.splitlines()
     stanzas = []  # list of frame-lists, one per access stanza (in order)
     i = 0
@@ -163,7 +206,7 @@ def parse_report(text):
     framework = all(s is not None and FRAMEWORK_FILES.search(s[0]) for s in sites if s)
     keys = sorted("%s:%s" % (s[0], s[1]) if s else "?" for s in sites)
     signature = " | ".join(keys)
-    return dict(signature=signature, sites=sites, framework=framework)
+    return dict(signature=signature, sites=sites, framework=framework, kind="race")
 
 
 # ---- catalog snapshot ----
@@ -291,7 +334,7 @@ class TSanDeduper:
         if self.suppressor.suppresses(report):
             self.seen["suppressed"] += 1
             return False, None
-        if report["framework"]:
+        if report.get("framework"):
             self.seen["framework"] += 1
             return True, "tsanFRAME"  # kept, but out of the tsanNEW bucket
         rid = self.snap.get(report["signature"])
@@ -301,8 +344,10 @@ class TSanDeduper:
                 return False, rid  # known + over cap -> prune duplicate
             self.kept[rid] += 1
             return True, rid
-        self.seen["NEW:" + report["signature"]] += 1
-        return True, "tsanNEW"
+        # A new (uncatalogued) finding -- label a SEGV/UAF distinctly from a data race.
+        is_segv = report.get("kind") == "segv"
+        self.seen[("NEW-SEGV:" if is_segv else "NEW:") + report["signature"]] += 1
+        return True, "tsanSEGV" if is_segv else "tsanNEW"
 
     def report(self):
         lines = ["TSan dedupe summary (seen / kept):"]

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -66,6 +66,27 @@ REPORT_FRAMEWORK = "\n".join(
 
 NO_RACE = "hello, no ThreadSanitizer here\nSUMMARY: nothing\n"
 
+# A SEGV whose stack TSan couldn't unwind (nested bug) -> signature is the fault addr + pc.
+REPORT_SEGV_NOFRAMES = "\n".join(
+    [
+        "==123==ERROR: ThreadSanitizer: SEGV on unknown address 0x0000000000d8"
+        " (pc 0x5555556bf69f bp 0xdead sp 0xbeef T123)",
+        "==123==The signal is caused by a READ memory access.",
+        "ThreadSanitizer: nested bug in the same thread, aborting.",
+    ]
+)
+
+# A use-after-free with a symbolized crash stack -> signature is the top real site.
+REPORT_UAF_FRAMES = "\n".join(
+    [
+        "==1==ERROR: ThreadSanitizer: heap-use-after-free on address 0x7f00"
+        " (pc 0x1234 bp 0x1 sp 0x2 T1)",
+        "    #0 dictiter_dealloc /b/./Objects/dictobject.c:5620:9 (python+0x1) (BuildId: aa)",
+        "    #1 _Py_Dealloc /b/Objects/object.c:3319:5 (python+0x2) (BuildId: aa)",
+        "SUMMARY: ThreadSanitizer: heap-use-after-free Objects/dictobject.c:5620 in dictiter_dealloc",
+    ]
+)
+
 
 class TestParse(unittest.TestCase):
     def test_signature_is_sorted_site_pair(self):
@@ -138,6 +159,37 @@ class TestDecide(unittest.TestCase):
 
     def test_unparseable_kept(self):
         self.assertEqual(self._deduper().decide(NO_RACE), (True, "tsanNOPARSE"))
+
+
+class TestSegv(unittest.TestCase):
+    def test_segv_no_frames_keyed_on_addr_and_pc(self):
+        r = tsan_dedup.parse_report(REPORT_SEGV_NOFRAMES)
+        self.assertEqual(r["kind"], "segv")
+        self.assertEqual(r["signature"], "SEGV addr=0xd8 pc=0x5555556bf69f")
+        self.assertFalse(r["framework"])
+
+    def test_uaf_with_frames_keyed_on_site(self):
+        r = tsan_dedup.parse_report(REPORT_UAF_FRAMES)
+        self.assertEqual(r["kind"], "segv")
+        self.assertEqual(
+            r["signature"], "heap-use-after-free Objects/dictobject.c:dictiter_dealloc"
+        )
+
+    def test_new_segv_labeled_tsansegv(self):
+        self.assertEqual(tsan_dedup.TSanDeduper().decide(REPORT_SEGV_NOFRAMES), (True, "tsanSEGV"))
+
+    def test_known_segv_labeled_and_prunable(self):
+        d = tsan_dedup.TSanDeduper(keep=1, prune=True)
+        d.snap = tsan_dedup.load_catalog(["TSAN-0009\tSEGV addr=0xd8 pc=0x5555556bf69f"])
+        self.assertEqual(
+            [d.decide(REPORT_SEGV_NOFRAMES) for _ in range(2)],
+            [(True, "TSAN-0009"), (False, "TSAN-0009")],
+        )
+
+    def test_segv_suppressible(self):
+        d = tsan_dedup.TSanDeduper()
+        d.suppressor = tsan_dedup.Suppressor.from_lines(["dictiter_dealloc"])
+        self.assertEqual(d.decide(REPORT_UAF_FRAMES), (False, None))
 
 
 class TestReadStdout(unittest.TestCase):


### PR DESCRIPTION
The first `--tsan` fleet turned up crash dirs that ThreadSanitizer reports as
`SEGV on unknown address` — and can't unwind (`nested bug in the same thread, aborting`, no
frames) — which `parse_report` ignored, so they lumped together as `tsanNOPARSE`.

Handle them: `parse_report` now dispatches on report kind and returns `kind="race"` (two access
stanzas, as before) or `kind="segv"` (one crash stack, covering `SEGV`/`heap-use-after-free`/
`lock-order-inversion`/`deadlock`). The segv signature is the top-real crash site when symbolized,
else `SEGV addr=0x.. pc=0x..` (deterministic under `setarch -R`'s fixed load address; build-specific
— regenerate the catalog per build). `decide()` labels a new one `tsanSEGV` and dedupes/prunes it
against the catalog like a race.

**Verified on fleet 01:** the 7 `pty` SEGVs (identical `addr=0xd8 pc=…`) collapse to one signature
instead of `noparse`. (The remaining `noparse` are genuine non-TSan aborts — bare `posix-sigabrt`
with no TSan report.)

+5 tests (`TestSegv`). Suite 1079 → 1084; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)