### PR TITLE
tsan: Slice D -- external C-extension source roots for race dedup

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -433,10 +433,13 @@ Emitter still gated (non-`--tsan` output unchanged).
 ## Phase 4: target-object coverage + provenance + extension dedup
 
 **Status (2026-07-18):** Slices **A** (worker roles, PR #213), **B** (provenance/attribution,
-PR #214), and **C** (target-object factories + extension-object iterators + the
-`add_tsan_shared_factory` plugin hook) are **implemented**; slices **D** (external source roots)
-and **E** (weird-subclasses-of-extension) remain planned. The slice descriptions below are the
-as-designed intent; see the commit history / the memory note for exact as-built details.
+PR #214), **C** (target-object factories + extension-object iterators + the
+`add_tsan_shared_factory` plugin hook, PR #215), and **D** (external C-extension source roots for
+`tsan_dedup` via `--tsan-source-root`) are **implemented**; slice **E**
+(weird-subclasses-of-extension) remains planned. The slice descriptions below are the as-designed
+intent; see the commit history / the memory note for exact as-built details. Slice D preserved the
+cross-repo signature contract: re-ingesting fleet-06 with the new parser and no roots reproduced
+all 119 CPython signatures byte-for-byte.
 
 **Motivation.** Phase 3.1 proved the op-mix finds *builtin* races (TSAN-0037, the bytes iterator)
 because the shared pool is mostly builtin containers + bare `Class()` instances. The campaign's

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -458,6 +458,17 @@ class Fuzzer(Application):
             action="store_true",
             default=False,
         )
+        tsan_options.add_option(
+            "--tsan-source-root",
+            action="append",
+            dest="tsan_source_roots",
+            metavar="DIR",
+            help="Source-tree root of a fuzzed C EXTENSION (repeatable). A race frame under this "
+            "dir (that is not CPython source) is keyed by its path relative to the root, so the "
+            "extension's own races dedupe instead of dropping to noparse. Default: none "
+            "(CPython-only signatures, unchanged).",
+            default=None,
+        )
 
         options = (
             input_options,
@@ -758,14 +769,16 @@ class Fuzzer(Application):
                 keep=self.options.tsan_dedup_keep,
                 prune=self.options.tsan_dedup_prune,
                 suppressions_path=self.options.tsan_suppressions,
+                source_roots=self.options.tsan_source_roots,
             )
             self.session_keep_policy = self._tsan_keep_policy
             project.error(
-                "TSan dedupe enabled: %s (keep=%d, prune=%s)"
+                "TSan dedupe enabled: %s (keep=%d, prune=%s, source_roots=%s)"
                 % (
                     self.options.tsan_dedup_catalog,
                     self.options.tsan_dedup_keep,
                     self.options.tsan_dedup_prune,
+                    self.options.tsan_source_roots or "none",
                 )
             )
 

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -18,6 +18,16 @@ across builds, so the signature is function-level; the exact lines are kept for 
 
 The catalog snapshot (``known_races.tsv``, produced by the sibling cpython-tsan-findings
 catalog) maps each known signature to a race id. Matching is exact on the signature.
