### PR TITLE
tsan_dedup: parse "Previous atomic write" stanzas; narrow the framework heuristic

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -287,6 +287,16 @@ This composes with the existing hooks — no new keep/prune plumbing, just a thi
   now excludes process-lifecycle calls (`TSAN_UNSAFE_CALLS`: fork/forkpty/spawn*/exec*/_exit/
   abort/system/popen/…) from both `_tsan_funcs` and the runtime `dir()` loop — they are never a
   useful race target and would fork/replace the fuzzer anyway.
+- **`posix-sigabrt` NOPARSE = the same self-destruct class, second face.** The other `tsanNOPARSE`
+  cluster was two `posix` runs killed by **SIGABRT** (signal 6) with *no* ThreadSanitizer output at
+  all — stdout ending exactly at `[TSAN] entering concurrency-stress region`. Diagnosed as
+  `posix.abort()` (≡ `os.abort()`): the pre-fix unfiltered `dir()` loop over the shared `posix`
+  module called it, and C `abort()` raises SIGABRT directly. Reproduces in one line
+  (`posix.abort()` → exit 134). Same root cause and **same fix** as the `pty` SEGV — `abort` is in
+  `TSAN_UNSAFE_CALLS`, so post-fix the shared module never exposes it. Deliberately *not*
+  auto-suppressed in the deduper: a bare signal-6 with no message is a harness self-abort, but a
+  signal-6 carrying a `Fatal Python error:` / `Assertion` banner would be a real concurrency crash,
+  so NOPARSE stays a manual glance. (Catalog: `notes/harness-self-destruct-noparse.md`.)
 
 ## Phase 1 as-built: the environment recipe (hard-won)
 

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -35,11 +35,16 @@ SEGV = re.compile(
     r"(?:.*?\baddress 0x0*([0-9a-fA-F]+))?(?:.*?\bpc 0x0*([0-9a-fA-F]+))?"
 )
 # An access stanza header: "[Previous ][Atomic ](Write|Read) of size N at 0xADDR by thread T#:".
-# TSan capitalises the FIRST access ("Write"/"Read") but lowercases the second ("Previous
-# write"/"Previous read"), so match either case. The thread-CREATION stanzas ("Thread T1 '...'
-# created by ...") do NOT match, so only the two racing data accesses feed the signature.
+# TSan capitalises the FIRST access ("Write"/"Read"/"Atomic write") but lowercases the second
+# ("Previous write"/"Previous read"/"Previous atomic write"), so match either case -- including
+# the `atomic` qualifier, which is lowercased on the second access too. Missing "Previous atomic
+# write" silently dropped the 2nd stanza, and the len(stanzas)<2 fallback below then duplicated
+# the 1st -- fabricating a symmetric "A | A" signature for exactly the non-atomic-reader-vs-
+# atomic-writer races this catalog is mostly made of (18% of fleet-03's race dirs). The
+# thread-CREATION stanzas ("Thread T1 '...' created by ...") do NOT match, so only the two racing
+# data accesses feed the signature.
 ACCESS = re.compile(
-    r"^\s*(?:Previous\s+)?(?:Atomic\s+)?(?:[Ww]rite|[Rr]ead) of size \d+ at 0x[0-9a-fA-F]+ by "
+    r"^\s*(?:Previous\s+)?(?:[Aa]tomic\s+)?(?:[Ww]rite|[Rr]ead) of size \d+ at 0x[0-9a-fA-F]+ by "
 )
 # A symbolized TSan frame: "#N func /abs/.../<CPythonDir>/file.c:line:col (module+0xoff) ...".
 # func or the location may be "<null>" (interceptors / non-CPython .so frames); those simply
