### PR TITLE
tsan: document + guard the posix.abort() self-abort NOPARSE

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -287,6 +287,16 @@ This composes with the existing hooks — no new keep/prune plumbing, just a thi
   now excludes process-lifecycle calls (`TSAN_UNSAFE_CALLS`: fork/forkpty/spawn*/exec*/_exit/
   abort/system/popen/…) from both `_tsan_funcs` and the runtime `dir()` loop — they are never a
   useful race target and would fork/replace the fuzzer anyway.
+- **`posix-sigabrt` NOPARSE = the same self-destruct class, second face.** The other `tsanNOPARSE`
+  cluster was two `posix` runs killed by **SIGABRT** (signal 6) with *no* ThreadSanitizer output at
+  all — stdout ending exactly at `[TSAN] entering concurrency-stress region`. Diagnosed as
+  `posix.abort()` (≡ `os.abort()`): the pre-fix unfiltered `dir()` loop over the shared `posix`
+  module called it, and C `abort()` raises SIGABRT directly. Reproduces in one line
+  (`posix.abort()` → exit 134). Same root cause and **same fix** as the `pty` SEGV — `abort` is in
+  `TSAN_UNSAFE_CALLS`, so post-fix the shared module never exposes it. Deliberately *not*
+  auto-suppressed in the deduper: a bare signal-6 with no message is a harness self-abort, but a
+  signal-6 carrying a `Fatal Python error:` / `Assertion` banner would be a real concurrency crash,
+  so NOPARSE stays a manual glance. (Catalog: `notes/harness-self-destruct-noparse.md`.)
 
 ## Phase 1 as-built: the environment recipe (hard-won)
 

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -32,10 +32,14 @@ def _tsan_module():
     def execv(*a):
         return a
 
+    def abort(*a):  # a self-signalling call (os.abort -> SIGABRT); must NOT be invoked
+        return a
+
     mod.Widget = Widget
     mod.helper = helper
     mod.fork = fork
     mod.execv = execv
+    mod.abort = abort
     return mod
 
 
@@ -140,6 +144,8 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("'helper'", funcs_line)
         self.assertNotIn("'fork'", funcs_line)
         self.assertNotIn("'execv'", funcs_line)
+        # os.abort() -> SIGABRT was the pre-#205 posix-sigabrt NOPARSE self-abort; keep it out.
+        self.assertNotIn("'abort'", funcs_line)
         self.assertIn("_tsan_unsafe = frozenset(", src)
         self.assertIn("n not in _tsan_unsafe", src)
 


### PR DESCRIPTION
## What

The fleet-01 `posix-sigabrt` `tsanNOPARSE` crashes (2 dirs) were the target **aborting itself**, not a data race or a CPython/TSan bug.

The pre-#205 stress region shared the `posix` **module object** and its worker looped over `dir(posix)` unfiltered, so `posix.abort()` (≡ `os.abort()`) got called; C `abort()` raises **SIGABRT** — signal 6, with **no ThreadSanitizer output at all** (stdout ends exactly at `[TSAN] entering concurrency-stress region`, which is why it wouldn't parse). One-line repro on the TSan build matches exactly:

```
posix.abort()  ->  exit 134 (128+6), no TSan banner
```

This is the **same self-destruct root cause** as the `pty` fork-in-thread SEGV (`__tsan::TraceSwitchPart`) fixed in #205 — second face. Together they account for the entire fleet-01 NOPARSE bucket (4 dirs).

## Already fixed by #205

`abort` is in `TSAN_UNSAFE_CALLS`, so it's excluded from both the curated `_tsan_funcs` list and the runtime `dir()` loop. Verified a freshly generated `posix` stress region no longer emits or reaches it (the module is still shared, but the `dir()` loop now guards on `n not in _tsan_unsafe`).

## This PR

- **Regression test**: `test_process_lifecycle_calls_excluded` now also asserts `abort` is excluded (added `abort` to the test module) — pins the exact builtin from this finding.
- **Doc**: `doc/tsan-mode-plan.md` fleet-01 section records the posix-sigabrt resolution next to pty, including **why a bare signal-6 NOPARSE must stay a manual glance** — a real `Fatal Python error:` / `Assertion` abort under concurrency would look similar, so the deduper deliberately does *not* auto-suppress signal-6/NOPARSE.

Companion catalog note (`notes/harness-self-destruct-noparse.md`) lands in `cpython-tsan-findings`.

## Test

27 tsan tests (`test_tsan_generation` + `test_tsan_dedup`) OK; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)