+
+``parse_report`` optionally takes ``source_roots`` (Slice D): a list of ``--tsan-source-root``
+directories. A frame that is NOT CPython source but whose file lives under one of those roots is
+normalised to its path relative to the root (``/build/cereggii/src/atomic_dict.c`` ->
+``src/atomic_dict.c``), so an out-of-tree extension's own races get a specific, dedupable
+signature instead of falling into ``noparse``. CPython frames are always matched first, so the
+default (no roots) is byte-for-byte identical to the CPython-only behaviour. This signature
+format is a **cross-repo contract** -- the sibling catalog's ``scripts/ingest.py`` imports this
+module by path, so a change here must keep every existing CPython signature unchanged (see the
+re-ingest guardrail in the Slice D notes).
 """
 
 import collections
@@ -54,6 +64,45 @@ FRAME = re.compile(r"^\s*#\d+\s+(\S+)\s+(.+?)\s+\(")
 CPY_SRC = re.compile(
     r"(?:^|/)((?:Objects|Python|Modules|Include|Parser|Programs)/[\w./+-]+\.(?:c|h)):(\d+)"
 )
+# Slice D: with `--tsan-source-root` roots, a frame whose source file is NOT in CPython but lives
+# under one of those roots is normalised to its path RELATIVE to the root (e.g. root
+# `/build/cereggii` + `/build/cereggii/src/atomic_dict.c:12` -> `src/atomic_dict.c`), so an
+# extension `.so`'s own races get a specific, dedupable signature instead of dropping to
+# `noparse`. Default (no roots) leaves CPython-only behaviour byte-for-byte unchanged -- CPython
+# is always matched FIRST, so roots only ever rescue a frame CPY_SRC didn't already claim.
+_EXT_SRC = re.compile(r"([\w./+-]+\.(?:c|h|cc|cpp|cxx|hpp|hh|pyx|pxd|pxi)):(\d+)")
+
+
+def _relative_to_root(path, root):
+    """``path`` normalised relative to ``root`` (a --tsan-source-root dir), or None if not under
+    it. Matches either an absolute-path prefix or the root's basename as a ``/name/`` anchor (the
+    build-time source path baked into the `.so` can differ from the local root path)."""
+    root = root.rstrip("/")
+    if not root:
+        return None
+    if path == root:
+        return os.path.basename(path)
+    if path.startswith(root + "/"):
+        return path[len(root) + 1 :]
+    anchor = "/" + os.path.basename(root) + "/"
+    idx = path.find(anchor)
+    if idx != -1:
+        return path[idx + len(anchor) :]
+    return None
+
+
+def _ext_frame_site(func, location, source_roots):
+    """(relpath, func, line) if this frame's source file is under a source root, else None."""
+    m = _EXT_SRC.search(location)
+    if not m:
+        return None
+    path, line = m.group(1), int(m.group(2))
+    for root in source_roots:
+        rel = _relative_to_root(path, root)
+        if rel is not None:
+            return (rel, func, line)
+    return None
+
 
 # Generic call/vectorcall/eval dispatch + interpreter-startup frames: always on the stack, never
 # the racing DATA site, so skip them to reach the real racing function (mirrors
@@ -125,53 +174,64 @@ def _is_framework(site):
     return bool(FRAMEWORK_FILES.search(site[0])) or site[1] in FRAMEWORK_FUNCS
 
 
-def _frame_site(func, location):
-    """Return (file, func, line) if this frame is a CPython source frame, else None."""
+def _frame_site(func, location, source_roots=None):
+    """Return (file, func, line) if this frame resolves to a source site we key on, else None.
+
+    A CPython source frame is matched first (unchanged). With ``source_roots`` (Slice D), a
+    non-CPython frame whose file is under one of those roots is normalised relative to it; without
+    roots the behaviour is exactly the old CPython-only match."""
     if func == "<null>":
         return None
     m = CPY_SRC.search(location)
-    if not m:
-        return None
-    return (m.group(1), func, int(m.group(2)))
+    if m:
+        return (m.group(1), func, int(m.group(2)))
+    if source_roots:
+        return _ext_frame_site(func, location, source_roots)
+    return None
 
 
 def _is_plumbing(func):
     return func in PLUMBING_SKIP or bool(_STACKREF.fullmatch(func))
 
 