@@ -89,10 +94,35 @@ PLUMBING_SKIP = frozenset(
 # here); skip by pattern.
 _STACKREF = re.compile(r"\w*StackRef\w*|_PyRun_\w*")
 
-# Thread/frame scaffolding: a race whose BOTH access sites live only here is Python's own
-# thread machinery racing under the harness spinning 8 threads up/down -- framework noise, not
-# a target finding. Labeled tsanFRAME (kept, but out of the tsanNEW bucket).
-FRAMEWORK_FILES = re.compile(r"(?:_threadmodule\.c|thread_pthread\.h)$")
+# Thread/frame scaffolding: a race whose BOTH access sites are Python's own thread-lifecycle
+# machinery (the harness spinning workers up/down) is framework noise, not a target finding.
+# Labeled tsanFRAME (kept, but out of the tsanNEW bucket).
+#
+# Match the FUNCTION, not just the file. `Modules/_threadmodule.c` also holds the PUBLIC _thread
+# API -- RLock/lock methods such as `rlock_repr` (= RLock.__repr__, a tp_repr slot) -- and a race
+# between those is a genuine finding. The old file-level `_threadmodule.c` match labeled every
+# such race as framework noise, silently burying the real RLock repr race (cf. TSAN-0028 /
+# cpython#153292). `thread_pthread.h` is pure platform bootstrap (no public API), so a file-level
+# match is still correct there.
+FRAMEWORK_FILES = re.compile(r"thread_pthread\.h$")
+# Thread-lifecycle entry points in _threadmodule.c: the create/run/bootstrap path the harness
+# exercises, never a target's own data.
+FRAMEWORK_FUNCS = frozenset(
+    {
+        "thread_run",
+        "do_start_new_thread",
+        "do_start_joinable_thread",
+        "ThreadHandle_start",
+        "thread_PyThread_start_joinable_thread",
+        "PyThread_start_joinable_thread",
+        "pythread_wrapper",
+    }
+)
+
+
+def _is_framework(site):
+    """True if this (file, func, line) site is harness thread-lifecycle scaffolding."""
+    return bool(FRAMEWORK_FILES.search(site[0])) or site[1] in FRAMEWORK_FUNCS
 
 
 def _frame_site(func, location):
@@ -203,7 +233,7 @@ def _parse_race(text):
     if all(s is None for s in sites):
         return None
     # Framework noise: every resolved site is thread/frame scaffolding.
-    framework = all(s is not None and FRAMEWORK_FILES.search(s[0]) for s in sites if s)
+    framework = all(s is not None and _is_framework(s) for s in sites if s)
     keys = sorted("%s:%s" % (s[0], s[1]) if s else "?" for s in sites)
     signature = " | ".join(keys)
     return dict(signature=signature, sites=sites, framework=framework, kind="race")

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -51,16 +51,51 @@ REPORT_SWAPPED = "\n".join(
 )
 
 # A race whose both access sites live only in the thread machinery -> framework noise.
+# Genuine framework noise: BOTH sites are the harness's own thread-lifecycle path (spinning
+# workers up/down), not any target data.
 REPORT_FRAMEWORK = "\n".join(
     [
         "WARNING: ThreadSanitizer: data race (pid=3)",
         "  Write of size 8 at 0x7f00 by thread T1:",
-        "    #0 lock_PyThread_acquire_lock /b/./Modules/_threadmodule.c:100:1 (python+0x1)",
+        "    #0 ThreadHandle_start /b/./Modules/_threadmodule.c:475:9 (python+0x1)",
         "",
         "  Previous read of size 8 at 0x7f00 by thread T2:",
-        "    #0 lock_PyThread_release_lock /b/./Modules/_threadmodule.c:200:2 (python+0x2)",
+        "    #0 thread_run /b/./Modules/_threadmodule.c:330:2 (python+0x2)",
         "",
-        "SUMMARY: ThreadSanitizer: data race in lock_PyThread_acquire_lock",
+        "SUMMARY: ThreadSanitizer: data race in ThreadHandle_start",
+    ]
+)
+
+# NOT framework noise: Modules/_threadmodule.c also holds the PUBLIC _thread API. A race between
+# public lock/RLock methods is a genuine finding -- the old file-level `_threadmodule.c` match
+# buried the real RLock repr race (cf. cpython#153292) as scaffolding.
+REPORT_PUBLIC_THREAD_API = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=3)",
+        "  Write of size 8 at 0x7f00 by thread T1:",
+        "    #0 _thread_RLock__release_save_impl /b/./Modules/_threadmodule.c:1233:22 (python+0x1)",
+        "",
+        "  Previous read of size 8 at 0x7f00 by thread T2:",
+        "    #0 rlock_repr /b/./Modules/_threadmodule.c:1295:28 (python+0x2)",
+        "",
+        "SUMMARY: ThreadSanitizer: data race in rlock_repr",
+    ]
+)
+
+# TSan lowercases the whole SECOND access line, including the `atomic` qualifier: "Previous
+# atomic write". The reader-vs-atomic-writer shape is the single most common race class in the
+# catalog, so failing to match this header dropped the 2nd stanza and (via the len<2 fallback)
+# fabricated a symmetric "A | A" signature.
+REPORT_PREVIOUS_ATOMIC = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=4)",
+        "  Read of size 8 at 0x7f00 by thread T3:",
+        "    #0 rlock_repr /b/./Modules/_threadmodule.c:1291:41 (python+0x1)",
+        "",
+        "  Previous atomic write of size 8 at 0x7f00 by thread T1:",
+        "    #0 _Py_atomic_store_ullong_relaxed /b/./Include/cpython/pyatomic_gcc.h:518:3 (python+0x2)",
+        "",
+        "SUMMARY: ThreadSanitizer: data race in rlock_repr",
     ]
 )
 
