### PR TITLE
tsan: Slice E -- hostile subclasses of the target's own C types (opt-in)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -432,14 +432,15 @@ Emitter still gated (non-`--tsan` output unchanged).
 
 ## Phase 4: target-object coverage + provenance + extension dedup
 
-**Status (2026-07-18):** Slices **A** (worker roles, PR #213), **B** (provenance/attribution,
-PR #214), **C** (target-object factories + extension-object iterators + the
-`add_tsan_shared_factory` plugin hook, PR #215), and **D** (external C-extension source roots for
-`tsan_dedup` via `--tsan-source-root`) are **implemented**; slice **E**
-(weird-subclasses-of-extension) remains planned. The slice descriptions below are the as-designed
-intent; see the commit history / the memory note for exact as-built details. Slice D preserved the
-cross-repo signature contract: re-ingesting fleet-06 with the new parser and no roots reproduced
-all 119 CPython signatures byte-for-byte.
+**Status (2026-07-18):** all five slices are **implemented** — **A** (worker roles, PR #213),
+**B** (provenance/attribution, PR #214), **C** (target-object factories + extension-object
+iterators + the `add_tsan_shared_factory` plugin hook, PR #215), **D** (external C-extension
+source roots for `tsan_dedup` via `--tsan-source-root`, PR #216), and **E** (hostile subclasses of
+the target's own C types, **opt-in** via `--tsan-weird-subclasses`). Operation *profiles* remain
+deliberately PARKED. The slice descriptions below are the as-designed intent; see the commit
+history / the memory note for exact as-built details. Slice D preserved the cross-repo signature
+contract: re-ingesting fleet-06 with the new parser and no roots reproduced all 119 CPython
+signatures byte-for-byte.
 
 **Motivation.** Phase 3.1 proved the op-mix finds *builtin* races (TSAN-0037, the bytes iterator)
 because the shared pool is mostly builtin containers + bare `Class()` instances. The campaign's

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -469,6 +469,16 @@ class Fuzzer(Application):
             "(CPython-only signatures, unchanged).",
             default=None,
         )
+        tsan_options.add_option(
+            "--tsan-weird-subclasses",
+            action="store_true",
+            help="Also share HOSTILE subclasses of the target's own (sub-classable) C types in "
+            "the stress region -- a managed __dict__ + raising __eq__/__hash__ layered on the C "
+            "base's slots, so a concurrent C op on a shared instance fires a hostile dunder "
+            "mid-operation (the __eq__-raises-during-store race class). Opt-in (default off): it "
+            "can surface the subclass's own races as noise. (Slice E.)",
+            default=False,
+        )
 
         options = (
             input_options,

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -733,6 +733,8 @@ class WritePythonCode(WriteCode):
         # Drop process-lifecycle calls (fork/exec/spawn/...): forking a worker crashes the child
         # under TSan and is never a useful race target (see TSAN_UNSAFE_CALLS).
         funcs = [f for f in (self.module_functions or []) if f not in TSAN_UNSAFE_CALLS][:40]
+        # Slice E (opt-in): also share hostile subclasses of the target's own C types.
+        weird_subclasses = bool(getattr(self.options, "tsan_weird_subclasses", False))
 
         # Slice C: build a richer, guarded set of shared-object FACTORIES (source_expr, label,
         # iterable) -- real target objects rather than only bare Class() instances. The same
@@ -806,6 +808,9 @@ class WritePythonCode(WriteCode):
             ],
             # extension-object iterators (iter(factory())) folded into op (h) on top of builtins.
             "ext_iterators": ext_iterators,
+            # hostile subclasses of these target C types shared too (Slice E, opt-in; guarded so
+            # non-subclassable bases drop at runtime).
+            "weird_subclasses": list(shared_classes) if weird_subclasses else [],
             "iter_off": iter_off,
             "roles": {"0": "writer", "1": "reader", "2": "both"},
             "ops": [
@@ -824,7 +829,7 @@ class WritePythonCode(WriteCode):
             "func_count": len(funcs),
         }
         provenance_line = (
-            "[TSAN] provenance module=%s shared=%s(%dobj+%dcls+%dplugin+module) "
+            "[TSAN] provenance module=%s shared=%s(%dobj+%dcls+%dplugin+module) weird=%d "
             "args=list,dict,set,bytearray iterators=8+%dext iter_off=%d roles=r/w/both "
             "ops=a-i workers=%d iters=%d funcs=%d"
             % (
@@ -833,6 +838,7 @@ class WritePythonCode(WriteCode):
                 len(shared_objects),
                 len(shared_classes),
                 len(plugin_factories),
+                len(shared_classes) if weird_subclasses else 0,
                 ext_iterators,
                 iter_off,
                 workers_per_obj,
@@ -874,6 +880,54 @@ class WritePythonCode(WriteCode):
         self.write(0, "_tsan_obj_factories = []")
         for src, _label, _iterable in obj_factory_specs:
             self.write(0, "_tsan_obj_factories.append(lambda: %s)" % src)
+        # Slice E (opt-in): derive HOSTILE subclasses from the target's own C types and add their
+        # instances to the pool. A managed __dict__ + raising __eq__/__hash__ on top of the C
+        # base's slots means a concurrent C op on a shared instance fires a hostile Python dunder
+        # mid-operation -- the __eq__-raises-during-store class (how cereggii's bug surfaced).
+        # Reuses tricky_weird's WeirdBase metaclass when compatible; the guard drops a
+        # non-subclassable base (Py_TPFLAGS_BASETYPE) or one needing constructor args.
+        if weird_subclasses and shared_classes:
+            self.write_block(
+                0,
+                '''
+                def _tsan_make_weird(_base):
+                    """A hostile subclass of a target C type: managed __dict__ + raising __eq__/
+                    __hash__ on the C base's slots. WeirdBase metaclass when compatible, else a
+                    plain subclass; a non-subclassable base raises and is dropped by the caller."""
+                    def _eq(self, other):
+                        if randint(0, 3) == 0:
+                            raise ValueError("tsan weird __eq__")
+                        return NotImplemented
+                    def _hash(self):
+                        if randint(0, 3) == 0:
+                            raise ValueError("tsan weird __hash__")
+                        return randint(0, 2 ** 61)
+                    _ns = {"__eq__": _eq, "__hash__": _hash}
+                    try:
+                        return WeirdBase("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))
+                    except Exception:
+                        return type("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))
+                _tsan_weird_classes = []
+                ''',
+            )
+            for name in shared_classes:
+                self.write(0, "try:")
+                with self.indented():
+                    self.write(
+                        0,
+                        "_tsan_weird_classes.append("
+                        "_tsan_make_weird(getattr(fuzz_target_module, %r)))" % name,
+                    )
+                self.write(0, "except Exception:")
+                with self.indented():
+                    self.write(0, "pass")
+            self.write_block(
+                0,
+                """
+                for _wb in _tsan_weird_classes:
+                    _tsan_obj_factories.append((lambda _wb=_wb: _wb()))
+                """,
+            )
         self.write(0, "_TSAN_MAX_SHARED = %d" % max(2, n_shared))
         self.write_block(
             0,
@@ -928,6 +982,16 @@ class WritePythonCode(WriteCode):
         for src, _label, iterable in obj_factory_specs:
             if iterable:
                 self.write(0, "_tsan_iter_factories.append(lambda: iter(%s))" % src)
+        # Slice E: point op (h) at the hostile subclasses' iterators too (the C base's tp_iternext
+        # under a Python subclass); guarded build below drops non-iterable ones.
+        if weird_subclasses and shared_classes:
+            self.write_block(
+                0,
+                """
+                for _wb in _tsan_weird_classes:
+                    _tsan_iter_factories.append((lambda _wb=_wb: iter(_wb())))
+                """,
+            )
         self.write_block(
             0,
             """

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -56,7 +56,7 @@ def _tsan_module():
     return mod
 
 
-def _make_tsan_options(threads=4, iterations=200, shared_objects=3):
+def _make_tsan_options(threads=4, iterations=200, shared_objects=3, weird_subclasses=False):
     o = MagicMock()
     o.tsan = True
     o.tsan_threads = threads
@@ -77,6 +77,7 @@ def _make_tsan_options(threads=4, iterations=200, shared_objects=3):
     o.classes_number = 0
     o.objects_number = 0
     o.methods_number = 2
+    o.tsan_weird_subclasses = weird_subclasses  # Slice E, opt-in
     return o
 
 
@@ -249,6 +250,39 @@ class TestTSanGeneration(unittest.TestCase):
         src = _generate_tsan(plugin_manager=pm)
         self.assertIn("_tsan_obj_factories.append(lambda: object())", src)
         self.assertNotIn("_tsan_iter_factories.append(lambda: iter(object()))", src)
+
+    def test_weird_subclasses_off_by_default(self):
+        # Slice E is opt-in: default output has no hostile-subclass machinery (so the flag-gated
+        # emitter leaves the default --tsan script unchanged).
+        src = _generate_tsan()
+        self.assertNotIn("_tsan_make_weird", src)
+        self.assertEqual(_extract_tsan_manifest(src)["weird_subclasses"], [])
+
+    def test_weird_subclasses_emitted_when_enabled(self):
+        # With --tsan-weird-subclasses, hostile subclasses of the discovered C types are built
+        # (guarded on subclassability) and their instances join the shared + iterator pools.
+        src = _generate_tsan(weird_subclasses=True)
+        ast.parse(src)  # still valid Python
+        self.assertIn("def _tsan_make_weird(_base):", src)
+        self.assertIn('raise ValueError("tsan weird __eq__")', src)
+        self.assertIn('raise ValueError("tsan weird __hash__")', src)
+        # reuses tricky_weird's WeirdBase metaclass, with a plain-subclass fallback
+        self.assertIn('WeirdBase("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))', src)
+        self.assertIn('type("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))', src)
+        # the Widget C base is fed to the weird-class builder (guarded)
+        self.assertIn("_tsan_make_weird(getattr(fuzz_target_module, 'Widget'))", src)
+        # instances + iterators of the weird classes join the pools
+        self.assertIn("_tsan_obj_factories.append((lambda _wb=_wb: _wb()))", src)
+        self.assertIn("_tsan_iter_factories.append((lambda _wb=_wb: iter(_wb())))", src)
+        # provenance records the count
+        manifest = _extract_tsan_manifest(src)
+        self.assertEqual(manifest["weird_subclasses"], ["Widget"])
+        self.assertIn("weird=1", src)
+
+    def test_weird_base_boilerplate_available(self):
+        # The hostile subclasses rely on tricky_weird's WeirdBase being spliced into the script.
+        src = _generate_tsan(weird_subclasses=True)
+        self.assertIn("class WeirdBase", src)
 
     def test_knobs_are_parameterised(self):
         src = _generate_tsan(threads=7, iterations=42)


### PR DESCRIPTION
## Phase 4, Slice E: hostile subclasses of the target's own C types (opt-in)

The stress region shares *real* target objects (Slice C) but never a **hostile subclass** of a target C type — the exact shape that surfaced cereggii's `__eq__`-raises-during-concurrent-store bug. Slice E adds them.

### Emitter (`write_python_code.py`, gated on `--tsan-weird-subclasses`)
For each already-sampled discovered class, emit a **guarded** `_tsan_make_weird(base)` that builds a subclass with a **managed `__dict__` + raising `__eq__`/`__hash__`** layered on the C base's slots (reusing `tricky_weird`'s `WeirdBase` metaclass when compatible, plain-subclass fallback otherwise). A concurrent C op on a shared instance then fires a hostile Python dunder mid-operation. The weird instances join the **shared-object pool** *and* (op *h*) the **shared-iterator pool**. The guard drops a non-subclassable base (`Py_TPFLAGS_BASETYPE`) or one needing constructor args — verified against real C types (`OrderedDict`/`BytesIO`/`list` build with a working managed `__dict__` and intermittently-raising dunders; `bool` is dropped).

### Why this enriches CPython core (not just extensions)
The weird subclasses derive from the **discovered `module_classes`**, which for this campaign are CPython's own internal C-extension types (`OrderedDict`, `BytesIO`, `array`, `Decimal`, `_asyncio.Task`, …). So this primarily exercises **subtype `tp_*` dispatch + managed-dict machinery under concurrency** on CPython core — the third-party-extension case is the rarer one (needs its own TSan build).

### Opt-in by design
Default **off** because a hostile subclass can surface its *own* Python-level races as noise. When enabled, Slice B's provenance manifest records `weird=N` / `weird_subclasses=[…]`, so any resulting hit stays attributable. CLI: `--tsan-weird-subclasses`.

### Safety / testing
- Emitter is `--tsan` **and** flag gated → default `--tsan` output and **non-`--tsan` goldens unchanged** (verified `test_golden_output`).
- +3 tests (off-by-default incl. manifest `weird_subclasses: []`, emitted-when-enabled incl. `WeirdBase`/fallback/pool+iterator wiring/`weird=1`, `WeirdBase` boilerplate present). Suite **1127 → 1130**. `ruff check` + `ruff format --check` clean.

Design: `doc/tsan-mode-plan.md` → "Phase 4 → Slice E". **This completes Phase 4 (A–E)**; operation profiles stay parked. Independent follow-up still open: wiring `add_tsan_shared_factory` from the cereggii/h5py plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)