-def _top_site(frames):
+def _top_site(frames, source_roots=None):
     """Given a stanza's frames (innermost first) as (func, location), return the top real
-    racing site (file, func, line): the innermost CPython frame whose func isn't plumbing.
-    Falls back to the innermost CPython frame if all are plumbing; None if no CPython frame."""
-    cpython = []
+    racing site (file, func, line): the innermost resolved frame whose func isn't plumbing.
+    Falls back to the innermost resolved frame if all are plumbing; None if none resolve.
+    ``source_roots`` (Slice D) additionally resolves extension frames under those roots."""
+    real = []
     for func, location in frames:
-        site = _frame_site(func, location)
+        site = _frame_site(func, location, source_roots)
         if site is not None:
-            cpython.append(site)
-    if not cpython:
+            real.append(site)
+    if not real:
         return None
-    for site in cpython:
+    for site in real:
         if not _is_plumbing(site[1]):
             return site
-    return cpython[0]  # all plumbing -> innermost CPython frame anyway
+    return real[0]  # all plumbing -> innermost resolved frame anyway
 
 
-def parse_report(text):
+def parse_report(text, source_roots=None):
     """Parse the first ThreadSanitizer report in ``text``.
 
     Returns a dict {signature, sites, framework, kind} where kind is "race" (a data race, two
     access sites) or "segv" (a SEGV/UAF/deadlock, one crash site), or None if there is no TSan
     report (or it can't be reduced to any signature).
+
+    ``source_roots`` (Slice D, default None) is an optional list of ``--tsan-source-root`` dirs
+    that lets non-CPython (extension) frames under those roots contribute a signature instead of
+    dropping out. With the default (None) the result is byte-for-byte the CPython-only behaviour.
     """
     if WARNING.search(text):
-        return _parse_race(text)
+        return _parse_race(text, source_roots)
     m = SEGV.search(text)
     if m:
-        return _parse_segv(text, m)
+        return _parse_segv(text, m, source_roots)
     return None
 
 
-def _parse_segv(text, m):
+def _parse_segv(text, m, source_roots=None):
     """Parse a non-race TSan report (SEGV/UAF/deadlock): one crash stack. Signature is the top
     real crash site if TSan symbolized it, else the fault address + pc (deterministic under the
     fixed load address `setarch -R` gives; build-specific -- regenerate the catalog per build)."""
@@ -188,7 +248,7 @@ def _parse_segv(text, m):
             frames.append((fm.group(1), fm.group(2)))
         elif frames:
             break  # crash stack ended
-    site = _top_site(frames)
+    site = _top_site(frames, source_roots)
     if site:
         signature = "%s %s:%s" % (kind_word, site[0], site[1])
         sites = [site]
@@ -198,7 +258,7 @@ def _parse_segv(text, m):
     return dict(signature=signature, sites=sites, framework=False, kind="segv")
 
 
-def _parse_race(text):
+def _parse_race(text, source_roots=None):
     lines = text.splitlines()
     stanzas = []  # list of frame-lists, one per access stanza (in order)
     i = 0
@@ -229,7 +289,7 @@ def _parse_race(text):
         if not stanzas:
             return None
         stanzas.append(stanzas[0])
-    sites = [_top_site(fr) for fr in stanzas[:2]]
+    sites = [_top_site(fr, source_roots) for fr in stanzas[:2]]
     if all(s is None for s in sites):
         return None
     # Framework noise: every resolved site is thread/frame scaffolding.
@@ -346,17 +406,27 @@ class TSanDeduper:
     always kept.
     """
 
-    def __init__(self, catalog_path=None, keep=5, prune=False, suppressions_path=None):
+    def __init__(
+        self,
+        catalog_path=None,
+        keep=5,
+        prune=False,
+        suppressions_path=None,
+        source_roots=None,
+    ):
         self.snap = load_catalog_file(catalog_path) if catalog_path else {}
         self.keep_cap = keep
         self.prune = prune
         self.suppressor = Suppressor.from_file(suppressions_path)
+        # Slice D: optional --tsan-source-root dirs so extension-`.so` frames get a signature
+        # instead of dropping to noparse. None (the default) -> CPython-only, unchanged.
+        self.source_roots = list(source_roots) if source_roots else None
         self.seen = collections.Counter()
         self.kept = collections.Counter()
 
     def decide(self, stdout_text):
         """Return (keep: bool, label: str) for one crashing session."""
-        report = parse_report(stdout_text)
+        report = parse_report(stdout_text, source_roots=self.source_roots)
         if report is None:
             # A kept --tsan session with no parseable race: keep it, unlabelled-ish, for a look.
             self.seen["noparse"] += 1

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -111,6 +111,38 @@ REPORT_SEGV_NOFRAMES = "\n".join(
     ]
 )
 
