### PR TITLE
tsan: Slice B -- provenance/attribution for the concurrency-stress region

### DIFF
--- a/fusil/python/fleet_report.py
+++ b/fusil/python/fleet_report.py
@@ -221,6 +221,7 @@ def collect_instance(inst_dir: str, *, now=None, systemd=True) -> dict:
         "by_kind": by_kind,
         "by_module_crash": by_module_crash,
         "modules": merged.get("modules", {}),
+        "tsan_kinds": merged.get("tsan_kinds", {}),
         "failed_imports": failed_imports,
         "mem_current": _int_or_none(sysd.get("MemoryCurrent")),
         "mem_peak": _int_or_none(sysd.get("MemoryPeak")),
@@ -271,6 +272,7 @@ def aggregate_campaign(reports: list[dict], *, now=None) -> dict:
         "by_kind": {},
         "by_module_crash": {},
         "modules": {},  # summed per-module {hits,crashes,timeouts} across instances
+        "tsan_kinds": {},  # summed --tsan shared-object composition across instances
         "started_at": None,
     }
     for r in reports:
@@ -278,6 +280,7 @@ def aggregate_campaign(reports: list[dict], *, now=None) -> dict:
             (r["by_label"], agg["by_label"]),
             (r["by_kind"], agg["by_kind"]),
             (r["by_module_crash"], agg["by_module_crash"]),
+            (r.get("tsan_kinds", {}), agg["tsan_kinds"]),
         ):
             for key, val in src.items():
                 dst[key] = dst.get(key, 0) + val
@@ -398,6 +401,8 @@ def render_instance(r: dict) -> str:
         % (", ".join("%s(%d)" % (m, c) for m, c in _top(r["by_module_crash"], 8)) or "(none)")
     )
     L.append("crash-rate (c/hits): %s" % _rate_str(r["modules"]))
+    if r.get("tsan_kinds"):
+        L.append("tsan shared-obj    : %s" % _taxo(r["tsan_kinds"]))
     if r["failed_imports"]:
         L.append(
             "failed imports     : %s"
@@ -474,6 +479,8 @@ def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]
         % (", ".join("%s(%d)" % (m, c) for m, c in _top(agg["by_module_crash"], 10)) or "(none)")
     )
     L.append("highest crash-rate    : %s" % _rate_str(agg.get("modules", {})))
+    if agg.get("tsan_kinds"):
+        L.append("tsan shared-obj       : %s" % _taxo(agg["tsan_kinds"]))
     L.append("-" * 84)
     if flags:
         L.append("HEALTH: %d flag(s)" % len(flags))

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -33,6 +33,9 @@ class PythonSource(ProjectAgent):
         ProjectAgent.__init__(self, project, "python_source")
         self.module: ModuleType | None = None
         self.module_name = ""
+        # Slice B: the --tsan shared-object composition of the last-generated session, read back
+        # by StatsAgent for per-session attribution (None outside --tsan). Set in on_session_start.
+        self.tsan_shared_kind: str | None = None
         self.write: WritePythonCode | None = None
         self.filename = ""
         self.options = options
@@ -198,6 +201,9 @@ class PythonSource(ProjectAgent):
         # successful loadModule this is a WritePythonCode (or an injected test double), never None.
         assert self.write is not None
         self.write.generate_fuzzing_script()
+        # Slice B: expose this session's --tsan shared-object composition for StatsAgent to
+        # attribute (None outside --tsan, where the emitter never set it).
+        self.tsan_shared_kind = getattr(self.write, "tsan_shared_kind", None)
         self.send("python_source", self.filename)
 
         # unload new modules