@@ -116,6 +151,41 @@ class TestParse(unittest.TestCase):
     def test_framework_race_flagged(self):
         r = tsan_dedup.parse_report(REPORT_FRAMEWORK)
         self.assertTrue(r["framework"])
+
+    def test_public_thread_api_race_is_not_framework(self):
+        # Modules/_threadmodule.c holds the public _thread API too; a race between public
+        # RLock methods is a real finding, not harness scaffolding.
+        r = tsan_dedup.parse_report(REPORT_PUBLIC_THREAD_API)
+        self.assertFalse(r["framework"])
+        self.assertEqual(
+            r["signature"],
+            "Modules/_threadmodule.c:_thread_RLock__release_save_impl"
+            " | Modules/_threadmodule.c:rlock_repr",
+        )
+
+    def test_previous_atomic_write_stanza_parsed(self):
+        # "Previous atomic write" (lowercased `atomic`) must be recognised as the 2nd access
+        # stanza; otherwise it is dropped and the 1st stanza duplicated into "A | A".
+        r = tsan_dedup.parse_report(REPORT_PREVIOUS_ATOMIC)
+        self.assertEqual(
+            r["signature"],
+            "Include/cpython/pyatomic_gcc.h:_Py_atomic_store_ullong_relaxed"
+            " | Modules/_threadmodule.c:rlock_repr",
+        )
+        self.assertFalse(r["framework"])
+
+    def test_access_header_variants_match(self):
+        for header in (
+            "  Write of size 8 at 0x7f00 by thread T1:",
+            "  Read of size 8 at 0x7f00 by thread T1:",
+            "  Previous write of size 8 at 0x7f00 by thread T1:",
+            "  Previous read of size 8 at 0x7f00 by thread T1:",
+            "  Atomic write of size 8 at 0x7f00 by thread T1:",
+            "  Atomic read of size 8 at 0x7f00 by thread T1:",
+            "  Previous atomic write of size 8 at 0x7f00 by thread T1:",
+            "  Previous atomic read of size 8 at 0x7f00 by thread T1:",
+        ):
+            self.assertTrue(tsan_dedup.ACCESS.search(header), header)
 
 
 class TestDecide(unittest.TestCase):

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -32,10 +32,14 @@ def _tsan_module():
     def execv(*a):
         return a
 
+    def abort(*a):  # a self-signalling call (os.abort -> SIGABRT); must NOT be invoked
+        return a
+
     mod.Widget = Widget
     mod.helper = helper
     mod.fork = fork
     mod.execv = execv
