### PR TITLE
oom_dedup: skip inlined _PyObject_GC_UNTRACK/_TRACK so OOM-0006 aborts fold

### DIFF
--- a/fusil/python/oom_dedup.py
+++ b/fusil/python/oom_dedup.py
@@ -345,12 +345,16 @@ _BT_SKIP = re.compile(
     r"|hook_fmalloc|hook_fcalloc|hook_frealloc|hook_ffree"
     r"|PyMem_Free|PyMem_RawFree|PyObject_Free|PyMem_Realloc|PyMem_RawRealloc|PyObject_Realloc"
     r"|tracemalloc_(raw_)?(alloc|calloc|realloc|free)"
-    # Inlined GC-bits readers (pycore_gc.h): when a bad/NULL object's ob_gc_bits is read they
-    # show as the innermost frame, masking the real .c caller (e.g. copy_lock_held_untracked =
-    # OOM-0044, a NULL-deref in the empty-dict copy assert under OOM). Analog of the
-    # refcount.h/object.h header skips below. NOT _PyObject_GC_TRACK/_UNTRACK (real sites, e.g.
-    # the OOM-0006 untrack), only the pure readers. Lockstep with catalog ingest.py NATIVE_SKIP.
-    r"|_PyObject_HAS_GC_BITS|_PyObject_GC_IS_TRACKED)$"
+    # Inlined GC helpers (pycore_gc.h): the ob_gc_bits READERS (_HAS_GC_BITS/_GC_IS_TRACKED)
+    # AND the TRACK/UNTRACK actions all show as the innermost frame when a bad/NULL or never-
+    # tracked object is processed under OOM, masking the real .c caller. Skip them all so the
+    # chain resolves to the actual site: copy_lock_held_untracked = OOM-0044 (empty-dict copy
+    # NULL-deref, via the readers); dictiter_dealloc = OOM-0006 (a never-tracked dict_itemiterator
+    # untracked on its constructor's OOM error path, via _PyObject_GC_UNTRACK). The catalog keys
+    # the real .c caller, never the inlined pycore_gc.h frame, so skipping the untrack is what
+    # lets OOM-0006's dictiter_dealloc func-key match instead of the crash reading as oomNEW.
+    # Analog of the refcount.h/object.h header skips below. Lockstep w/ catalog ingest.py NATIVE_SKIP.
+    r"|_PyObject_HAS_GC_BITS|_PyObject_GC_IS_TRACKED|_PyObject_GC_TRACK|_PyObject_GC_UNTRACK)$"
 )
 # Inlined refcount/atomic helpers live in these headers and show up as the innermost frame
 # of a "DECREF a freed object" segv -- skip them so the site is the real .c caller (e.g.

--- a/tests/python/test_oom_dedup.py
+++ b/tests/python/test_oom_dedup.py
@@ -501,6 +501,34 @@ ASAN_SEGV = "\n".join(
 )
 
 