--- a/fusil/python/session_stats.py
+++ b/fusil/python/session_stats.py
@@ -23,6 +23,10 @@ Sidecar schema (v1)::
       "modules": {                # per-target-module breakdown
         "_blake2": {"hits": 15, "crashes": 3, "timeouts": 0},
         ...
+      },
+      "tsan_kinds": {             # --tsan sessions by shared-object composition (Slice B)
+        "target-objects": 900,   # shared real target-module instances
+        "module-only": 100       # only the module object was shareable
       }
     }
 """
@@ -64,6 +68,8 @@ class SessionStats:
         self.cpu_load_kills = 0
         # module name -> {"hits": int, "crashes": int, "timeouts": int}
         self.modules: dict[str, dict[str, int]] = {}
+        # --tsan shared-object composition -> count (Slice B). Empty for non-tsan runs.
+        self.tsan_kinds: dict[str, int] = {}
 
     def record(
         self,
@@ -72,6 +78,7 @@ class SessionStats:
         crash: bool = False,
         timeout: bool = False,
         cpu_load: bool = False,
+        tsan_kind: str | None = None,
     ) -> None:
         """Fold one finished session into the counters."""
         self.sessions += 1
@@ -81,6 +88,8 @@ class SessionStats:
             self.timeouts += 1
         if cpu_load:
             self.cpu_load_kills += 1
+        if tsan_kind:
+            self.tsan_kinds[tsan_kind] = self.tsan_kinds.get(tsan_kind, 0) + 1
         # ``module`` can legitimately be None very early (before the first module loads);
         # bucket those under "?" rather than dropping the session from the module view.
         key = module or "?"
@@ -108,6 +117,7 @@ class SessionStats:
             "timeouts": self.timeouts,
             "cpu_load_kills": self.cpu_load_kills,
             "modules": self.modules,
+            "tsan_kinds": self.tsan_kinds,
         }
 
     def write(self, path: str) -> None:
@@ -137,6 +147,7 @@ class SessionStats:
             "timeouts": 0,
             "cpu_load_kills": 0,
             "modules": {},
+            "tsan_kinds": {},
             "started_at": None,
             "updated_at": None,
             "runs": 0,
@@ -151,6 +162,8 @@ class SessionStats:
                 acc = out["modules"].setdefault(name, {"hits": 0, "crashes": 0, "timeouts": 0})
                 for field in ("hits", "crashes", "timeouts"):
                     acc[field] += int(bucket.get(field, 0) or 0)
+            for kind, count in (d.get("tsan_kinds") or {}).items():
+                out["tsan_kinds"][kind] = out["tsan_kinds"].get(kind, 0) + int(count or 0)
             started = d.get("started_at")
             if started is not None and (out["started_at"] is None or started < out["started_at"]):
                 out["started_at"] = started

--- a/fusil/python/stats_agent.py
+++ b/fusil/python/stats_agent.py
@@ -62,11 +62,15 @@ class StatsAgent(ProjectAgent):
         success = getattr(project, "success_score", 0.5) if project else 0.5
         crash = score is not None and score >= success
         module = getattr(self.source, "module_name", None)
+        # Slice B: the --tsan shared-object composition of this session (None outside --tsan),
+        # so the sidecar/fleet report can show the target-object vs module-only distribution.
+        tsan_kind = getattr(self.source, "tsan_shared_kind", None)
         self.stats.record(
             module,
             crash=crash,
             timeout="timeout" in self._rename_parts,
             cpu_load="cpu_load" in self._rename_parts,
+            tsan_kind=tsan_kind,
         )
         self._maybe_flush()
 

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import inspect
+import json
 import logging
 import time
 from random import choice, randint, random
@@ -105,6 +106,11 @@ class WritePythonCode(WriteCode):
         self.enable_threads = threads
         self.enable_async = _async
         self.generated_filename = filename
+        # Slice B provenance: set by _write_tsan_stress_region at generation time so the
+        # PythonSource/StatsAgent can attribute a --tsan session's shared-object composition
+        # (None outside --tsan). tsan_manifest is the full descriptor emitted into the script.
+        self.tsan_manifest: dict | None = None
+        self.tsan_shared_kind: str | None = None
 
         self.arg_generator = ArgumentGenerator(
             self.options,
@@ -710,6 +716,67 @@ class WritePythonCode(WriteCode):
         # Drop process-lifecycle calls (fork/exec/spawn/...): forking a worker crashes the child
         # under TSan and is never a useful race target (see TSAN_UNSAFE_CALLS).
         funcs = [f for f in (self.module_functions or []) if f not in TSAN_UNSAFE_CALLS][:40]
+        # Per-session rotation of which shared iterator each worker GROUP collides on. Computed
+        # once here so the SAME value feeds both the emitted `_ITER_OFF` and the provenance
+        # manifest below (Slice B attribution).
+        iter_off = randint(0, 7)
+
+        # Slice B provenance: the parent knows the full generation context, so record it (and
+        # emit it into the script) rather than mis-attributing a builtin race to whatever module
+        # this session happened to pick. shared_kind = did we share real target-module objects,
+        # or only the module itself? (feeds fusil_stats.json + fleet report).
+        shared_kind = "target-objects" if shared_classes else "module-only"
+        self.tsan_shared_kind = shared_kind
+        self.tsan_manifest = {
+            "kind": "tsan-provenance",
+            "v": 1,
+            "module": self.module_name,
+            "shared_classes": list(shared_classes),
+            "shared_kind": shared_kind,
+            "shared_args": ["list", "dict", "set", "bytearray"],
+            # iterator kinds registered into the shared-iterator pool (op h); the last two are
+            # attempted under try/except in the script (near-always present on the target).
+            "iterators": [
+                "str",
+                "bytes",
+                "list",
+                "tuple",
+                "dict",
+                "range",
+                "itertools.count",
+                "struct.iter_unpack",
+            ],
+            "iter_off": iter_off,
+            "roles": {"0": "writer", "1": "reader", "2": "both"},
+            "ops": [
+                "a:read-churn",
+                "b:method",
+                "c:module-func",
+                "d:attr-dict",
+                "e:weakref",
+                "f:container-mutate",
+                "g:gc",
+                "h:shared-iter",
+                "i:read-while-mutate",
+            ],
+            "workers_per_obj": workers_per_obj,
+            "iters": iters,
+            "func_count": len(funcs),
+        }
+        provenance_line = (
+            "[TSAN] provenance module=%s shared=%s(%dcls+module) args=list,dict,set,bytearray "
+            "iterators=8 iter_off=%d roles=r/w/both ops=a-i workers=%d iters=%d funcs=%d"
+            % (
+                self.module_name,
+                shared_kind,
+                len(shared_classes),
+                iter_off,
+                workers_per_obj,
+                iters,
+                len(funcs),
+            )
+        )
+        manifest_line = "[TSAN-MANIFEST] " + json.dumps(self.tsan_manifest, sort_keys=True)
 
         self.emptyLine()
         self.write(0, "# --- TSan concurrency-stress region (--tsan) ---")
@@ -718,6 +785,11 @@ class WritePythonCode(WriteCode):
         self.write(0, "import weakref as _tsan_weakref")
         self.write(0, "import operator as _tsan_operator")
         self.write_print_to_stderr(0, '"[TSAN] entering concurrency-stress region"')
+        # Emit provenance FIRST (before the region runs) so it is already in the crash dir's
+        # captured output no matter where a later race/abort stops the child. Human line + a
+        # machine-parseable JSON line (both literals -- no runtime json import in the script).
+        self.write_print_to_stderr(0, repr(provenance_line))
+        self.write_print_to_stderr(0, repr(manifest_line))
         # Free-threading is mandatory: without it the whole region is GIL-serialised noise.
         self.write(0, 'if getattr(sys, "_is_gil_enabled", lambda: True)():')
         with self.indented():
@@ -780,7 +852,8 @@ class WritePythonCode(WriteCode):
         # Per-session rotation of which shared iterator each worker GROUP shares, so all workers
         # on one _idx collide on the SAME iterator (roles below race it) while different sessions
         # cover different iterator kinds. Constant across workers -> sharing is preserved.
-        self.write(0, "_ITER_OFF = %d" % randint(0, 7))
+        # (iter_off computed above so it also appears in the provenance manifest.)
+        self.write(0, "_ITER_OFF = %d" % iter_off)
         self.write(0, "_tsan_total = len(_tsan_shared) * _WORKERS_PER_OBJ")
         self.write(0, "_tsan_barrier = _tsan_threading.Barrier(_tsan_total)")
         self.write_block(

--- a/tests/python/test_fleet_report.py
+++ b/tests/python/test_fleet_report.py
@@ -126,6 +126,24 @@ class TestCollectAndAggregate(unittest.TestCase):
             insts = fr.discover_instances(os.path.join(tmp, "inst-01"))
             self.assertEqual(len(insts), 1)
 
+    def test_tsan_kinds_flow_through_and_render(self):
+        # Slice B: the --tsan shared-object distribution rides the sidecar through
+        # collect_instance -> aggregate_campaign and is rendered in both report views.
+        with tempfile.TemporaryDirectory() as tmp:
+            r1 = os.path.join(tmp, "inst-01", "python")
+            os.makedirs(r1)
+            _sidecar(
+                os.path.join(r1, "fusil_stats.json"),
+                sessions=50,
+                tsan_kinds={"target-objects": 40, "module-only": 10},
+            )
+            r = fr.collect_instance(os.path.join(tmp, "inst-01"), now=2000.0, systemd=False)
+            self.assertEqual(r["tsan_kinds"], {"target-objects": 40, "module-only": 10})
+            report = fr.build_report(tmp, None, systemd=False, now=2000.0)
+            self.assertEqual(report["campaign"]["tsan_kinds"]["target-objects"], 40)
+            self.assertIn("tsan shared-obj", fr.render(report, 1))  # instance view
+            self.assertIn("target-objects", fr.render(report, None))  # campaign view
+
     def test_live_session_dirs_not_counted_as_crashes(self):
         # A still-named "session-N" dir holds a source.py while it runs, but it's a live
         # session, not a kept crash (kept crashes are renamed <module>-<kind>-<label>).

--- a/tests/python/test_session_stats.py
+++ b/tests/python/test_session_stats.py
@@ -34,6 +34,16 @@ class TestRecord(unittest.TestCase):
         self.assertEqual(s.modules["json"], {"hits": 3, "crashes": 2, "timeouts": 0})
         self.assertEqual(s.modules["sqlite3"], {"hits": 1, "crashes": 0, "timeouts": 1})
 
+    def test_tsan_kinds_counted(self):
+        # Slice B: --tsan sessions record their shared-object composition; non-tsan sessions
+        # (tsan_kind=None) never touch the counter.
+        s = self._stats()
+        s.record("m", tsan_kind="target-objects")
+        s.record("m", tsan_kind="target-objects", crash=True)
+        s.record("m", tsan_kind="module-only")
+        s.record("m")  # no tsan_kind -> not counted
+        self.assertEqual(s.tsan_kinds, {"target-objects": 2, "module-only": 1})
+
     def test_none_module_bucketed_as_question(self):
         s = self._stats()
         s.record(None)

--- a/tests/python/test_stats_agent.py
+++ b/tests/python/test_stats_agent.py
@@ -81,6 +81,22 @@ class TestStatsAgentWiring(unittest.TestCase):
             agent.on_session_done(0.0)
             self.assertEqual(agent.stats.cpu_load_kills, 1)
 
+    def test_tsan_kind_recorded_from_source(self):
+        # Slice B: StatsAgent reads the --tsan shared-object composition off the PythonSource and
+        # folds it into the sidecar; absent the attribute (non-tsan runs) nothing is recorded.
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = self._agent(tmp, module="json")
+            agent.source.tsan_shared_kind = "target-objects"
+            agent.on_session_start()
+            agent.on_session_done(0.0)
+            self.assertEqual(agent.stats.tsan_kinds, {"target-objects": 1})
+
+            # a non-tsan-style source (no attribute) leaves the counter untouched.
+            other = self._agent(tmp, module="json")
+            other.on_session_start()
+            other.on_session_done(0.0)
+            self.assertEqual(other.stats.tsan_kinds, {})
+
     def test_flush_writes_sidecar(self):
         with tempfile.TemporaryDirectory() as tmp:
             agent = self._agent(tmp, module="json")

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -6,13 +6,26 @@ the single-threaded function/class/object sweeps are replaced by it. Mirrors tes
 """
 
 import ast
