### PR TITLE
tsan: Slice C -- richer target-object factories + extension-object iterators

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -94,6 +94,7 @@ by" column is where the core reads it back, so you can see exactly what each hoo
 | `add_blacklist_entry(kind, pattern, pattern_type="exact")` | Skip a discovered name. `kind` ∈ `module`/`class`/`function`/`object`/`method`; `pattern_type` `exact` or `glob`. | name filtering in `WritePythonCode` |
 | `add_whitelist_entry(kind, pattern, pattern_type="exact")` | Keep a name normally skipped (honoured for `method`, e.g. `__del__`). | method filtering in `WritePythonCode` |
 | `add_suppression_entry(pattern, reason=None)` | A regex `re.search`ed against a crash's stdout to drop known/uninteresting **hits** (see `--suppress-hit-regex`, issue #53). | `Fuzzer._suppression_keep_policy` |
+| `add_tsan_shared_factory(source, label=None, iterable=True, condition=…)` | A Python **expression** (e.g. `"__import__('cereggii').AtomicDict()"`) spliced into the `--tsan` concurrency-stress region as a shared object hammered from many threads; `iterable=True` also folds `iter(source)` into the shared-iterator op (points op *h* at the target's own `tp_iternext`); `condition(config, module)` gates it. | `WritePythonCode._write_tsan_stress_region` |
 | `add_hook(name, func)` | Lifecycle hook; `name` ∈ `startup`/`shutdown`. `startup(config)` runs after option parsing; `shutdown()` at exit. | `Application.setup` / `Application.exit` |
 | `declare_dependency(name, required_version=None)` | Advertise a required package/plugin. | `check_dependencies` at startup |
 | `declare_incompatibility(name)` | Advertise a conflicting plugin. | `check_dependencies` at startup |

--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -430,7 +430,13 @@ so the entire "concurrent `next()` on one iterator" surface was unreachable:
 Tests: `test_tsan_generation.py::{test_shared_iterator_op_emitted,test_read_while_mutate_op_emitted}`.
 Emitter still gated (non-`--tsan` output unchanged).
 
-## Phase 4 (planned): target-object coverage + provenance + extension dedup
+## Phase 4: target-object coverage + provenance + extension dedup
+
+**Status (2026-07-18):** Slices **A** (worker roles, PR #213), **B** (provenance/attribution,
+PR #214), and **C** (target-object factories + extension-object iterators + the
+`add_tsan_shared_factory` plugin hook) are **implemented**; slices **D** (external source roots)
+and **E** (weird-subclasses-of-extension) remain planned. The slice descriptions below are the
+as-designed intent; see the commit history / the memory note for exact as-built details.
 
 **Motivation.** Phase 3.1 proved the op-mix finds *builtin* races (TSAN-0037, the bytes iterator)
 because the shared pool is mostly builtin containers + bare `Class()` instances. The campaign's

--- a/fusil/plugin_manager.py
+++ b/fusil/plugin_manager.py
@@ -104,6 +104,24 @@ class SuppressionEntry:
 
 
 @dataclass
+class TSanSharedFactory:
+    """A --tsan shared-object factory contributed by a plugin (Phase 4 Slice C).
+
+    ``source`` is a Python EXPRESSION spliced into the generated script (which runs out of
+    process), evaluated to yield a target object the concurrency-stress region hammers from
+    many threads -- e.g. ``"__import__('cereggii').AtomicDict()"``. ``label`` names it in the
+    provenance manifest (defaults to ``source``). ``iterable`` also folds ``iter(source)``
+    into the shared-iterator op (op h) so the extension's own ``tp_iternext`` is raced.
+    ``condition(config, module_name) -> bool`` gates when the factory is active.
+    """
+
+    source: str
+    label: str | None = None
+    iterable: bool = True
+    condition: Callable[[Any, str], bool] = lambda cfg, mod: True
+
+
+@dataclass
 class PluginMetadata:
     """Metadata about a loaded plugin."""
 
@@ -131,6 +149,7 @@ class PluginManager:
         self.blacklist_entries: list[NameFilterEntry] = []
         self.whitelist_entries: list[NameFilterEntry] = []
         self.suppression_entries: list[SuppressionEntry] = []
+        self.tsan_shared_factories: list[TSanSharedFactory] = []
         self.stdout_ignore_regexes: list[str] = []
         self.hooks: dict[str, list[Callable]] = {
             "startup": [],
@@ -309,6 +328,32 @@ class PluginManager:
         """
         self.suppression_entries.append(SuppressionEntry(pattern=pattern, reason=reason))
 
+    def add_tsan_shared_factory(
+        self,
+        source: str,
+        *,
+        label: str | None = None,
+        iterable: bool = True,
+        condition: Callable[[Any, str], bool] = lambda cfg, mod: True,
+    ) -> None:
+        """Contribute a target-specific shared object to the --tsan stress region (Slice C).
+
+        Lets a plugin point the concurrency-stress region at the extension's own objects
+        (e.g. cereggii's ``AtomicDict()``) instead of only generic ``Class()`` instances, so
+        the FT-race-rich C paths that motivated this campaign are exercised directly.
+
+        Args:
+            source: a Python EXPRESSION evaluated in the generated (out-of-process) script to
+                build one shared object, e.g. ``"__import__('cereggii').AtomicDict()"``.
+            label: name shown in the provenance manifest (defaults to ``source``).
+            iterable: also fold ``iter(source)`` into the shared-iterator op so the object's
+                own ``tp_iternext`` is raced (guarded -- a non-iterable just drops).
+            condition: ``(config, module_name) -> bool`` gating when the factory is active.
+        """
+        self.tsan_shared_factories.append(
+            TSanSharedFactory(source=source, label=label, iterable=iterable, condition=condition)
+        )
+
     def add_stdout_ignore_regex(self, pattern: str) -> None:
         """Register a regex whose matching stdout lines are IGNORED by crash detection.
 
@@ -433,6 +478,16 @@ class PluginManager:
     def get_stdout_ignore_regexes(self) -> list[str]:
         """Return plugin-registered crash-detection ignore regexes (see add_stdout_ignore_regex)."""
         return list(self.stdout_ignore_regexes)
+
+    def get_tsan_shared_factories(
+        self, config: Any, module_name: str
+    ) -> list[tuple[str, str, bool]]:
+        """Return active --tsan shared-object factories as ``(source, label, iterable)`` (Slice C)."""
+        out = []
+        for reg in self.tsan_shared_factories:
+            if reg.condition(config, module_name):
+                out.append((reg.source, reg.label or reg.source, reg.iterable))
+        return out
 
     def get_active_mode(self, config: Any) -> FuzzingMode | None:
         """

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -694,6 +694,23 @@ class WritePythonCode(WriteCode):
         )
         self.emptyLine()
 
+    def _tsan_ctor_argexpr(self) -> str:
+        """A pure-expression constructor-arg string (0-2 simple args) for a --tsan class factory.
+
+        Returns ``""`` when no usable args were produced. Only single-line simple-argument
+        expressions are kept, so the result stays valid inside a ``lambda:`` factory; a runtime
+        guard drops wrong-arity/type instantiations (Slice C).
+        """
+        parts: list[str] = []
+        for _ in range(randint(0, 2)):
+            try:
+                lines = self.arg_generator.create_simple_argument()
+            except Exception:
+                continue
+            if len(lines) == 1 and lines[0].strip():
+                parts.append(lines[0].strip())
+        return ", ".join(parts)
+
     def _write_tsan_stress_region(self) -> None:
         """Emit the --tsan concurrency-stress region.
 
@@ -716,6 +733,40 @@ class WritePythonCode(WriteCode):
         # Drop process-lifecycle calls (fork/exec/spawn/...): forking a worker crashes the child
         # under TSan and is never a useful race target (see TSAN_UNSAFE_CALLS).
         funcs = [f for f in (self.module_functions or []) if f not in TSAN_UNSAFE_CALLS][:40]
+
+        # Slice C: build a richer, guarded set of shared-object FACTORIES (source_expr, label,
+        # iterable) -- real target objects rather than only bare Class() instances. The same
+        # factories seed the shared pool AND (for iterables) point op (h) at the target's own
+        # tp_iternext. Sources: discovered module-level objects, class instances (w/ & w/o
+        # ArgumentGenerator args), and plugin-contributed objects (e.g. cereggii AtomicDict()).
+        objects = self.module_objects or []
+        shared_objects = sample(objects, min(n_shared, len(objects))) if objects else []
+        obj_factory_specs: list[tuple[str, str, bool]] = []
+        for name in shared_objects:
+            obj_factory_specs.append(
+                ("getattr(fuzz_target_module, %r)" % name, "obj:%s" % name, True)
+            )
+        for name in shared_classes:
+            obj_factory_specs.append(
+                ("getattr(fuzz_target_module, %r)()" % name, "cls:%s" % name, True)
+            )
+            argexpr = self._tsan_ctor_argexpr()
+            if argexpr:
+                obj_factory_specs.append(
+                    (
+                        "getattr(fuzz_target_module, %r)(%s)" % (name, argexpr),
+                        "cls:%s/args" % name,
+                        True,
+                    )
+                )
+        plugin_factories = (
+            self.plugin_manager.get_tsan_shared_factories(self.options, self.module_name)
+            if self.plugin_manager
+            else []
+        )
+        for src, label, iterable in plugin_factories:
+            obj_factory_specs.append((src, label, bool(iterable)))
+
         # Per-session rotation of which shared iterator each worker GROUP collides on. Computed
         # once here so the SAME value feeds both the emitted `_ITER_OFF` and the provenance
         # manifest below (Slice B attribution).
@@ -725,16 +776,23 @@ class WritePythonCode(WriteCode):
         # emit it into the script) rather than mis-attributing a builtin race to whatever module
         # this session happened to pick. shared_kind = did we share real target-module objects,
         # or only the module itself? (feeds fusil_stats.json + fleet report).
-        shared_kind = "target-objects" if shared_classes else "module-only"
+        shared_kind = (
+            "target-objects"
+            if (shared_objects or shared_classes or plugin_factories)
+            else "module-only"
+        )
+        ext_iterators = sum(1 for _s, _l, it in obj_factory_specs if it)
         self.tsan_shared_kind = shared_kind
         self.tsan_manifest = {
             "kind": "tsan-provenance",
             "v": 1,
             "module": self.module_name,
+            "shared_objects": list(shared_objects),
             "shared_classes": list(shared_classes),
+            "plugin_factories": [label for _s, label, _i in plugin_factories],
             "shared_kind": shared_kind,
             "shared_args": ["list", "dict", "set", "bytearray"],
-            # iterator kinds registered into the shared-iterator pool (op h); the last two are
+            # builtin iterator kinds always in the shared-iterator pool (op h); the last two are
             # attempted under try/except in the script (near-always present on the target).
             "iterators": [
                 "str",
@@ -746,6 +804,8 @@ class WritePythonCode(WriteCode):
                 "itertools.count",
                 "struct.iter_unpack",
             ],
+            # extension-object iterators (iter(factory())) folded into op (h) on top of builtins.
+            "ext_iterators": ext_iterators,
             "iter_off": iter_off,
             "roles": {"0": "writer", "1": "reader", "2": "both"},
             "ops": [
@@ -764,12 +824,16 @@ class WritePythonCode(WriteCode):
             "func_count": len(funcs),
         }
         provenance_line = (
-            "[TSAN] provenance module=%s shared=%s(%dcls+module) args=list,dict,set,bytearray "
-            "iterators=8 iter_off=%d roles=r/w/both ops=a-i workers=%d iters=%d funcs=%d"
+            "[TSAN] provenance module=%s shared=%s(%dobj+%dcls+%dplugin+module) "
+            "args=list,dict,set,bytearray iterators=8+%dext iter_off=%d roles=r/w/both "
+            "ops=a-i workers=%d iters=%d funcs=%d"
             % (
                 self.module_name,
                 shared_kind,
+                len(shared_objects),
                 len(shared_classes),
+                len(plugin_factories),
+                ext_iterators,
                 iter_off,
                 workers_per_obj,
                 iters,
@@ -803,19 +867,30 @@ class WritePythonCode(WriteCode):
         # Runtime skip set: the worker introspects dir(shared_object), so a shared MODULE object
         # would still expose fork/exec/... by name -- filter them there too.
         self.write(0, "_tsan_unsafe = frozenset(%r)" % (tuple(sorted(TSAN_UNSAFE_CALLS)),))
-        # Build the shared objects: instantiate a few module classes (guarded), plus the module.
-        self.write(0, "_tsan_shared = []")
-        for class_name in shared_classes:
-            self.write(0, "try:")
-            with self.indented():
-                self.write(0, "_tsan_shared.append(getattr(fuzz_target_module, %r)())" % class_name)
-            self.write(0, "except Exception:")
-            with self.indented():
-                self.write(0, "pass")
-        self.write(0, "_tsan_shared.append(fuzz_target_module)")
-        self.write(0, "if not _tsan_shared:")
-        with self.indented():
-            self.write(0, "_tsan_shared = [fuzz_target_module]")
+        # Build the shared objects from the guarded factories (Slice C): a few real target
+        # objects (module-level instances, class instances w/ & w/o args, plugin objects),
+        # capped for CONCENTRATION (few objects, many workers = what trips a race), plus the
+        # module itself (exposes module funcs to op c). The same factories feed op (h) below.
+        self.write(0, "_tsan_obj_factories = []")
+        for src, _label, _iterable in obj_factory_specs:
+            self.write(0, "_tsan_obj_factories.append(lambda: %s)" % src)
+        self.write(0, "_TSAN_MAX_SHARED = %d" % max(2, n_shared))
+        self.write_block(
+            0,
+            """
+            _tsan_shared = []
+            for _of in _tsan_obj_factories:
+                if len(_tsan_shared) >= _TSAN_MAX_SHARED:
+                    break
+                try:
+                    _tsan_shared.append(_of())
+                except Exception:
+                    pass
+            _tsan_shared.append(fuzz_target_module)
+            if not _tsan_shared:
+                _tsan_shared = [fuzz_target_module]
+            """,
+        )
         # Shared ITERATORS: one live iterator per kind, held in a 1-element cell and shared BY
         # REFERENCE so sibling workers advance the SAME cursor. Concurrent next()/repr() on one
         # iterator is the shared-iterator-state race class -- str/bytes/list/tuple/dict/range
@@ -844,7 +919,27 @@ class WritePythonCode(WriteCode):
                     lambda: _tsan_struct.Struct("i").iter_unpack(bytes(4 * 4096)))
             except Exception:
                 pass
-            _tsan_iters = [[_f()] for _f in _tsan_iter_factories]
+            """,
+        )
+        # Extension-object iterators (Slice C): fold iter(factory()) for each iterable shared-obj
+        # factory into the pool, pointing op (h) at the TARGET's own tp_iternext on top of the
+        # builtins above. Guarded build below drops non-iterables (a Widget() etc.) so the
+        # factory/iters lists stay length-aligned for the worker's StopIteration refresh.
+        for src, _label, iterable in obj_factory_specs:
+            if iterable:
+                self.write(0, "_tsan_iter_factories.append(lambda: iter(%s))" % src)
+        self.write_block(
+            0,
+            """
+            _tsan_iters = []
+            _tsan_iter_ok = []
+            for _f in _tsan_iter_factories:
+                try:
+                    _tsan_iters.append([_f()])
+                    _tsan_iter_ok.append(_f)
+                except Exception:
+                    pass
+            _tsan_iter_factories = _tsan_iter_ok
             """,
         )
         self.write(0, "_WORKERS_PER_OBJ = %d" % workers_per_obj)

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -80,7 +80,7 @@ def _make_tsan_options(threads=4, iterations=200, shared_objects=3):
     return o
 
 
-def _generate_tsan(**opt_overrides):
+def _generate_tsan(plugin_manager=None, **opt_overrides):
     parent = MagicMock()
     parent.options = _make_tsan_options(**opt_overrides)
     parent.filenames = ["/bin/sh"]
@@ -94,7 +94,7 @@ def _generate_tsan(**opt_overrides):
             "tsanmod",
             threads=False,
             _async=False,
-            plugin_manager=None,
+            plugin_manager=plugin_manager,
         )
         writer.generate_fuzzing_script()
         with open(path) as fp:
@@ -139,7 +139,7 @@ class TestTSanGeneration(unittest.TestCase):
         # repr() reading its state -- the class behind cpython#153928/#154013/#153981.
         src = _generate_tsan()
         self.assertIn("_tsan_iter_factories", src)
-        self.assertIn("_tsan_iters = [[_f()] for _f in _tsan_iter_factories]", src)
+        self.assertIn("_tsan_iters.append([_f()])", src)  # guarded, length-aligned build (Slice C)
         self.assertIn("next(_it)", src)  # concurrent cursor advance on the shared iterator
         self.assertIn("repr(_it)", src)  # state read racing the concurrent next()
         # covers the builtin iterator family + the stdlib C iterators from the linked issues
@@ -195,12 +195,60 @@ class TestTSanGeneration(unittest.TestCase):
 
     def test_shares_objects_and_module_functions(self):
         src = _generate_tsan()
-        # a module class is instantiated into the shared pool, plus the module itself.
-        self.assertIn("_tsan_shared.append(getattr(fuzz_target_module, 'Widget')())", src)
+        # a module class is instantiated as a guarded FACTORY into the shared pool (Slice C),
+        # and the module itself is always appended.
+        self.assertIn(
+            "_tsan_obj_factories.append(lambda: getattr(fuzz_target_module, 'Widget')())", src
+        )
         self.assertIn("_tsan_shared.append(fuzz_target_module)", src)
+        # the pool is capped for concentration, then built from the factories under a guard.
+        self.assertIn("_TSAN_MAX_SHARED = ", src)
+        self.assertIn("_tsan_shared.append(_of())", src)
         # module functions are called concurrently with the shared object as an argument.
         self.assertIn("'helper'", src)
         self.assertIn("_tsan_shared_args", src)
+
+    def test_extension_object_iterators_folded(self):
+        # Slice C: each iterable shared-object factory also seeds an iter(factory()) into op (h),
+        # pointing the shared-iterator machinery at the target's own tp_iternext.
+        src = _generate_tsan()
+        self.assertIn(
+            "_tsan_iter_factories.append(lambda: iter(getattr(fuzz_target_module, 'Widget')()))",
+            src,
+        )
+        manifest = _extract_tsan_manifest(src)
+        self.assertGreaterEqual(manifest["ext_iterators"], 1)  # >=1 (Widget); 2 if args built
+
+    def test_plugin_shared_factory_spliced(self):
+        # Slice C: a plugin-contributed target object is spliced into the shared pool + iterator
+        # pool, and its label lands in the provenance manifest.
+        from fusil.plugin_manager import PluginManager
+
+        pm = PluginManager()
+        pm.add_tsan_shared_factory(
+            "__import__('collections').OrderedDict()", label="cereggii:AtomicDict", iterable=True
+        )
+        src = _generate_tsan(plugin_manager=pm)
+        self.assertIn(
+            "_tsan_obj_factories.append(lambda: __import__('collections').OrderedDict())", src
+        )
+        self.assertIn(
+            "_tsan_iter_factories.append(lambda: iter(__import__('collections').OrderedDict()))",
+            src,
+        )
+        manifest = _extract_tsan_manifest(src)
+        self.assertIn("cereggii:AtomicDict", manifest["plugin_factories"])
+        self.assertEqual(manifest["shared_kind"], "target-objects")
+
+    def test_non_iterable_plugin_factory_not_folded(self):
+        # iterable=False -> spliced into the shared pool but NOT the iterator pool.
+        from fusil.plugin_manager import PluginManager
+
+        pm = PluginManager()
+        pm.add_tsan_shared_factory("object()", label="opaque", iterable=False)
+        src = _generate_tsan(plugin_manager=pm)
+        self.assertIn("_tsan_obj_factories.append(lambda: object())", src)
+        self.assertNotIn("_tsan_iter_factories.append(lambda: iter(object()))", src)
 
     def test_knobs_are_parameterised(self):
         src = _generate_tsan(threads=7, iterations=42)

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -84,6 +84,39 @@ class TestSuppressionEntries(unittest.TestCase):
         self.assertEqual(PluginManager().get_suppression_entries(), [])
 
 
+class TestTSanSharedFactories(unittest.TestCase):
+    def test_register_and_get_active(self):
+        m = PluginManager()
+        m.add_tsan_shared_factory("AtomicDict()", label="cereggii:AtomicDict")
+        m.add_tsan_shared_factory("Counter()")  # label defaults to source, iterable defaults True
+        self.assertEqual(
+            m.get_tsan_shared_factories(config=None, module_name="cereggii"),
+            [
+                ("AtomicDict()", "cereggii:AtomicDict", True),
+                ("Counter()", "Counter()", True),
+            ],
+        )
+
+    def test_condition_gates_activation(self):
+        m = PluginManager()
+        m.add_tsan_shared_factory("AtomicDict()", condition=lambda cfg, mod: mod == "cereggii")
+        self.assertEqual(m.get_tsan_shared_factories(None, "json"), [])
+        self.assertEqual(
+            m.get_tsan_shared_factories(None, "cereggii"),
+            [("AtomicDict()", "AtomicDict()", True)],
+        )
+
+    def test_iterable_flag_preserved(self):
+        m = PluginManager()
+        m.add_tsan_shared_factory("File('x')", label="h5py:File", iterable=False)
+        self.assertEqual(
+            m.get_tsan_shared_factories(None, "h5py"), [("File('x')", "h5py:File", False)]
+        )
+
+    def test_empty_manager_has_no_factories(self):
+        self.assertEqual(PluginManager().get_tsan_shared_factories(None, "m"), [])
+
+
 class TestStdoutIgnoreRegexes(unittest.TestCase):
     def test_register_and_get(self):
         m = PluginManager()


### PR DESCRIPTION
## Phase 4, Slice C: better target objects (+ extension-object iterators)

The `--tsan` shared pool was mostly builtin containers + bare `Class()` instances, so the op-mix found **builtin** races (like TSAN-0037, the bytes iterator) but rarely touched the **target C extension's own objects** — where the campaign's actual value is. Slice C points the same machinery at real target objects.

### Emitter (`write_python_code.py`)
The shared pool is now built from a **guarded set of object factories** `(source_expr, label, iterable)` instead of only bare `Class()`:
1. **discovered module-level objects** (`self.module_objects`, previously discovered-but-unused);
2. **class instances with `ArgumentGenerator` constructor args** (new `_tsan_ctor_argexpr` helper — single-line simple args only, so it stays a valid `lambda` body) *as well as* bare `Class()`, reaching constructor allocation paths;
3. **plugin-contributed objects** via the new hook (below);
4. the module (unchanged fallback).

The pool is **capped** (`_TSAN_MAX_SHARED`) to preserve concentration — few objects, many workers is what trips a race. Each iterable factory **also folds `iter(factory())`** into the op-(h) iterator pool, pointing the shared-iterator machinery at the extension's own `tp_iternext`. The iterator build is now **guarded and length-aligned** (factories/iters filtered together) so the worker's `StopIteration` refresh stays consistent.

### Plugin hook (`plugin_manager.py`)
`add_tsan_shared_factory(source, *, label=None, iterable=True, condition=…)` / `get_tsan_shared_factories(config, module)` — lets the cereggii/h5py plugins contribute target-specific shared objects (e.g. `"__import__('cereggii').AtomicDict()"`). `iterable=True` also races the object's own iterator. Documented in `doc/plugins.md`. (Wiring the hook from the sibling plugins is a follow-up.)

### Provenance (Slice B) integration
The manifest gains `shared_objects`, `plugin_factories`, and `ext_iterators`, and the human line shows `shared=<kind>(Nobj+Ncls+Nplugin+module) iterators=8+Next` — so the richer composition stays attributable.

### Safety / testing
- Emitter stays `--tsan`-gated → **non-`--tsan` goldens unchanged**; the generated script `compile()`s and the with-args constructor expressions resolve against the emitted boilerplate (and are guarded regardless).
- +7 tests: factory splicing, extension-object iterator fold, non-iterable-not-folded, plugin-factory splice into pool+iterators+manifest, and 4 `PluginManager` hook unit tests. Suite **1110 → 1117**.
- `ruff check` + `ruff format --check` clean.

Design: `doc/tsan-mode-plan.md` → "Phase 4 → Slice C". Remaining: Slice D (external C-ext source roots for dedup — cross-repo contract) and Slice E (weird-subclasses-of-extension); using the new plugin hook from cereggii/h5py is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)