### PR TITLE
process: run the fuzzed child in its own session and reap its whole process group

### DIFF
--- a/fusil/process/create.py
+++ b/fusil/process/create.py
@@ -1,5 +1,5 @@
 from errno import ENOENT
-from os import devnull, kill
+from os import devnull, getpgid, getpgrp, kill, killpg
 from os.path import basename
 from pwd import getpwuid
 from signal import SIGKILL
@@ -18,7 +18,29 @@ from fusil.project_agent import ProjectAgent
 DEFAULT_TIMEOUT = 10.0
 
 
-def terminateProcess(process):
+def killProcessGroup(pgid):
+    """SIGKILL every process in group ``pgid``. Returns True if the group still existed.
+
+    Refuses to signal our own process group: fusil would kill itself. That can only happen if
+    the child's ``setsid()`` did not take effect, in which case ``process_group`` is never set
+    (see ``CreateProcess.createProcess``) -- this is a second belt on the same braces.
+    """
+    if pgid is None or pgid == getpgrp():
+        return False
+    try:
+        killpg(pgid, SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False  # group already gone (or not ours to signal)
+    return True
+
+
+def terminateProcess(process, pgid=None):
+    """SIGKILL the child and, when its process group is known, every descendant with it.
+
+    SIGKILLing the child alone leaks its grandchildren: they are reparented to init and
+    survive for the lifetime of the fleet (see CreateProcess.terminate).
+    """
+    killProcessGroup(pgid)
     kill(process.pid, SIGKILL)
 
 
@@ -77,6 +99,7 @@ class CreateProcess(ProjectAgent):
     def init(self):
         self.score = None
         self.process = None
+        self.process_group = None
         self.timeout_reached = False
         self.status = None
         self.current_popen_args = None
@@ -148,6 +171,14 @@ class CreateProcess(ProjectAgent):
                 raise
         pid = self.process.pid
         self.info("Process identifier: %s" % pid)
+        # Remember the child's process group (created by start_new_session=True) so we can
+        # sweep its descendants later, even once the child itself is gone. Read it now: after
+        # the child is reaped, getpgid() no longer resolves.
+        try:
+            pgid = getpgid(pid)
+        except OSError:
+            pgid = None  # already gone; nothing to sweep
+        self.process_group = pgid if pgid != getpgrp() else None
         self.closeStreams()
         self.send("process_create", self)
 
@@ -190,6 +221,13 @@ class CreateProcess(ProjectAgent):
         self.stdout_file = self.createStdout()
         popen_args["stdout"] = self.stdout_file.fileno()
         popen_args["preexec_fn"] = self.prepareProcess
+        # Run the child in its own session/process group (setsid() before exec), so every
+        # descendant it spawns shares one pgid we can sweep on teardown. Without this we can
+        # only SIGKILL the direct child, and anything it forked (multiprocessing's forkserver
+        # and resource_tracker, pool workers, ...) is orphaned to init and leaks. It also
+        # detaches the child from our controlling terminal, so a Ctrl+C aimed at fusil no
+        # longer races us to the child -- we kill it ourselves during teardown.
+        popen_args["start_new_session"] = True
         return popen_args
 
     def createStdin(self):
@@ -282,16 +320,28 @@ class CreateProcess(ProjectAgent):
         # Check if process is still running or not
         if not self.process:
             return
-        if self.poll() is not None:
-            return
+        if self.poll() is None:
+            # Kill the process and wait for its exit status
+            self.warning("Terminate process %s" % self.process.pid)
+            self._terminate()
+            self.waitExit()
 
-        # Kill the process and wait for its exit status
-        self.warning("Terminate process %s" % self.process.pid)
-        self._terminate()
-        self.waitExit()
+        # Sweep whatever the child left behind. This must run even when the child already
+        # exited on its own -- for a fuzzer that is the COMMON case (it crashed), and it is
+        # exactly the case where nothing else kills its descendants: multiprocessing's
+        # forkserver and resource_tracker are started on demand and only shut down via the
+        # atexit handlers of a *clean* interpreter exit, so a crashed/SIGKILLed child strands
+        # them. They are then reparented to init and survive for the whole run.
+        self.reapProcessGroup()
+
+    def reapProcessGroup(self):
+        """SIGKILL any descendants of the child that outlived it (see terminate())."""
+        pgid, self.process_group = self.process_group, None
+        if killProcessGroup(pgid):
+            self.info("Killed leftover descendants in process group %s" % pgid)
 
     def _terminate(self):
-        terminateProcess(self.process)
+        terminateProcess(self.process, self.process_group)
 
     def waitExit(self):
         # Get the process exit status to avoid creation of a zombi process

--- a/tests/test_process_create.py
+++ b/tests/test_process_create.py
@@ -135,6 +135,53 @@ class TestTerminateProcess(unittest.TestCase):
             terminateProcess(SimpleNamespace(pid=4242))
         kill.assert_called_once_with(4242, create.SIGKILL)
 
+    def test_kills_process_group_before_pid(self):
+        # A known pgid must be swept too: SIGKILLing the child alone orphans its
+        # grandchildren (multiprocessing forkserver/resource_tracker, pool workers).
+        with patch.object(create, "kill") as kill, patch.object(create, "killpg") as killpg:
+            with patch.object(create, "getpgrp", return_value=1):
+                terminateProcess(SimpleNamespace(pid=4242), pgid=4242)
+        killpg.assert_called_once_with(4242, create.SIGKILL)
+        kill.assert_called_once_with(4242, create.SIGKILL)
+
+    def test_without_pgid_only_kills_pid(self):
+        with patch.object(create, "kill") as kill, patch.object(create, "killpg") as killpg:
+            terminateProcess(SimpleNamespace(pid=4242))
+        killpg.assert_not_called()
+        kill.assert_called_once_with(4242, create.SIGKILL)
+
+
+@unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")
+class TestKillProcessGroup(unittest.TestCase):
+    def test_kills_group(self):
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            self.assertTrue(create.killProcessGroup(4242))
+        killpg.assert_called_once_with(4242, create.SIGKILL)
+
+    def test_refuses_our_own_group(self):
+        # Signalling our own process group would SIGKILL fusil itself.
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=4242),
+        ):
+            self.assertFalse(create.killProcessGroup(4242))
+        killpg.assert_not_called()
+
+    def test_none_is_noop(self):
+        with patch.object(create, "killpg") as killpg:
+            self.assertFalse(create.killProcessGroup(None))
+        killpg.assert_not_called()
+
+    def test_group_already_gone_is_not_an_error(self):
+        with (
+            patch.object(create, "killpg", side_effect=ProcessLookupError),
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            self.assertFalse(create.killProcessGroup(4242))
+
 
 # =========================================================================== construction
 @unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")
@@ -164,6 +211,15 @@ class TestConstruction(unittest.TestCase):
         agent, _ = _make(arguments=["python"], name="p")
         self.assertEqual(agent.popen_args["stderr"], create.STDOUT)
         self.assertTrue(agent.popen_args["close_fds"])
+
+    def test_createPopenArguments_starts_a_new_session(self):
+        # setsid() in the child gives it (and every descendant it spawns) a private pgid,
+        # which is what makes the teardown sweep in terminate() possible.
+        agent, _ = _make(arguments=["python"], name="p")
+        agent.env.create = lambda: {}
+        agent.createStdin = lambda: None
+        agent.createStdout = lambda: SimpleNamespace(fileno=lambda: 1)
+        self.assertTrue(agent.createPopenArguments()["start_new_session"])
 
     def test_timeout_and_stdout_stored(self):
         agent, _ = _make(arguments=["python"], name="p", timeout=3.5, stdout="null")
@@ -677,9 +733,55 @@ class TestTerminate(unittest.TestCase):
     def test_underscore_terminate_calls_terminateProcess(self):
         agent, _ = _make(arguments=["python"], name="p")
         agent.process = _FakePopen(pid=321)
+        agent.process_group = 321
         with patch.object(create, "terminateProcess") as tp:
             agent._terminate()
-        tp.assert_called_once_with(agent.process)
+        tp.assert_called_once_with(agent.process, 321)
+
+    def test_already_exited_child_still_sweeps_its_process_group(self):
+        # THE leak: for a fuzzer the child usually dies on its own (it crashed), and
+        # multiprocessing's forkserver/resource_tracker only shut down via the atexit
+        # handlers of a *clean* exit -- so they survive, get reparented to init, and leak
+        # for the whole run. terminate() used to return early here and kill nothing.
+        agent, _ = _make(arguments=["python"], name="p")
+        agent.process = _FakePopen(pid=321, poll_status=-11)  # already dead (SIGSEGV)
+        agent.process_group = 321
+        agent._killed = False
+        agent._terminate = lambda: setattr(agent, "_killed", True)
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.terminate()
+        self.assertFalse(agent._killed)  # nothing to SIGKILL: it already exited
+        killpg.assert_called_once_with(321, create.SIGKILL)  # ...but the group is swept
+        self.assertIsNone(agent.process_group)
+
+    def test_running_child_is_killed_and_group_swept(self):
+        agent, _ = _make(arguments=["python"], name="p")
+        agent.process = _FakePopen(pid=321, poll_status=None)
+        agent.process_group = 321
+        agent._killed = False
+        agent._terminate = lambda: setattr(agent, "_killed", True)
+        agent.waitExit = lambda: None
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.terminate()
+        self.assertTrue(agent._killed)
+        killpg.assert_called_once_with(321, create.SIGKILL)
+
+    def test_reap_process_group_is_idempotent(self):
+        agent, _ = _make(arguments=["python"], name="p")
+        agent.process_group = 321
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.reapProcessGroup()
+            agent.reapProcessGroup()  # second sweep: pgid already consumed
+        killpg.assert_called_once_with(321, create.SIGKILL)
 
 
 # =========================================================================== waitExit


### PR DESCRIPTION
The fuzzed child's **grandchildren** were never killed, so they piled up as stray `python` processes owned by fusil.

Observed in a `--tsan` fleet — multiprocessing's `resource_tracker` and `forkserver` still alive **~8.5 minutes** after their session ended, reparented to init, their session directory already deleted, plus zombie workers parented to those forkservers:

```
python -c from multiprocessing.resource_tracker import main;main(3)          ppid=1  age 518s
python -c ...from multiprocessing.forkserver import main; main(3, 6, ...)    ppid=1  age 517s
   main_path: .../fusil-tsan_fleet_04/inst-06/python/session-68/source.py
```

## Two compounding causes

1. **`terminateProcess()` SIGKILLed the direct child only.** Anything the child forked — multiprocessing's forkserver and resource_tracker, `Pool` / `ProcessPoolExecutor` workers — is a *grandchild*, and was never signalled.
2. **`terminate()` returned early when `poll()` showed the child had already exited**, so nothing was killed *at all* in that path. For a fuzzer that is the common case (the child crashed) — and it is exactly the case that strands these daemons, because they only shut down via the atexit handlers of a **clean** interpreter exit.

Same symptom class as the old `fork()` problem (#205), but `TSAN_UNSAFE_CALLS` cannot help here: it filters `module_functions` **by name** (`fork`/`spawn*`/`exec*`) and never sees multiprocessing's or `concurrent.futures`' public API.

## Fix

At the **process-group** level rather than per-API, so it covers anything the child spawns:

- **`start_new_session=True`** on the Popen — `setsid()` before exec gives the child (and every descendant) a private pgid. It also detaches the child from our controlling terminal, so a Ctrl+C aimed at fusil no longer races us to it.
- **`killProcessGroup(pgid)` / `terminateProcess(process, pgid)`** — SIGKILL the whole group, guarded to never signal our own group (that would kill fusil itself).
- **`terminate()` restructured** so the group sweep always runs, including the already-exited path — the actual leak.

I deliberately did not blacklist `multiprocessing`/`concurrent.futures`: they are legitimate free-threading targets, and reaping the group keeps the coverage without the strays.

## Verification

Spawn a child that starts the daemons, kill it the old way vs the new way, count survivors:

| | spawned | survived |
|---|---|---|
| old (`kill` child pid only) | 2 | **2** |
| new (`start_new_session` + `killpg`) | 2 | **0** |

Same for `concurrent.futures.ProcessPoolExecutor` (3 workers + forkserver):

| | spawned | survived |
|---|---|---|
| old | 4 | **4** |
| new | 4 | **0** |

Confirmed live on a running fleet after restart: children now show `pgid == pid`, no orphans.

## Tests

+10 — group kill, refusing our own group, group-already-gone, pgid plumbed through `_terminate`, `start_new_session` set, and a regression test pinning that an **already-exited** child still gets its group swept. Suite **1088 → 1098**, `ruff check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)