+# Slice D: a race whose BOTH real sites live in an out-of-tree C extension (cereggii). The only
+# CPython-ish frames are the <null> interceptor, so WITHOUT --tsan-source-root the report reduces
+# to nothing (noparse); WITH the extension's root it resolves to root-relative sites.
+REPORT_EXT_VS_EXT = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=7)",
+        "  Write of size 8 at 0x7f00 by thread T1:",
+        "    #0 memset <null> (cereggii.so+0x1) (BuildId: bb)",
+        "    #1 AtomicDict_SetItem /build/cereggii/src/atomic_dict.c:412:9 (cereggii.so+0x2)",
+        "",
+        "  Previous read of size 8 at 0x7f00 by thread T2:",
+        "    #0 AtomicDict_GetItem /build/cereggii/src/atomic_dict.c:355:5 (cereggii.so+0x3)",
+        "",
+        "SUMMARY: ThreadSanitizer: data race in AtomicDict_SetItem",
+    ]
+)
+
+# Slice D: a race across the boundary -- one CPython site, one extension site. The CPython side
+# always resolves; the extension side is "?" without a root and resolves with one.
+REPORT_EXT_VS_CPYTHON = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=8)",
+        "  Write of size 8 at 0x7f00 by thread T1:",
+        "    #0 AtomicRef_Set /build/cereggii/src/atomic_ref.c:88:3 (cereggii.so+0x1)",
+        "",
+        "  Previous read of size 8 at 0x7f00 by thread T2:",
+        "    #0 list_extend /b/Objects/listobject.c:850:9 (python+0x5) (BuildId: aa)",
+        "",
+        "SUMMARY: ThreadSanitizer: data race in AtomicRef_Set",
+    ]
+)
+
 # A use-after-free with a symbolized crash stack -> signature is the top real site.
 REPORT_UAF_FRAMES = "\n".join(
     [
@@ -260,6 +292,77 @@ class TestSegv(unittest.TestCase):
         d = tsan_dedup.TSanDeduper()
         d.suppressor = tsan_dedup.Suppressor.from_lines(["dictiter_dealloc"])
         self.assertEqual(d.decide(REPORT_UAF_FRAMES), (False, None))
+
+
+class TestSourceRoots(unittest.TestCase):
+    """Slice D: external C-extension source roots. The mandatory invariant is that the DEFAULT
+    (no roots) is byte-for-byte the CPython-only behaviour -- the cross-repo signature contract."""
+
+    CEREGGII = "/build/cereggii"
+
+    def test_default_is_unchanged_cpython_only(self):
+        # No roots -> identical to the pre-Slice-D signature.
+        r = tsan_dedup.parse_report(REPORT_TWO_SITES)
+        self.assertEqual(
+            r["signature"],
+            "Objects/listobject.c:list_append | Objects/listobject.c:list_extend",
+        )
+
+    def test_cpython_matched_first_even_when_a_root_would_match(self):
+        # Passing a broad root that also contains the CPython build dir must NOT change a CPython
+        # frame's signature -- CPython is always resolved first.
+        r = tsan_dedup.parse_report(REPORT_TWO_SITES, source_roots=["/b"])
+        self.assertEqual(
+            r["signature"],
+            "Objects/listobject.c:list_append | Objects/listobject.c:list_extend",
+        )
+
+    def test_ext_vs_ext_is_noparse_without_roots(self):
+        self.assertIsNone(tsan_dedup.parse_report(REPORT_EXT_VS_EXT))
+
+    def test_ext_vs_ext_resolves_with_root(self):
+        r = tsan_dedup.parse_report(REPORT_EXT_VS_EXT, source_roots=[self.CEREGGII])
+        self.assertEqual(
+            r["signature"],
+            "src/atomic_dict.c:AtomicDict_GetItem | src/atomic_dict.c:AtomicDict_SetItem",
+        )
+
+    def test_ext_vs_cpython_resolves_both_sides_with_root(self):
+        r = tsan_dedup.parse_report(REPORT_EXT_VS_CPYTHON, source_roots=[self.CEREGGII])
+        self.assertEqual(
+            r["signature"],
+            "Objects/listobject.c:list_extend | src/atomic_ref.c:AtomicRef_Set",
+        )
+
+    def test_ext_vs_cpython_degrades_to_question_without_root(self):
+        # Without a root the extension side is unresolved ("?"), but the CPython side still keys.
+        r = tsan_dedup.parse_report(REPORT_EXT_VS_CPYTHON)
+        self.assertEqual(r["signature"], "? | Objects/listobject.c:list_extend")
+
+    def test_relative_to_root_absolute_prefix(self):
+        self.assertEqual(
+            tsan_dedup._relative_to_root("/build/cereggii/src/atomic_dict.c", "/build/cereggii"),
+            "src/atomic_dict.c",
+        )
+
+    def test_relative_to_root_basename_anchor_when_build_path_differs(self):
+        # The path baked into the .so can differ from the local root; fall back to the /name/ anchor.
+        self.assertEqual(
+            tsan_dedup._relative_to_root(
+                "/somewhere/else/cereggii/src/atomic_dict.c", "/home/me/cereggii"
+            ),
+            "src/atomic_dict.c",
+        )
+
+    def test_relative_to_root_not_under_root(self):
+        self.assertIsNone(tsan_dedup._relative_to_root("/other/pkg/foo.c", "/build/cereggii"))
+
+    def test_deduper_resolves_ext_race_with_source_roots(self):
+        # End-to-end: an ext-vs-ext race that would be noparse is a real tsanNEW with a root.
+        d_default = tsan_dedup.TSanDeduper()
+        self.assertEqual(d_default.decide(REPORT_EXT_VS_EXT), (True, "tsanNOPARSE"))
+        d_roots = tsan_dedup.TSanDeduper(source_roots=[self.CEREGGII])
+        self.assertEqual(d_roots.decide(REPORT_EXT_VS_EXT), (True, "tsanNEW"))
 
 
 class TestReadStdout(unittest.TestCase):


### PR DESCRIPTION
## Phase 4, Slice D: external C-extension source roots

An out-of-tree C extension's own race frames (its `.so`'s source paths) don't match `CPY_SRC`, so `parse_report` dropped them — an extension-vs-extension race reduced to **noparse** and never deduped, and an extension-vs-CPython race lost the extension half. Slice D lets those frames key a signature.

### Parser (`tsan_dedup.py`)
`parse_report` / `_parse_race` / `_parse_segv` / `_top_site` / `_frame_site` gain an optional `source_roots` param. A frame that is **not** CPython source but whose file lives under one of the roots is normalised to its path relative to the root (`/build/cereggii/src/atomic_dict.c` → `src/atomic_dict.c`). **CPython is always matched first**, so with the default (no roots) every signature is byte-for-byte unchanged — roots only ever rescue a frame `CPY_SRC` didn't already claim. `_relative_to_root` handles both an absolute-path prefix and the root's basename as a `/name/` anchor (the source path baked into the `.so` can differ from the local checkout).

### CLI (`__init__.py`)
New repeatable `--tsan-source-root DIR`, passed to `TSanDeduper(source_roots=…)`.

### Cross-repo contract
The signature format is imported by the sibling `cpython-tsan-findings/scripts/ingest.py` (via `FUSIL_TSAN_DEDUP`). That repo is updated in lockstep (committed there, `main`@ef637ef): ingest collects roots from `--source-root`/`-r`/`FUSIL_TSAN_SOURCE_ROOTS` and passes them through **only when set**, so with no roots it calls the old one-arg `parse_report` and stays compatible with a pre-Slice-D fusil checkout.

**Mandatory guardrail run:** re-ingesting **fleet-06 (223 dirs)** with the new parser and no roots reproduced **all 119 CPython signatures byte-for-byte** (TSAN-0037×196, TSAN-0013×5, …); diff against the pre-change baseline was empty.

### Testing
+10 unit tests: default-unchanged, CPython-matched-first-even-with-a-broad-root, ext-vs-ext (noparse → resolved), ext-vs-CPython (both sides), `_relative_to_root` (prefix / basename-anchor / not-under), and the deduper end-to-end (noparse → tsanNEW with a root). Suite **1117 → 1127**. `ruff check` + `ruff format --check` clean.

Design: `doc/tsan-mode-plan.md` → "Phase 4 → Slice D". Remaining: Slice E (weird-subclasses-of-extension, gated on `Py_TPFLAGS_BASETYPE`); wiring the `add_tsan_shared_factory` hook from the cereggii/h5py plugins is an independent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)