### PR TITLE
fleet: export PYTHONPYCACHEPREFIX so the root runner leaves the build tree clean

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -110,7 +110,13 @@ python3 scripts/gen_known_races.py                        # regenerate known_rac
   `fleet up` fills in the paths/limits and installs it. `systemctl start fusil@3` ⇒ runs
   instance 3.
 - **`fleet-run N`** — what each unit actually runs: makes `inst-NN/`, picks the GIL mode
-  for instance N, `exec`s fusil there so systemd supervises fusil directly.
+  for instance N, `exec`s fusil there so systemd supervises fusil directly. It also exports
+  `PYTHONPYCACHEPREFIX=/tmp/fusil-pycache-root` so the (root) runner interpreter never writes
+  `.pyc` into the target build's shared `Lib/` — systemd gives the service a clean env, so a
+  shell export before `fleet up` would never reach it, and the interpreter reads the var only at
+  startup. (fusil redirects its own module-discovery imports and its downgraded fusil-user
+  children to `/tmp/fusil-pycache` in-process.) Keeps the matrix tree free of root-owned `.pyc`
+  that would otherwise block `rm`/rebuild.
 - **`fleet`** — a thin wrapper over `systemctl` + reads the result dirs for `status`/`finds`.
 
 To see raw systemd state at any time: `systemctl status 'fusil@*'`,

--- a/fleet/fleet-run
+++ b/fleet/fleet-run
@@ -27,6 +27,16 @@ if [ -z "${HOME:-}" ]; then
 fi
 export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
 export PYTHON_GIL="$gil"
+# Keep CPython's bytecode cache out of the target build tree. systemd runs fusil as root, and the
+# target is usually a venv sharing a matrix build's Lib/, so RUNNER_PY (fusil's main process) would
+# write ROOT-owned .pyc into builds/*/Lib/**/__pycache__ -- which then blocks the matrix owner from
+# rm/rebuilding without sudo. fusil already redirects its own module-discovery imports and its
+# downgraded fusil-user children (to /tmp/fusil-pycache) in-process, but PYTHONPYCACHEPREFIX is only
+# read at interpreter STARTUP, so the main interpreter's own startup imports can ONLY be redirected
+# from the environment -- which is here (systemd gives the service a clean env; a shell export
+# before `fleet up` never reaches it). Disposable /tmp prefix, root phase distinct from the fusil
+# children's; honour an override.
+export PYTHONPYCACHEPREFIX="${PYTHONPYCACHEPREFIX:-/tmp/fusil-pycache-root}"
 # systemd runs with a clean environment (no venv activation); add the fusil repo root so
 # `import fusil` works whether or not fusil is pip-installed in RUNNER_PY's environment.
 export PYTHONPATH="$(dirname "$(dirname "$FUSIL_PY")")${PYTHONPATH:+:$PYTHONPATH}"


### PR DESCRIPTION
## Close the last `.pyc` gap in the fleet launcher

Companion to PR #219 (in-fusil `.pyc` redirect). Your intuition was right: **a shell export before `fleet` doesn't reach the fuzzer** — systemd starts `fusil@N` with a *clean* environment, so env must come from the unit or its `ExecStart` script.

### Why the code fix alone isn't enough here
`#219` covers, in-process: fusil's own module-discovery imports (`sys.pycache_prefix`), the TSan preflight subprocess, and the downgraded fusil-user children (child env). But `PYTHONPYCACHEPREFIX` is only read at **interpreter startup**, so the **root runner interpreter's own startup imports** (`encodings`/`codecs`/… from the venv's shared build `Lib/`) run *before* any fusil code and can only be redirected from the environment.

### The fix
`fleet-run` is exactly where per-instance env is exported (`PYTHON_GIL`, `ASAN_OPTIONS`, `PYTHONPATH`) right before `exec`ing the runner. Adding one export there means the runner gets `PYTHONPYCACHEPREFIX` at startup:

```sh
export PYTHONPYCACHEPREFIX="${PYTHONPYCACHEPREFIX:-/tmp/fusil-pycache-root}"
```

Now every context that runs an interpreter against the build writes `.pyc` to a disposable `/tmp` prefix — root phases → `/tmp/fusil-pycache-root`, fusil-user children → `/tmp/fusil-pycache` — so the matrix tree never collects root-owned `.pyc` that block `rm`/rebuild. It honours an override, and is documented in `fleet/README.md`.

### Why here and not the unit
Equivalent to a systemd `Environment=` in the unit template, but `fleet-run` matches the existing env-setup pattern and needs no `fleet up` reinstall/`daemon-reload` — a `fleet restart` (or the normal `Restart=always` cycle) picks it up.

### Verification
Proven that a pre-`exec` env var redirects **all** imports including startup (33 `.pyc` → `/tmp`, source tree clean). `bash -n fleet-run` OK. After a fresh run: `find <build> ! -user <owner> -print` should print nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)