+    mod.abort = abort
     return mod
 
 
@@ -140,6 +144,8 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("'helper'", funcs_line)
         self.assertNotIn("'fork'", funcs_line)
         self.assertNotIn("'execv'", funcs_line)
+        # os.abort() -> SIGABRT was the pre-#205 posix-sigabrt NOPARSE self-abort; keep it out.
+        self.assertNotIn("'abort'", funcs_line)
         self.assertIn("_tsan_unsafe = frozenset(", src)
         self.assertIn("n not in _tsan_unsafe", src)
 


### PR DESCRIPTION
Two bugs in the `--tsan` race deduper, both surfaced while checking fleet-03's `tsanFRAME` bucket for false positives (all 10 were false positives).

## 1. `Previous atomic write` stanzas were dropped → fabricated `A | A` signatures

TSan capitalises the **first** access line (`Read of size ...`) but **lowercases the second, including the qualifier**: `Previous atomic write of size ...`. The `ACCESS` regex only accepted a capital `Atomic`, so that header never matched. `_parse_race` then found only one stanza, and the `if len(stanzas) < 2: stanzas.append(stanzas[0])` fallback **duplicated the first** — fabricating a symmetric `A | A` signature.

This hits precisely the **non-atomic-reader-vs-atomic-writer** shape, which is the most common race class the catalog tracks: **150 of fleet-03's 827 race dirs (18%)** were mis-parsed.

It also caused real mis-diagnoses. The catalog's `binarysort | binarysort` — which read as *two concurrent sorters* and never reproduced as such — is really `_Py_atomic_load_ptr | binarysort`: a reader's atomic load racing `binarysort`'s in-place write. That matches what shrinkray independently established (sort-vs-**read**).

**Fix:** accept `[Aa]tomic`.

## 2. `FRAMEWORK_FILES` matched all of `_threadmodule.c`, burying real races

`Modules/_threadmodule.c` also holds the **public `_thread` API**. Combined with (1), a real RLock race (`rlock_repr` = `RLock.__repr__`, a `tp_repr` slot) had both fabricated sites in `_threadmodule.c` and got labeled `tsanFRAME` — filed away as harness noise.

Evidence across fleets 01–03: the only `_threadmodule.c` functions that ever appear as **access-stanza sites** are the public RLock API (`rlock_repr` ×19, `_thread_RLock_acquire_impl` ×18, `_thread_RLock__release_save_impl` ×1). The thread-lifecycle functions appear only in thread-**creation** stacks, which never feed a signature. So the file-level match scored **10 false positives and 0 true positives**.

**Fix:** match the *function*, not the file — keep `thread_pthread.h` (pure platform bootstrap, no public API) and add an explicit `FRAMEWORK_FUNCS` set of lifecycle entry points (`thread_run`, `ThreadHandle_start`, `do_start_new_thread`, …) via a new `_is_framework()` helper.

This also corrects the old test fixture, which asserted that a race between `lock_PyThread_acquire_lock` and `lock_PyThread_release_lock` is framework noise. Those are public `_thread.lock` methods; a race between them is a genuine finding. The fixture now uses real lifecycle frames, and a new test pins the public-API case as **not** framework.

## Impact on the catalog

Catalog signatures were re-derived from evidence (re-parsing all 1248 dirs of fleets 01–03 both ways; 1:1 map, no ambiguity) in `devdanzin/cpython-tsan-findings@6f71184`. Two substantive corrections fell out, including a **real bug that was being suppressed**: the `bytearray___init__ | bytearray___init__` suppression ("concurrent `__init__`, out of scope per cpython#127192") was an artifact — those vehicles are truly `bytearray(shared_list)` reading the list while another thread appends, a shared-list reader face of TSAN-0013.

After this fix, all three fleets re-ingest clean (fleet-03: **0 new signature groups, 0 framework**).

## Tests

+4 tests (public-API-not-framework; `Previous atomic write` parsed; all 8 access-header variants match; plus the reworked fixture). **30 tsan tests OK**, full suite OK, `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)