### PR TITLE
tsan: add shared-iterator and read-while-mutate ops to the stress op-mix

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -408,6 +408,28 @@ and the user didn't already pass it), logged as `TSan: forcing --no-numpy`. Veri
 a run with **no** `--no-numpy` flag now auto-suppresses numpy and still detects + labels the race.
 Test: `test_tsan_generation.py::test_enriched_op_mix_emitted`. Goldens unchanged (emitter gated).
 
+### Phase 3.1: shared-iterator + read-while-mutate ops (2026-07-18)
+
+Two op classes added after the `unicode_ascii_iter_next` find (cpython#153928) showed the op-mix
+never *shared an iterator across threads* — it built iterators (`iter(_obj)`) but discarded them,
+so the entire "concurrent `next()` on one iterator" surface was unreachable:
+
+- **(h) Shared-iterator races** — a pool of one live iterator per kind, each held in a 1-element
+  cell and shared *by reference* so every sibling worker advances the **same** cursor. Each
+  iteration does a few `next()`s and a periodic `repr()` (state read racing the concurrent
+  `next()`s). Covers the builtin iterator family (`str`/`bytes`/`list`/`tuple`/`dict`/`range` —
+  the non-atomic `it_index`/`it_seq` class) plus the stdlib C iterators from the sibling reports:
+  `struct.Struct.iter_unpack` (cpython#154013) and `itertools.count(10**18, 2)` in **big-int
+  "slow mode"** (cpython#153981). Finite iterators are rebuilt from their factory on
+  `StopIteration`; `count()` never exhausts.
+- **(i) Read-while-mutate on the shared container** — iterate/copy/sort the shared
+  `list`/`dict`/`set`/`bytearray` while sibling workers mutate it in (f): the non-atomic
+  reader-vs-writer class (`list` `Py_SIZE` + `binarysort`/`list.sort` = TSAN-0013/0014,
+  `bytes_join`, dict/odict/set iter-vs-resize = TSAN-0015/0026).
+
+Tests: `test_tsan_generation.py::{test_shared_iterator_op_emitted,test_read_while_mutate_op_emitted}`.
+Emitter still gated (non-`--tsan` output unchanged).
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -743,6 +743,37 @@ class WritePythonCode(WriteCode):
         self.write(0, "if not _tsan_shared:")
         with self.indented():
             self.write(0, "_tsan_shared = [fuzz_target_module]")
+        # Shared ITERATORS: one live iterator per kind, held in a 1-element cell and shared BY
+        # REFERENCE so sibling workers advance the SAME cursor. Concurrent next()/repr() on one
+        # iterator is the shared-iterator-state race class -- str/bytes/list/tuple/dict/range
+        # iterators (unicode_ascii_iter_next it_index/it_seq, cpython#153928), struct.iter_unpack
+        # (cpython#154013), and itertools.count in big-int "slow mode" (cpython#153981). The
+        # factories rebuild an exhausted iterator (the finite ones); count() never exhausts.
+        self.write_block(
+            0,
+            """
+            _tsan_iter_factories = [
+                lambda: iter("A" * 4096),
+                lambda: iter(b"A" * 4096),
+                lambda: iter(list(range(4096))),
+                lambda: iter(tuple(range(4096))),
+                lambda: iter({_k: _k for _k in range(2048)}),
+                lambda: iter(range(4096)),
+            ]
+            try:
+                import itertools as _tsan_itertools
+                _tsan_iter_factories.append(lambda: _tsan_itertools.count(10 ** 18, 2))
+            except Exception:
+                pass
+            try:
+                import struct as _tsan_struct
+                _tsan_iter_factories.append(
+                    lambda: _tsan_struct.Struct("i").iter_unpack(bytes(4 * 4096)))
+            except Exception:
+                pass
+            _tsan_iters = [[_f()] for _f in _tsan_iter_factories]
+            """,
+        )
         self.write(0, "_WORKERS_PER_OBJ = %d" % workers_per_obj)
         self.write(0, "_ITERS = %d" % iters)
         self.write(0, "_tsan_total = len(_tsan_shared) * _WORKERS_PER_OBJ")
@@ -815,6 +846,36 @@ class WritePythonCode(WriteCode):
                             _tsan_gc.collect()
                         except Exception:
                             pass
+                    # (h) shared-iterator races: advance ONE shared iterator's cursor from every
+                    # sibling worker (non-atomic it_index / iternext state) and repr() it while
+                    # others advance it (state read racing next()). Targets the whole builtin/
+                    # stdlib iterator family -- cpython#153928 / #154013 / #153981 (count slow mode).
+                    _cell = _tsan_iters[(_wid + _idx) % len(_tsan_iters)]
+                    try:
+                        _it = _cell[0]
+                        for _ in range(4):
+                            next(_it)
+                        if _i % 8 == 0:
+                            repr(_it)
+                    except StopIteration:
+                        _cell[0] = _tsan_iter_factories[(_wid + _idx) % len(_tsan_iter_factories)]()
+                    except Exception:
+                        pass
+                    # (i) read-while-mutate on the shared container: iterate / copy / sort it while
+                    # sibling workers mutate it in (f) -- the non-atomic reader-vs-writer class
+                    # (list Py_SIZE + binarysort/list.sort, bytes_join, dict/odict/set iter-vs-resize).
+                    try:
+                        if isinstance(_bag, list):
+                            sorted(_bag)
+                            _bag[:]
+                        elif isinstance(_bag, dict):
+                            list(_bag.items())
+                        elif isinstance(_bag, set):
+                            list(_bag)
+                        elif isinstance(_bag, bytearray):
+                            bytes(_bag)
+                    except Exception:
+                        pass
             """,
         )
         self.write_block(

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -121,6 +121,24 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("setattr(_obj,", src)  # managed-dict / attribute churn
         self.assertIn("isinstance(_bag,", src)  # shared-container mutation
 
+    def test_shared_iterator_op_emitted(self):
+        # (h) shared-iterator races: one iterator advanced by every sibling worker, plus a
+        # repr() reading its state -- the class behind cpython#153928/#154013/#153981.
+        src = _generate_tsan()
+        self.assertIn("_tsan_iter_factories", src)
+        self.assertIn("_tsan_iters = [[_f()] for _f in _tsan_iter_factories]", src)
+        self.assertIn("next(_it)", src)  # concurrent cursor advance on the shared iterator
+        self.assertIn("repr(_it)", src)  # state read racing the concurrent next()
+        # covers the builtin iterator family + the stdlib C iterators from the linked issues
+        self.assertIn("iter_unpack", src)  # struct (cpython#154013)
+        self.assertIn("_tsan_itertools.count(10 ** 18, 2)", src)  # count slow mode (cpython#153981)
+
+    def test_read_while_mutate_op_emitted(self):
+        # (i) iterate / copy / sort the shared container while siblings mutate it in (f).
+        src = _generate_tsan()
+        self.assertIn("sorted(_bag)", src)  # concurrent sort of a shared list (binarysort)
+        self.assertIn("list(_bag.items())", src)  # dict iter-vs-resize
+
     def test_shares_objects_and_module_functions(self):
         src = _generate_tsan()
         # a module class is instantiated into the shared pool, plus the module itself.


### PR DESCRIPTION
## Why

The `--tsan` op-mix hammered shared objects and shared containers but **never shared an *iterator* across threads** — it built iterators (`iter(_obj)`) and immediately discarded them, so the entire "concurrent `next()` on one iterator" surface was unreachable. That's exactly the surface where the `unicode_ascii_iter_next` race lives (python/cpython#153928, which this fuzzer's approach found), and the sibling reports show more of the same class:
- **python/cpython#154013** — `struct.Struct.iter_unpack` iterator not memory-safe
- **python/cpython#153981** — `itertools.count` repr-vs-next UAF, reached in **big-int "slow mode"**

## What

Two new per-iteration ops in the worker:

**(h) Shared-iterator races** — a pool of one live iterator per kind, each in a 1-element cell shared *by reference* so every sibling worker advances the **same** cursor, plus a periodic `repr()` reading state while others advance it. Covers the builtin iterator family (`str`/`bytes`/`list`/`tuple`/`dict`/`range` — the non-atomic `it_index`/`it_seq` class), `struct.Struct.iter_unpack`, and `itertools.count(10**18, 2)` slow mode. Finite iterators are rebuilt from their factory on `StopIteration`; `count()` never exhausts.

**(i) Read-while-mutate** — iterate/copy/sort the shared `list`/`dict`/`set`/`bytearray` while siblings mutate it in (f): the non-atomic reader-vs-writer class (`list` `Py_SIZE` + `binarysort`/`list.sort` = TSAN-0013/0014, `bytes_join`, dict/odict/set iter-vs-resize = TSAN-0015/0026).

## Tests / safety

- +2 tests: `test_shared_iterator_op_emitted`, `test_read_while_mutate_op_emitted`; existing `test_emitted_script_is_valid_python` covers compilation. All TSan + golden + generation tests pass.
- Emitter stays gated behind `--tsan`, so non-`--tsan` output is unchanged (goldens untouched).
- ruff `check` + `format --check` clean.
- Doc: Phase 3.1 in `doc/tsan-mode-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)