### PR TITLE
process: reap the child's process group when it self-exits, not only on terminate()

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -95,7 +95,11 @@ see `doc/tsan-mode-plan.md`. Crash dirs self-label `…-warning_threadsanitizer_
 
 ```sh
 FUSIL_TSAN_DEDUP=../fusil/fusil/python/tsan_dedup.py \
-  python3 scripts/ingest.py <fleet-dir>/inst-*/python/*   # bucket by race signature; NEW ones need a report
+  python3 scripts/ingest.py '<fleet-dir>/inst-*/python*/*'  # bucket by race signature; NEW ones need a report
+# NB: `python*`, not `python` -- a restarted instance gets a FRESH project dir (python-2, python-3,
+# ...) beside the first one, so `inst-*/python/*` silently ingests only the pre-restart run. On one
+# restarted fleet that glob covered 155 of 1585 dirs (10%). Quote the pattern so ingest.py globs it
+# itself rather than the shell.
 # write reports/TSAN-NNNN-.../meta.json for each new signature, then:
 python3 scripts/gen_known_races.py                        # regenerate known_races.tsv; fleet restart picks it up
 ```

--- a/fusil/process/create.py
+++ b/fusil/process/create.py
@@ -274,6 +274,15 @@ class CreateProcess(ProjectAgent):
             self.renameSession(status)
             self.send("process_exit", self, status)
         self.status = status
+        # The child is gone. Sweep its process group NOW, while we still have it: a child that
+        # exits (or crashes) on its own is the common case, and it is exactly the case where
+        # nothing else kills the descendants it spawned (multiprocessing forkserver/resource_tracker,
+        # Pool / ProcessPoolExecutor workers), which only shut down via a *clean* interpreter exit.
+        # Doing it here rather than only in terminate() matters because clearProcess() below nulls
+        # self.process, after which terminate()/deinit()'s `if self.process` guards would skip the
+        # sweep entirely -- so without this, the group is only ever reaped for fusil-killed (timeout)
+        # sessions, and every self-exiting session leaks.
+        self.reapProcessGroup()
         self.clearProcess()
 
     def closeStreams(self):
@@ -383,6 +392,11 @@ class CreateProcess(ProjectAgent):
         if self.process:
             self.terminate()
             self.process = None
+        else:
+            # Child already exited on its own (processExited nulled self.process). That path
+            # already reaps the group, but sweep again as a backstop in case the exit was
+            # observed somewhere that did not -- reapProcessGroup is a no-op once consumed.
+            self.reapProcessGroup()
 
     def getScore(self):
         return self.score

--- a/tests/test_process_create.py
+++ b/tests/test_process_create.py
@@ -630,6 +630,36 @@ class TestPoll(unittest.TestCase):
         self.assertEqual(agent.status, 5)
         self.assertIsNone(agent.process)
 
+    def test_self_exit_reaps_process_group(self):
+        # THE leak: a child that exits on its own is reaped by poll() -> processExited, which
+        # nulls self.process. The group sweep must happen HERE, because terminate()/deinit() both
+        # gate on `if self.process` and would otherwise skip it -- so a self-exiting session (the
+        # common case) would never reap its descendants (multiprocessing forkserver/workers).
+        agent, _ = _make(arguments=["python"], name="p")
+        agent.process = _FakePopen(pid=1, poll_status=0)
+        agent.process_group = 321
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.poll()  # -> processExited -> reapProcessGroup
+        killpg.assert_called_once_with(321, create.SIGKILL)
+        self.assertIsNone(agent.process_group)  # consumed
+        self.assertIsNone(agent.process)
+
+    def test_deinit_after_self_exit_does_not_double_kill(self):
+        # After a self-exit already swept the group, deinit()'s backstop must be a no-op.
+        agent, _ = _make(arguments=["python"], name="p")
+        agent.process = _FakePopen(pid=1, poll_status=0)
+        agent.process_group = 321
+        with (
+            patch.object(create, "killpg") as killpg,
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.poll()  # self-exit -> reap (killpg once, process_group consumed)
+            agent.deinit()  # backstop -> reapProcessGroup is a no-op now
+        killpg.assert_called_once_with(321, create.SIGKILL)
+
 
 # =========================================================================== closeStreams
 @unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")


### PR DESCRIPTION
Follow-up to #208. That fix made `terminate()` sweep the fuzzed child's process group, but `terminate()` is almost never *reached* for a self-exiting child — so the leak came back.

## Root cause

```
child exits/crashes on its own
  → poll() → processExited() → clearProcess() → self.process = None
  → later, deinit():  `if self.process:`  is False → terminate()/reapProcessGroup() SKIPPED
```

`processExited` (called from `poll()` the moment fusil observes the exit) nulls `self.process`, and both `terminate()` and `deinit()` gate the sweep behind `if self.process`. So the group was only ever swept for sessions fusil **kills itself** (wall-clock timeout via `live()`). Every session whose child exits or crashes on its own — the common case for a fuzzer — skipped the sweep, and the descendants it spawned (multiprocessing `forkserver`/`resource_tracker`, `Pool`/`ProcessPoolExecutor` workers, which only shut down on a *clean* interpreter exit) reparented to init and leaked.

#208's regression test missed this because it called `terminate()` **directly** with `self.process` still set, bypassing the real `poll → processExited → (process=None) → deinit` order.

## Fix

Reap the group the moment the child exits, with a `deinit` backstop:
- `processExited()` calls `reapProcessGroup()` **before** `clearProcess()` nulls `self.process` — the child is gone, so any surviving descendants are orphans.
- `deinit()` sweeps when `self.process` is already `None`.

Both idempotent (`reapProcessGroup` consumes the pgid → no double-kill).

## Verification

- The group is captured correctly: `getpgid(pid) == pid`, **300/300** — the setsid-before-`getpgid` race can't fire because `fork_exec` synchronizes on `exec`, which is *after* the child's `setsid`.
- `killProcessGroup` does kill multiprocessing daemons end-to-end (2 spawned → 0 survive).
- **+2 regression tests** exercising the real self-exit flow (`poll()` → sweep) and the deinit backstop. Suite **1098 → 1100**, `ruff check` + `format --check` clean.

## Known residual (deferred)

`killpg` still cannot reach a descendant that `setsid()`s / daemonizes (it leaves the group). multiprocessing/`subprocess` workers do **not** setsid, so they're covered; a truly daemonizing library would escape. A subreaper (`prctl(PR_SET_CHILD_SUBREAPER)`) or a per-session cgroup would close that too — deferred until confirmed necessary.

## Also folded in

An unrelated fleet-doc fix: the ingest command in `fleet/README.md` globbed `inst-*/python/*`, which silently misses a restarted instance's fresh project dir (`python-2`, …); corrected to `inst-*/python*/*` (quoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)