### PR TITLE
--tsan: exclude process-lifecycle calls (fork/exec/spawn) from the stress region

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -277,6 +277,16 @@ This composes with the existing hooks — no new keep/prune plumbing, just a thi
   clean report), the `fleet` preflight validates a `--tsan` fleet's TSan target + `known_races.tsv`
   catalog, and `fleet/README.md` documents the `--tsan` fleet config + the ingest → report →
   `gen_known_races` triage loop. Ready to point at a real target and catalog real races.
+- **Fleet 01 (first real run) + a harness fix.** The first `--tsan` fleet found ~17 distinct race
+  signatures (11 seeded as `TSAN-0001..0011`; dominant = cjkcodecs `MultibyteIncrementalDecoder`
+  getstate/reset, 10 vehicles). It also surfaced a repeated `SEGV addr=0xd8` in `pty` runs: the
+  crashing pc resolves to **`__tsan::TraceSwitchPart`** — the *ThreadSanitizer runtime*, not
+  CPython. Cause: the stress region reached `pty.fork()`/`os.forkpty()` (via the shared module
+  object's `dir()`), forking a worker thread; TSan does not support `fork()` in a multithreaded
+  process without an immediate `exec`, so the child crashes in the TSan runtime. Fix: the emitter
+  now excludes process-lifecycle calls (`TSAN_UNSAFE_CALLS`: fork/forkpty/spawn*/exec*/_exit/
+  abort/system/popen/…) from both `_tsan_funcs` and the runtime `dir()` loop — they are never a
+  useful race target and would fork/replace the fuzzer anyway.
 
 ## Phase 1 as-built: the environment recipe (hard-won)
 

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -59,6 +59,23 @@ TRIVIAL_TYPES = {
 }
 TRIVIAL_TYPES_STR = "{int, str, float, bool, bytes, tuple, list, dict, set, type(None),}"
 
+# Process-lifecycle calls the --tsan stress region must never make: forking a fuzzer worker
+# thread (os.fork/forkpty, pty.fork/spawn, os.spawn*/posix_spawn without an immediate exec)
+# leaves the child with an inconsistent runtime -- and under ThreadSanitizer that is an
+# *unsupported* case (fork in a multithreaded process w/o immediate exec), so the child crashes
+# inside the TSan runtime (__tsan::TraceSwitchPart, a NULL ThreadState deref). exec*/_exit/abort
+# would replace or kill the fuzzing process outright. None of these are useful to race; skip them.
+TSAN_UNSAFE_CALLS = frozenset(
+    {
+        "fork", "forkpty", "posix_spawn", "posix_spawnp",
+        "spawn", "spawnl", "spawnle", "spawnlp", "spawnlpe",
+        "spawnv", "spawnve", "spawnvp", "spawnvpe",
+        "exec", "execl", "execle", "execlp", "execlpe",
+        "execv", "execve", "execvp", "execvpe",
+        "_exit", "abort", "system", "popen", "register_at_fork",
+    }
+)  # fmt: skip
+
 
 class PythonFuzzerError(Exception):
     """Custom exception raised when fuzzer encounters unrecoverable errors."""
@@ -690,7 +707,9 @@ class WritePythonCode(WriteCode):
 
         classes = self.module_classes or []
         shared_classes = sample(classes, min(n_shared, len(classes))) if classes else []
-        funcs = list(self.module_functions or [])[:40]
+        # Drop process-lifecycle calls (fork/exec/spawn/...): forking a worker crashes the child
+        # under TSan and is never a useful race target (see TSAN_UNSAFE_CALLS).
+        funcs = [f for f in (self.module_functions or []) if f not in TSAN_UNSAFE_CALLS][:40]
 
         self.emptyLine()
         self.write(0, "# --- TSan concurrency-stress region (--tsan) ---")
@@ -708,6 +727,9 @@ class WritePythonCode(WriteCode):
         # Mutable containers shared BY REFERENCE across every worker (shared-argument races).
         self.write(0, '_tsan_shared_args = [[1, 2, 3], {"k": 1}, {1, 2, 3}, bytearray(b"fusil")]')
         self.write(0, "_tsan_funcs = %r" % (funcs,))
+        # Runtime skip set: the worker introspects dir(shared_object), so a shared MODULE object
+        # would still expose fork/exec/... by name -- filter them there too.
+        self.write(0, "_tsan_unsafe = frozenset(%r)" % (tuple(sorted(TSAN_UNSAFE_CALLS)),))
         # Build the shared objects: instantiate a few module classes (guarded), plus the module.
         self.write(0, "_tsan_shared = []")
         for class_name in shared_classes:
@@ -730,7 +752,7 @@ class WritePythonCode(WriteCode):
             """
             def _tsan_worker(_idx, _wid):
                 _obj = _tsan_shared[_idx]
-                _names = [n for n in dir(_obj) if not n.startswith("_")]
+                _names = [n for n in dir(_obj) if not n.startswith("_") and n not in _tsan_unsafe]
                 # one shared mutable container this worker (and its siblings on _idx) also hammers
                 _bag = _tsan_shared_args[_idx % len(_tsan_shared_args)]
                 _tsan_barrier.wait()

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -26,8 +26,16 @@ def _tsan_module():
     def helper(*a):
         return a
 
+    def fork(*a):  # a process-lifecycle call the stress region must NOT invoke
+        return a
+
+    def execv(*a):
+        return a
+
     mod.Widget = Widget
     mod.helper = helper
+    mod.fork = fork
+    mod.execv = execv
     return mod
 
 
@@ -122,6 +130,18 @@ class TestTSanGeneration(unittest.TestCase):
         src = _generate_tsan(threads=7, iterations=42)
         self.assertIn("_WORKERS_PER_OBJ = 7", src)
         self.assertIn("_ITERS = 42", src)
+
+    def test_process_lifecycle_calls_excluded(self):
+        # fork/exec/spawn/... must not be in the module-function list, and the runtime dir()
+        # filter must guard the shared module object too (forking a worker crashes the child
+        # under TSan -- __tsan::TraceSwitchPart -- and would fork/replace the fuzzer anyway).
+        src = _generate_tsan()
+        funcs_line = next(ln for ln in src.splitlines() if ln.startswith("_tsan_funcs = "))
+        self.assertIn("'helper'", funcs_line)
+        self.assertNotIn("'fork'", funcs_line)
+        self.assertNotIn("'execv'", funcs_line)
+        self.assertIn("_tsan_unsafe = frozenset(", src)
+        self.assertIn("n not in _tsan_unsafe", src)
 
     def test_replaces_single_threaded_sweeps(self):
         # Under --tsan the normal function-fuzzing sweep is skipped in favour of the stress


### PR DESCRIPTION
Root-cause + fix for the `pty` SEGVs the first `--tsan` fleet turned up (`SEGV on unknown address
0xd8`, repeated across forked children, TSan `nested bug … aborting`, no frames).

**Diagnosis:** the crashing pc resolves to **`__tsan::TraceSwitchPart(__tsan::ThreadState*)`** — a
function in the **ThreadSanitizer runtime, not CPython**. The stress region reached `pty.fork()` /
`os.forkpty()` (via the shared *module* object's `dir()`), forking a worker thread. TSan does not
support `fork()` in a multithreaded process unless the child immediately `exec`s; here the child
runs Python, inherits an inconsistent TSan `ThreadState`, and segfaults on its next instrumented
access. **Not a CPython bug** — a harness artifact (and a hazard: a fuzzer must not fork/exec-replace
itself). Confirmed it does *not* reproduce on a plain free-threaded build.

**Fix:** `TSAN_UNSAFE_CALLS` (fork/forkpty/posix_spawn/spawn\*/exec\*/_exit/abort/system/popen/
register_at_fork) are excluded from `_tsan_funcs` at emit time **and** from the worker's runtime
`dir(shared_object)` loop (a shared module object would otherwise still expose them by name). They
were never useful race targets. Verified a `--tsan pty` script no longer lists fork/forkpty/spawn.

+1 test; suite 1084 → 1085; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)