+import json
 import os
+import re
 import tempfile
 import unittest
 from types import ModuleType
 from unittest.mock import MagicMock
 
 from fusil.python.write_python_code import WritePythonCode
+
+
+def _extract_tsan_manifest(src):
+    """Pull the emitted `[TSAN-MANIFEST] {json}` payload back out of the generated source."""
+    for line in src.splitlines():
+        line = line.strip()
+        if "[TSAN-MANIFEST]" in line and line.startswith("print("):
+            m = re.match(r"print\((.*), file=stderr\)$", line)
+            printed = ast.literal_eval(m.group(1))  # the string literal print()s
+            return json.loads(printed[len("[TSAN-MANIFEST] ") :])
+    raise AssertionError("no [TSAN-MANIFEST] line in generated source")
 
 
 def _tsan_module():
@@ -150,6 +163,35 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("_ITER_OFF =", src)
         self.assertIn("_cell = _tsan_iters[(_idx + _ITER_OFF) % len(_tsan_iters)]", src)
         self.assertIn("_tsan_operator.length_hint(_it, 0)", src)  # non-advancing it_index read
+
+    def test_provenance_markers_emitted(self):
+        # Slice B: the region prints a human `[TSAN] provenance ...` line and a machine-parseable
+        # `[TSAN-MANIFEST] {json}` line, so a crash dir's stdout carries the real generation
+        # context (fixing the "builtin race stamped with whatever module the session picked" bug).
+        src = _generate_tsan()
+        self.assertIn("[TSAN] provenance module=tsanmod", src)
+        self.assertIn("[TSAN-MANIFEST] ", src)
+        # both markers land BEFORE the region does any work (so a later abort can't lose them):
+        self.assertLess(src.index("[TSAN-MANIFEST]"), src.index("def _tsan_worker"))
+        manifest = _extract_tsan_manifest(src)
+        self.assertEqual(manifest["kind"], "tsan-provenance")
+        self.assertEqual(manifest["module"], "tsanmod")
+        # the fixture has one class (Widget) -> a real target object is shared:
+        self.assertEqual(manifest["shared_classes"], ["Widget"])
+        self.assertEqual(manifest["shared_kind"], "target-objects")
+        self.assertEqual(manifest["roles"], {"0": "writer", "1": "reader", "2": "both"})
+        self.assertIn("h:shared-iter", manifest["ops"])
+        # fork/execv/abort are filtered out of the module-func pool -> only helper remains:
+        self.assertEqual(manifest["func_count"], 1)
+        self.assertEqual(manifest["iters"], 200)
+
+    def test_provenance_iter_off_matches_emitted(self):
+        # The manifest's iter_off must equal the emitted `_ITER_OFF` (single source, so triage can
+        # reconstruct which iterator each worker group shared).
+        src = _generate_tsan()
+        manifest = _extract_tsan_manifest(src)
+        off_line = next(ln for ln in src.splitlines() if ln.startswith("_ITER_OFF = "))
+        self.assertEqual(int(off_line.split("=")[1]), manifest["iter_off"])
 
     def test_shares_objects_and_module_functions(self):
         src = _generate_tsan()


