### PR TITLE
tsan: Phase 4 plan + Slice A (complementary worker roles)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -430,6 +430,84 @@ so the entire "concurrent `next()` on one iterator" surface was unreachable:
 Tests: `test_tsan_generation.py::{test_shared_iterator_op_emitted,test_read_while_mutate_op_emitted}`.
 Emitter still gated (non-`--tsan` output unchanged).
 
+## Phase 4 (planned): target-object coverage + provenance + extension dedup
+
+**Motivation.** Phase 3.1 proved the op-mix finds *builtin* races (TSAN-0037, the bytes iterator)
+because the shared pool is mostly builtin containers + bare `Class()` instances. The campaign's
+actual value is races in the *target C extension* (cereggii/h5py/…). Phase 4 points the same
+machinery at the extension's own objects, attributes races correctly, and makes extension-source
+races dedupable. Derived from a Codex review (2026-07-18); **operation *profiles* are deliberately
+excluded** (parked — see Open questions) — Phase 4 keeps the single always-on op-mix and enriches
+it in place.
+
+### Slice A — complementary worker roles (in-place, no profiles)
+
+Today every `_tsan_worker` runs the identical op-mix; identical workers under-produce the
+reader-vs-writer overlap the interesting races need (next-vs-repr found the `count` bug #153981;
+mutate-vs-iterate is the whole read-while-mutate class). Assign a **role by `_wid`** so siblings
+sharing one `_idx`/resource do *complementary* ops: iterator group → some `next()` (advance),
+others `repr()`/`len()`/`list()` (read cursor); container group → some mutate, others sort/iterate/
+copy; object group → some read-churn, others attr-dict/weakref/GC mutation. Keep the single start
+barrier (round-level re-sync noted as an optional knob, not built). File: `write_python_code.py`
+only. Tests: role markers emitted + `compile()` + FT smoke-run. Risk: low (emitter-only, gated).
+
+### Slice B — provenance / attribution
+
+Fixes the real misattribution: a builtin race gets stamped with whatever module the session picked.
+The parent knows the full context at generation time → emit a stdout marker into the generated
+script (`[TSAN] provenance module=… shared=<factory-descriptors> roles=<map> ops=<…> seed=<N>` +
+a `[TSAN-MANIFEST] {json}` line) so it lands in every crash dir's stdout, and record the op-family /
+shared-object *kind* per session in `fusil_stats.json` (`stats_agent.py`) so `fleet report` shows
+iterator-race vs target-object-race distribution. Files: `write_python_code.py`, `stats_agent.py`,
+a thread-through in `python_source.py`. Risk: low (additive output + one stats field).
+
+### Slice C — better target objects (+ extension-object iterators)
+
+Replace the `_tsan_shared` builder (currently `sample(module_classes)` instances + module) with a
+set of **guarded factories**, recording which succeed (feeds Slice B):
+1. splice the already-discovered-but-unused `self.module_objects` into the pool;
+2. instantiate `module_classes` with args from the existing `ArgumentGenerator` (guarded), not just
+   `Class()`;
+3. a new `PluginManager` hook (`add_tsan_shared_factory` / `get_tsan_shared_factories`) so
+   cereggii/h5py plugins contribute target-specific shared objects (e.g. `AtomicDict()`);
+4. module fallback (keep).
+
+**Extension-object iterators (folded in):** for each object factory, also register wrapped variants
+`lambda: iter(factory())` (and `lambda: iter(factory(range(X)))` where a sequence-ish arg fits) into
+the op-(h) iterator pool — pointing the shared-iterator machinery at the extension's own
+`tp_iternext`. Everything guarded, so non-iterable/failed factories drop out. Files:
+`write_python_code.py`, `plugin_manager.py`, `doc/plugins.md`. Using the hook from the sibling
+plugins is a follow-up. Risk: medium — keep factories guarded; `--tsan` gate intact.
+
+### Slice D — external C-extension source roots (strictly additive; contract-touching)
+
+Without it, extension `.so` frames are dropped (`CPY_SRC` only matches CPython dirs) → `noparse`.
+Add an **optional** `source_roots=None` param to `parse_report`/`_frame_site` (`tsan_dedup.py`):
+default → current behavior byte-for-byte (CPython matched first, all 119 catalog sigs unchanged);
+otherwise normalize a non-CPython frame to its path relative to a matching root (`/…/cereggii` →
+`src/atomic_dict.c:func`). New repeatable `--tsan-source-root` feeds the in-loop dedup. Sibling
+catalog `ingest.py` reads roots from env/config and passes them through, plus CPython-vs-ext /
+ext-vs-ext signature tests. **Guardrail (mandatory):** `test_tsan_dedup` + re-ingest fleet-06 →
+119 CPython sigs identical. Risk: medium (the cross-repo contract) — additive-only + the re-ingest
+check.
+
+### Slice E — weird subclasses derived from extension classes (later / optional)
+
+Wire the `tricky_weird` weird-class machinery to derive hostile subclasses from *discovered
+extension bases* and share instances — the hostile-dunder-under-concurrency angle that turned up
+cereggii's `__eq__`-raises-during-concurrent-store bug. **Deferred** because: subclassing is gated on
+`Py_TPFLAGS_BASETYPE` (only a subset of C types allow it — guarded, lower/target-dependent yield);
+it's a bigger integration than a factory variant; and it can surface the weird class's *own*
+Python-level races (noise). Gate on subclassability; do after A–D land and lean on Slice B/D to keep
+its output attributable and dedupable.
+
+### Order & verification
+
+**A → B → C → D** (A/B low-risk quick wins; C is the payoff; D independent but needs the catalog in
+lockstep), E later. After each slice: full suite, `test_tsan_generation` + `test_tsan_dedup`,
+non-`--tsan` golden check (untouched), `ruff check` + `ruff format --check`; for C/D a real
+emitted-script smoke run + a fleet re-ingest showing **0 unexpected new signatures**.
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -699,7 +699,7 @@ class WritePythonCode(WriteCode):
         a race. The worker is type-agnostic (introspects `dir(obj)` at runtime) so one emitted
         body drives any shared object.
         """
-        from random import sample
+        from random import randint, sample
 
         workers_per_obj = max(2, self.options.tsan_threads)
         iters = max(1, self.options.tsan_iterations)
@@ -716,6 +716,7 @@ class WritePythonCode(WriteCode):
         self.write(0, "import threading as _tsan_threading")
         self.write(0, "import gc as _tsan_gc")
         self.write(0, "import weakref as _tsan_weakref")
+        self.write(0, "import operator as _tsan_operator")
         self.write_print_to_stderr(0, '"[TSAN] entering concurrency-stress region"')
         # Free-threading is mandatory: without it the whole region is GIL-serialised noise.
         self.write(0, 'if getattr(sys, "_is_gil_enabled", lambda: True)():')
@@ -776,6 +777,10 @@ class WritePythonCode(WriteCode):
         )
         self.write(0, "_WORKERS_PER_OBJ = %d" % workers_per_obj)
         self.write(0, "_ITERS = %d" % iters)
+        # Per-session rotation of which shared iterator each worker GROUP shares, so all workers
+        # on one _idx collide on the SAME iterator (roles below race it) while different sessions
+        # cover different iterator kinds. Constant across workers -> sharing is preserved.
+        self.write(0, "_ITER_OFF = %d" % randint(0, 7))
         self.write(0, "_tsan_total = len(_tsan_shared) * _WORKERS_PER_OBJ")
         self.write(0, "_tsan_barrier = _tsan_threading.Barrier(_tsan_total)")
         self.write_block(
@@ -784,98 +789,113 @@ class WritePythonCode(WriteCode):
             def _tsan_worker(_idx, _wid):
                 _obj = _tsan_shared[_idx]
                 _names = [n for n in dir(_obj) if not n.startswith("_") and n not in _tsan_unsafe]
-                # one shared mutable container this worker (and its siblings on _idx) also hammers
+                # This worker's GROUP (every _wid on this _idx) shares ONE container and ONE
+                # iterator, so the complementary roles below race the SAME resource.
                 _bag = _tsan_shared_args[_idx % len(_tsan_shared_args)]
+                _cell = _tsan_iters[(_idx + _ITER_OFF) % len(_tsan_iters)]
+                # Role by _wid: readers (_role != 1) inspect/iterate/read; writers (_role != 0)
+                # mutate/advance; _role == 2 does both. With >=2 workers per object both sides are
+                # present, so a reader always races a writer on the object / container / iterator.
+                _role = _wid % 3
                 _tsan_barrier.wait()
                 for _i in range(_ITERS):
-                    # (a) dunder / read churn on the shared object
-                    for _op in (repr, hash, list, len, bool, iter, str):
-                        try:
-                            _op(_obj)
-                        except Exception:
-                            pass
-                    # (b) a method call with shared (mutable) arguments
-                    if _names:
+                    if _role != 1:
+                        # (a) reader: dunder / read churn on the shared object
+                        for _op in (repr, hash, list, len, bool, iter, str):
+                            try:
+                                _op(_obj)
+                            except Exception:
+                                pass
+                    if _role != 0 and _names:
+                        # (b) writer: a method call with shared (mutable) arguments
                         try:
                             _m = getattr(_obj, _names[(_wid + _i) % len(_names)])
                             if callable(_m):
                                 _m(*_tsan_shared_args[: (_i % 3)])
                         except Exception:
                             pass
-                    # (c) a module function with the shared object as an argument
-                    if _tsan_funcs:
+                    if _role != 0 and _tsan_funcs:
+                        # (c) writer: a module function with the shared object as an argument
                         try:
                             getattr(fuzz_target_module,
                                     _tsan_funcs[(_wid + _i) % len(_tsan_funcs)])(_obj)
                         except Exception:
                             pass
-                    # (d) attribute-dict churn: concurrent __dict__ materialise/mutate on one
-                    # shared instance (the managed-dict race class -- e.g. OOM-0023/set_keys,
-                    # the deferred-refcount corruption dpdani's cereggii hit).
+                    # (d) attribute-dict race: writers setattr/delattr, readers getattr -- concurrent
+                    # __dict__ materialise/mutate vs read (managed-dict class: OOM-0023/set_keys, the
+                    # deferred-refcount corruption dpdani's cereggii hit).
                     try:
-                        setattr(_obj, "_tsan_a%d" % (_i % 4), _i)
-                        getattr(_obj, "_tsan_a%d" % (_wid % 4), None)
-                        if _i % 8 == 0:
-                            delattr(_obj, "_tsan_a%d" % (_i % 4))
+                        if _role != 0:
+                            setattr(_obj, "_tsan_a%d" % (_i % 4), _i)
+                            if _i % 8 == 0:
+                                delattr(_obj, "_tsan_a%d" % (_i % 4))
+                        if _role != 1:
+                            getattr(_obj, "_tsan_a%d" % (_wid % 4), None)
                     except Exception:
                         pass
-                    # (e) weakref churn: concurrent weakref creation/clear on the shared object
+                    # (e) weakref churn: concurrent weakref creation on the shared object (all roles).
                     try:
                         _tsan_weakref.ref(_obj)
                     except Exception:
                         pass
-                    # (f) shared-container mutation: hammer ONE container from every sibling worker
-                    try:
-                        if isinstance(_bag, list):
-                            _bag.append(_i)
-                            _bag[:1]
-                        elif isinstance(_bag, dict):
-                            _bag[_wid] = _i
-                            _bag.get(_i)
-                        elif isinstance(_bag, set):
-                            _bag.add(_wid)
-                            _bag.discard(_i)
-                        elif isinstance(_bag, bytearray):
-                            _bag.append(_i & 0xFF)
-                    except Exception:
-                        pass
-                    # (g) concurrent GC while all the above churns refcounts + containers
-                    # (concurrent collection is itself a rich FT-race surface).
-                    if _i % 16 == 0:
+                    if _role != 0:
+                        # (f) writer: hammer ONE shared container from every writer in the group
+                        try:
+                            if isinstance(_bag, list):
+                                _bag.append(_i)
+                                _bag[:1]
+                            elif isinstance(_bag, dict):
+                                _bag[_wid] = _i
+                                _bag.get(_i)
+                            elif isinstance(_bag, set):
+                                _bag.add(_wid)
+                                _bag.discard(_i)
+                            elif isinstance(_bag, bytearray):
+                                _bag.append(_i & 0xFF)
+                        except Exception:
+                            pass
+                    if _role != 1 and _i % 16 == 0:
+                        # (g) reader-side concurrent GC while writers churn refcounts + containers.
                         try:
                             _tsan_gc.collect()
                         except Exception:
                             pass
-                    # (h) shared-iterator races: advance ONE shared iterator's cursor from every
-                    # sibling worker (non-atomic it_index / iternext state) and repr() it while
-                    # others advance it (state read racing next()). Targets the whole builtin/
-                    # stdlib iterator family -- cpython#153928 / #154013 / #153981 (count slow mode).
-                    _cell = _tsan_iters[(_wid + _idx) % len(_tsan_iters)]
+                    # (h) shared-iterator race: writers advance the group's ONE iterator (next),
+                    # readers read its cursor state (repr for count slow-mode; length_hint reads
+                    # it_index) while it is advanced -- non-atomic it_index / iternext / it_seq
+                    # (cpython#153928 bytes/str, #154013 struct, #153981 count).
                     try:
                         _it = _cell[0]
-                        for _ in range(4):
-                            next(_it)
-                        if _i % 8 == 0:
+                        if _role != 0:
+                            for _ in range(4):
+                                next(_it)
+                        if _role != 1:
                             repr(_it)
+                            try:
+                                _tsan_operator.length_hint(_it, 0)
+                            except Exception:
+                                pass
                     except StopIteration:
-                        _cell[0] = _tsan_iter_factories[(_wid + _idx) % len(_tsan_iter_factories)]()
+                        _cell[0] = _tsan_iter_factories[
+                            (_idx + _ITER_OFF) % len(_tsan_iter_factories)]()
                     except Exception:
                         pass
-                    # (i) read-while-mutate on the shared container: iterate / copy / sort it while
-                    # sibling workers mutate it in (f) -- the non-atomic reader-vs-writer class
-                    # (list Py_SIZE + binarysort/list.sort, bytes_join, dict/odict/set iter-vs-resize).
-                    try:
-                        if isinstance(_bag, list):
-                            sorted(_bag)
-                            _bag[:]
-                        elif isinstance(_bag, dict):
-                            list(_bag.items())
-                        elif isinstance(_bag, set):
-                            list(_bag)
-                        elif isinstance(_bag, bytearray):
-                            bytes(_bag)
-                    except Exception:
-                        pass
+                    if _role != 1:
+                        # (i) reader: iterate / copy / sort the shared container while writers
+                        # mutate it in (f) -- the non-atomic reader-vs-writer class (list Py_SIZE +
+                        # binarysort/list.sort, bytes_join, dict/odict/set iter-vs-resize).
+                        try:
+                            if isinstance(_bag, list):
+                                sorted(_bag)
+                                _bag[:]
+                            elif isinstance(_bag, dict):
+                                list(_bag.items())
+                            elif isinstance(_bag, set):
+                                list(_bag)
+                            elif isinstance(_bag, bytearray):
+                                bytes(_bag)
+                        except Exception:
+                            pass
             """,
         )
         self.write_block(

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -139,6 +139,18 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("sorted(_bag)", src)  # concurrent sort of a shared list (binarysort)
         self.assertIn("list(_bag.items())", src)  # dict iter-vs-resize
 
+    def test_worker_roles_emitted(self):
+        # Slice A: workers take complementary reader/writer roles by _wid so a reader always
+        # races a writer on the SAME shared object / container / iterator (per-group sharing).
+        src = _generate_tsan()
+        self.assertIn("_role = _wid % 3", src)
+        self.assertIn("if _role != 1:", src)  # reader-gated ops (read-churn, iterate, length_hint)
+        self.assertIn("if _role != 0:", src)  # writer-gated ops (mutate, advance)
+        # the group shares ONE iterator (rotated per session) so roles collide on it
+        self.assertIn("_ITER_OFF =", src)
+        self.assertIn("_cell = _tsan_iters[(_idx + _ITER_OFF) % len(_tsan_iters)]", src)
+        self.assertIn("_tsan_operator.length_hint(_it, 0)", src)  # non-advancing it_index read
+
     def test_shares_objects_and_module_functions(self):
         src = _generate_tsan()
         # a module class is instantiated into the shared pool, plus the module itself.


### PR DESCRIPTION
## Phase 4 plan (doc)

Adds a **Phase 4** section to `doc/tsan-mode-plan.md`: target-object coverage + provenance + extension dedup, as five slices (A–E). Operation **profiles are deliberately excluded** (parked). Extension-object iterators are folded into Slice C; weird-subclass-of-extension is Slice E (later).

## Slice A — complementary worker roles

The op-mix workers were all identical, which under-produces the reader-vs-writer overlap the races need (next-vs-repr found #153981; mutate-vs-iterate is the read-while-mutate class).

- Each worker takes a **role by `_wid`**: readers (`_role != 1`) inspect/iterate/read; writers (`_role != 0`) mutate/advance; `_role == 2` does both. With ≥2 workers per object both sides are present, so a reader always races a writer.
- Each worker **group** (all `_wid` on one `_idx`) now shares **one** container and **one** iterator, so the roles collide on the *same* resource. The shared iterator is rotated per session (`_ITER_OFF`) so sessions cover different kinds while sharing is preserved.
- Reader side adds a non-advancing `operator.length_hint(_it, 0)` read of `it_index` alongside `repr()` (the count slow-mode face).

Emitter stays `--tsan`-gated → non-`--tsan` output and goldens unchanged.

## Verification

- `+test_worker_roles_emitted`; full suite **1104 → 1105**, all pass.
- `ruff check` + `ruff format --check` clean.
- Emitted script `compile()`s; role logic runtime-exercised across roles 0/1/2 and both groups (per-group cell + `length_hint` work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)