### PR TITLE
tsan: enrich Slice E weird subclasses with curated, diverse hostile dunders

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -881,28 +881,61 @@ class WritePythonCode(WriteCode):
         for src, _label, _iterable in obj_factory_specs:
             self.write(0, "_tsan_obj_factories.append(lambda: %s)" % src)
         # Slice E (opt-in): derive HOSTILE subclasses from the target's own C types and add their
-        # instances to the pool. A managed __dict__ + raising __eq__/__hash__ on top of the C
-        # base's slots means a concurrent C op on a shared instance fires a hostile Python dunder
-        # mid-operation -- the __eq__-raises-during-store class (how cereggii's bug surfaced).
-        # Reuses tricky_weird's WeirdBase metaclass when compatible; the guard drops a
-        # non-subclassable base (Py_TPFLAGS_BASETYPE) or one needing constructor args.
+        # instances to the pool. A managed __dict__ + a curated set of DELAYED, exception-diverse
+        # failure-injection dunders on top of the C base's slots means a concurrent C op on a
+        # shared instance fires a hostile Python dunder mid-operation -- the
+        # __eq__-raises-during-store class (how cereggii's bug surfaced). Reuses tricky_weird's
+        # WeirdBase metaclass when compatible; the guard drops a non-subclassable base
+        # (Py_TPFLAGS_BASETYPE) or one needing constructor args.
         if weird_subclasses and shared_classes:
             self.write_block(
                 0,
                 '''
+                # Curated arm-vs-leave: ARM comparison / hashing / formatting / index dunders
+                # (the paths the op-mix drives on a shared instance, plus comparisons that fire via
+                # sort / dict-key / method-internal use -- the __gt__ class), and LEAVE the
+                # container/iteration protocol (__iter__/__next__/__len__/__getitem__/__contains__)
+                # to the C base so op (a)/(h)/(i) still race the base's OWN slots. Lifecycle dunders
+                # stay working so construction + op-(d) setattr churn keep going.
+                _TSAN_WEIRD_ARM = ("__eq__", "__ne__", "__hash__", "__lt__", "__le__", "__gt__",
+                                   "__ge__", "__repr__", "__str__", "__format__", "__index__")
+                # A TSan-appropriate exception mix: boring + caught by the worker -- deliberately NOT
+                # MemoryError (the OOM signal) or SystemError (a crash word), so a caught weird raise
+                # never masquerades as a hit.
+                _TSAN_WEIRD_EXCS = (ValueError, TypeError, RuntimeError, KeyError, IndexError,
+                                    OverflowError, ArithmeticError)
+                def _tsan_arm_slot(_name, _base):
+                    # Delayed bomb: succeed a per-instance random number of times (delegating to the
+                    # C base's real slot so the object behaves normally + races that slot), THEN
+                    # raise a random exc -- detonating deeper in a concurrent C op than an immediate
+                    # raise would.
+                    _bslot = getattr(_base, _name, None)
+                    def _slot(self, *_a, **_k):
+                        _c = self._tsan_bomb_calls
+                        _c[_name] = _c.get(_name, 0) + 1
+                        if _c[_name] > self._tsan_bomb_delay:
+                            raise choice(_TSAN_WEIRD_EXCS)("tsan weird via " + _name)
+                        if callable(_bslot):
+                            return _bslot(self, *_a, **_k)
+                        # base has no usable slot (e.g. list.__hash__ is None): a type-correct value
+                        return id(self) if _name == "__hash__" else (
+                            0 if _name == "__index__" else NotImplemented)
+                    _slot.__name__ = _name
+                    return _slot
                 def _tsan_make_weird(_base):
-                    """A hostile subclass of a target C type: managed __dict__ + raising __eq__/
-                    __hash__ on the C base's slots. WeirdBase metaclass when compatible, else a
-                    plain subclass; a non-subclassable base raises and is dropped by the caller."""
-                    def _eq(self, other):
-                        if randint(0, 3) == 0:
-                            raise ValueError("tsan weird __eq__")
-                        return NotImplemented
-                    def _hash(self):
-                        if randint(0, 3) == 0:
-                            raise ValueError("tsan weird __hash__")
-                        return randint(0, 2 ** 61)
-                    _ns = {"__eq__": _eq, "__hash__": _hash}
+                    """A hostile subclass of a target C type: managed __dict__ + curated delayed
+                    failure-injection dunders on the C base's slots. WeirdBase metaclass when
+                    compatible, else a plain subclass; a non-subclassable base raises and is
+                    dropped by the caller."""
+                    _ns = {_n: _tsan_arm_slot(_n, _base) for _n in _TSAN_WEIRD_ARM}
+                    def _wi(self, *_a, **_k):
+                        object.__setattr__(self, "_tsan_bomb_calls", {})
+                        object.__setattr__(self, "_tsan_bomb_delay", randint(0, 3))
+                        try:
+                            _base.__init__(self, *_a, **_k)
+                        except Exception:
+                            pass
+                    _ns["__init__"] = _wi
                     try:
                         return WeirdBase("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))
                     except Exception:

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -264,8 +264,11 @@ class TestTSanGeneration(unittest.TestCase):
         src = _generate_tsan(weird_subclasses=True)
         ast.parse(src)  # still valid Python
         self.assertIn("def _tsan_make_weird(_base):", src)
-        self.assertIn('raise ValueError("tsan weird __eq__")', src)
-        self.assertIn('raise ValueError("tsan weird __hash__")', src)
+        # curated, DELAYED, exception-diverse failure-injection dunders (the bomb pattern)
+        self.assertIn("def _tsan_arm_slot(_name, _base):", src)
+        self.assertIn("_tsan_bomb_delay", src)  # delay: succeed then detonate
+        self.assertIn("_TSAN_WEIRD_EXCS = (", src)  # exception diversity
+        self.assertIn('raise choice(_TSAN_WEIRD_EXCS)("tsan weird via " + _name)', src)
         # reuses tricky_weird's WeirdBase metaclass, with a plain-subclass fallback
         self.assertIn('WeirdBase("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))', src)
         self.assertIn('type("_TsanWeird_" + _base.__name__, (_base,), dict(_ns))', src)
@@ -278,6 +281,24 @@ class TestTSanGeneration(unittest.TestCase):
         manifest = _extract_tsan_manifest(src)
         self.assertEqual(manifest["weird_subclasses"], ["Widget"])
         self.assertIn("weird=1", src)
+
+    def test_weird_subclasses_curated_arm_list(self):
+        # The arm-vs-leave contract: ARM comparison/hash/eq/repr/index; LEAVE the container /
+        # iteration protocol to the C base (so op a/h/i still race its OWN slots), and keep the
+        # exception mix free of the OOM (MemoryError) / crash (SystemError) signal words.
+        src = _generate_tsan(weird_subclasses=True)
+        # extract the full (possibly multi-line) armed-dunder tuple text
+        start = src.index("_TSAN_WEIRD_ARM = (")
+        arm_text = src[start : src.index(")", start)]
+        for armed in ("__eq__", "__hash__", "__lt__", "__gt__", "__repr__", "__index__"):
+            self.assertIn(armed, arm_text, armed)
+        for left in ("__iter__", "__next__", "__len__", "__getitem__", "__contains__"):
+            self.assertNotIn(left, arm_text, left)  # left to the C base
+        exc_start = src.index("_TSAN_WEIRD_EXCS = (")
+        exc_text = src[exc_start : src.index(")", exc_start)]
+        self.assertIn("ValueError", exc_text)
+        self.assertNotIn("MemoryError", exc_text)  # OOM signal
+        self.assertNotIn("SystemError", exc_text)  # crash word
 
     def test_weird_base_boilerplate_available(self):
         # The hostile subclasses rely on tricky_weird's WeirdBase being spliced into the script.


### PR DESCRIPTION
## Slice E enrichment: curated, diverse hostile dunders

Follow-up to Slice E (#217). The hostile subclass only armed `__eq__`/`__hash__`, always `ValueError`, on a crude 1-in-4 random — far less diverse than fusil's bombs (delay + ~10 exception types + ~60 dunders). But the op-mix already drives `repr`/`hash`/`bool`/`str` and comparisons (via `sorted()`) on the shared instance, so those calls just hit the C base's real slots and passed. This arms them — motivated by a real `__gt__` crash we caught recently.

### Curated arm-vs-leave (the key design point)
Because the weird object **is-a** C type and we share it precisely to race the **C base's own slots** (we even fold `iter(weird())` into op h):
- **ARM** (inject failure): `__eq__ __ne__ __hash__ __lt__ __le__ __gt__ __ge__ __repr__ __str__ __format__ __index__` — the paths the op-mix drives, plus comparisons that fire via sort / dict-key / method-internal use.
- **LEAVE to the C base**: `__iter__`/`__next__`/`__len__`/`__getitem__`/`__contains__` (so op a/h/i still race the base's OWN slots) and lifecycle dunders (so construction + op-d's `setattr` churn keep working).

### Delayed + exception-diverse, reusing the bomb pattern
Each armed slot **succeeds a per-instance random number of times — delegating to the C base's real slot** so the object behaves normally and races that slot — then raises a random exception from a TSan-appropriate set (`ValueError`/`TypeError`/`RuntimeError`/`KeyError`/`IndexError`/`OverflowError`/`ArithmeticError`; deliberately **not** `MemoryError` (the OOM signal) or `SystemError` (a crash word), so a caught weird raise never masquerades as a hit). The success path is **type-correct by delegation**, with an `id()`/`0`/`NotImplemented` fallback for the case where the base has no usable slot (e.g. `list.__hash__ is None`).

### Verification
Validated against real C bases — `OrderedDict`/`BytesIO`/`list`/`str`/`int`/`tuple`/`bytearray`/`frozenset` all build with a managed `__dict__`, a type-safe success path, and fire our curated exceptions on delay-0; `bool`/`NoneType`/`range` are dropped as non-subclassable. Emitter stays `--tsan`+flag gated → default `--tsan` output and non-`--tsan` goldens unchanged. +1 test (curated arm-vs-leave contract) + updated the emission test; suite **1130 → 1131**; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)