### PR DESCRIPTION
## Phase 4, Slice B: provenance / attribution

Slice A ([#213](https://github.com/devdanzin/fusil/pull/213)) gave every `--tsan` session the same op-mix but left no record of what it actually shared. So a **builtin** race (e.g. the bytes-iterator race TSAN-0037 that fleet 06 found) lands in a crash dir stamped only with whatever module the session happened to pick — a real misattribution. The parent knows the full generation context; this slice makes it durable.

### Emitter — stdout provenance markers (`write_python_code.py`)
`_write_tsan_stress_region` now builds a manifest of the generation context (module, shared-object composition, iterator kinds, `iter_off`, role map, op list, worker/iter knobs) and prints two stderr markers **right after** `"entering concurrency-stress region"` — before the region does any work, so a later abort/race can't lose them:

```
[TSAN] provenance module=tsanmod shared=target-objects(1cls+module) args=list,dict,set,bytearray iterators=8 iter_off=3 roles=r/w/both ops=a-i workers=4 iters=200 funcs=1
[TSAN-MANIFEST] {"func_count": 1, "iter_off": 3, "iterators": [...], "kind": "tsan-provenance", "module": "tsanmod", "ops": [...], "roles": {...}, "shared_classes": ["Widget"], "shared_kind": "target-objects", ...}
```

Both are **literals** (no runtime `json` import in the generated script). `iter_off` is computed once and feeds **both** the manifest and the emitted `_ITER_OFF`, so triage can reconstruct which iterator each worker group shared.

### Stats — per-session shared-object kind (`session_stats.py` + `stats_agent.py` + `python_source.py`)
Record the per-session shared-object composition — `"target-objects"` when real module-class instances were shared, else `"module-only"` — in `fusil_stats.json` via a new `tsan_kinds` counter (`record`/`to_dict`/`merge`; additive, schema stays v1). `PythonSource` exposes `tsan_shared_kind` off the writer after generation; `StatsAgent` folds it in (None outside `--tsan` → counter untouched). `fleet_report` surfaces the distribution in both the instance and campaign views (`tsan shared-obj: ...`).

### Safety / testing
- Emitter stays `--tsan`-gated → **non-`--tsan` goldens unchanged** (verified `test_golden_output` + `test_write_python_code`).
- +5 tests: provenance markers + `iter_off` consistency, `tsan_kinds` record/merge, agent thread-through, fleet-report flow. Suite **1105 → 1110**.
- `ruff check` + `ruff format --check` clean.

Design: `doc/tsan-mode-plan.md` → "Phase 4 (planned) → Slice B". Next: Slice C (better target objects + extension-object iterators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)