+# A real OOM-0006 ABORT as captured in stdout: dictiter_new's OOM error path untracks a
+# never-tracked dict_itemiterator. The inlined _PyObject_GC_UNTRACK (pycore_gc.h) is the
+# innermost real frame and MASKS the true .c site dictiter_dealloc one frame down -- so unless
+# the untrack is skipped, the crash reads as oomNEW instead of folding to OOM-0006 (which the
+# catalog keys on dictiter_dealloc). Line numbers differ from the snapshot's (5620 vs 5532):
+# the cloud binary is a different commit, so the func-name match must carry it, not the line.
+ASAN_ABORT_OOM0006 = "\n".join(
+    [
+        "Objects/dictobject.c:5620: _PyObject_GC_UNTRACK: Assertion "
+        '"_PyObject_GC_IS_TRACKED(((PyObject*)(op)))" failed: object not tracked by the '
+        "garbage collector",
+        "Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed",
+        "    #8 0x615b242f9838 in _PyObject_AssertFailed "
+        "/home/danzin/projects/upstream_cpython/Objects/object.c:3278:5",
+        "    #9 0x615b242b59e8 in _PyObject_GC_UNTRACK "
+        "/home/danzin/projects/upstream_cpython/Include/internal/pycore_gc.h:254:5",
+        "    #10 0x615b242ba087 in dictiter_dealloc "
+        "/home/danzin/projects/upstream_cpython/Objects/dictobject.c:5620:5",
+        "    #11 0x615b242f8573 in _Py_Dealloc "
+        "/home/danzin/projects/upstream_cpython/Objects/object.c:3319:5",
+        "    #14 0x615b242b9982 in dictiter_new "
+        "/home/danzin/projects/upstream_cpython/Objects/dictobject.c:5604:5",
+        "    #16 0x615b241e8bc2 in PyObject_GetIter "
+        "/home/danzin/projects/upstream_cpython/Objects/abstract.c:2825:12",
+    ]
+)
+
+
 class TestNativeBacktrace(unittest.TestCase):
     """The fix: resolve a SEGV from the native backtrace ALREADY in stdout (ASan debug
     build), with no gdb re-run -- so a crash whose source.py would not reproduce under a
@@ -521,6 +549,20 @@ class TestNativeBacktrace(unittest.TestCase):
     def test_asan_segv_matches_known_without_gdb(self):
         # OOM-0006 is keyed on dictiter_dealloc in the snapshot; no resolver provided.
         keep, label = self._deduper().decide(ASAN_SEGV, source_path=None)
+        self.assertTrue(keep)
+        self.assertEqual(label, "OOM-0006")
+
+    def test_extract_native_skips_gc_untrack_returns_dictiter(self):
+        # The inlined _PyObject_GC_UNTRACK (pycore_gc.h) must be skipped so the innermost
+        # resolved site is the real .c caller dictiter_dealloc, not the untrack helper.
+        sites = oom_dedup.extract_native_sites(ASAN_ABORT_OOM0006)
+        self.assertEqual(sites[0], "dictiter_dealloc@Objects/dictobject.c:5620")
+        self.assertNotIn("_PyObject_GC_UNTRACK", " ".join(sites))
+
+    def test_asan_abort_untrack_folds_to_oom0006_not_new(self):
+        # Whole-crash: an OOM-0006 abort whose innermost frame is _PyObject_GC_UNTRACK folds to
+        # OOM-0006 (via dictiter_dealloc), not oomNEW -- the 321-vehicle oom_cloud dedup gap.
+        keep, label = self._deduper().decide(ASAN_ABORT_OOM0006, source_path=None)
         self.assertTrue(keep)
         self.assertEqual(label, "OOM-0006")
 


### PR DESCRIPTION
## Problem

An **OOM-0006** abort — `dictiter_new()`'s OOM error path untracks a never-tracked `dict_itemiterator` — symbolizes with the inlined `_PyObject_GC_UNTRACK` (`pycore_gc.h`) as the innermost real frame, **masking** the true `.c` site `dictiter_dealloc` one frame down. The catalog keys OOM-0006 on `dictiter_dealloc` (never on the inlined `pycore_gc.h` frame), so the crash resolved to the untrack helper and read as `oomNEW` instead of folding.

Found triaging an `oom_cloud` batch: **321 dirs** mislabelled `oomNEW` were all this one already-filed bug (python/cpython#152107).

## Fix

Add `_PyObject_GC_UNTRACK`/`_PyObject_GC_TRACK` to `_BT_SKIP` (alongside the existing `_HAS_GC_BITS`/`_GC_IS_TRACKED` readers) so the resolved chain reaches the real `.c` caller:
- `dictiter_dealloc` → OOM-0006
- `copy_lock_held_untracked` → OOM-0044 (also future-proofs its abort face)

## Safety

Nothing in the catalog keys on the untrack frame, so this regresses **no** dedup. Verified over the full `oom_cloud` corpus (monkeypatched): all 321 fold to OOM-0006 (known 879→1200), OOM-0044 stays 301 (no contamination), needs-gdb unchanged, nothing else moves. The exposed frame is a concrete dealloc function, not a generic trampoline, so none of the past "skip-exposed-a-trampoline → over-match" hazards apply.

+2 tests. Lockstep with the sibling catalog's `ingest.py` `NATIVE_SKIP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)