### PR TITLE
tsan: foundation for multi-race-per-session (--tsan-no-halt + parse_all_reports)

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -479,6 +479,16 @@ class Fuzzer(Application):
             "can surface the subclass's own races as noise. (Slice E.)",
             default=False,
         )
+        tsan_options.add_option(
+            "--tsan-no-halt",
+            action="store_true",
+            help="Run TSan with halt_on_error=0 (report-and-continue) instead of stopping at the "
+            "first race, so ONE session can surface many distinct races (the op-mix keeps running "
+            "the full iteration count). Detection is textual, so races still score. Caveat: after "
+            "a memory-corrupting race (UAF/SEGV) later reports may be corruption artifacts -- the "
+            "first race is the trustworthy one. Default off (halt at first race).",
+            default=False,
+        )
 
         options = (
             input_options,
@@ -658,8 +668,11 @@ class Fuzzer(Application):
             # shell) and blocks ~forever on that currently-blackholed endpoint. With it cleared in
             # the child (below), symbolization returns in ~0.3s with full file:line frames -- worth
             # having in-loop, since the racing site then lands in the crash dir for triage/dedup.
-            # halt_on_error=1/exitcode=66: stop at the first race with a clean exit.
-            tsan_opts = ["halt_on_error=1", "symbolize=1", "exitcode=66", "history_size=4"]
+            # halt_on_error=1/exitcode=66: stop at the first race with a clean exit. With
+            # --tsan-no-halt, report-and-continue (0) so one session surfaces many races; exit is
+            # still 66 (TSan's exitcode fires at exit if any error was reported).
+            halt = "0" if self.options.tsan_no_halt else "1"
+            tsan_opts = ["halt_on_error=%s" % halt, "symbolize=1", "exitcode=66", "history_size=4"]
             if self.options.tsan_suppressions:
                 tsan_opts.append("suppressions=%s" % self.options.tsan_suppressions)
             process.env.set("TSAN_OPTIONS", ":".join(tsan_opts))

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -231,6 +231,37 @@ def parse_report(text, source_roots=None):
     return None
 
 
+# The start of one TSan report: `WARNING: ThreadSanitizer: ...` or `==PID==ERROR: ThreadSanitizer:
+# ...` at line start. Deliberately NOT `SUMMARY: ThreadSanitizer:` (that ends a report). Used to
+# split a report-and-continue (halt_on_error=0) stdout into per-report chunks for parse_all_reports.
+_REPORT_START = re.compile(r"^(?:={2,}\d+={2,})?\s*(?:WARNING|ERROR): ThreadSanitizer: ", re.M)
+
+
+def parse_all_reports(text, source_roots=None):
+    """Parse EVERY ThreadSanitizer report in ``text`` (halt_on_error=0 emits many), in order,
+    de-duplicated by signature. Returns a list of report dicts of the same shape as
+    ``parse_report`` (each carrying an extra ``order`` index = its position in the stream, so a
+    caller can flag reports that FOLLOW a UAF/SEGV as possible corruption artifacts).
+
+    ``parse_report`` stays first-report-only -- this is purely additive, so the sibling catalog's
+    signature contract (which uses ``parse_report``) is unchanged.
+    """
+    starts = [m.start() for m in _REPORT_START.finditer(text)]
+    if not starts:
+        return []
+    out = []
+    seen = set()
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(text)
+        rep = parse_report(text[start:end], source_roots)  # each chunk holds exactly one report
+        if not rep or not rep.get("signature") or rep["signature"] in seen:
+            continue
+        seen.add(rep["signature"])
+        rep = dict(rep, order=len(out))
+        out.append(rep)
+    return out
+
+
 def _parse_segv(text, m, source_roots=None):
     """Parse a non-race TSan report (SEGV/UAF/deadlock): one crash stack. Signature is the top
     real crash site if TSan symbolized it, else the fault address + pc (deterministic under the

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -155,6 +155,42 @@ REPORT_UAF_FRAMES = "\n".join(
 )
 
 
+class TestParseAll(unittest.TestCase):
+    """parse_all_reports: extract EVERY race from a report-and-continue (halt_on_error=0) stdout."""
+
+    def test_multiple_distinct_races(self):
+        text = "\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC, REPORT_SEGV_NOFRAMES])
+        reps = tsan_dedup.parse_all_reports(text)
+        self.assertEqual([r["kind"] for r in reps], ["race", "race", "segv"])
+        self.assertEqual([r["order"] for r in reps], [0, 1, 2])  # stream position preserved
+        sigs = {r["signature"] for r in reps}
+        self.assertIn("Objects/listobject.c:list_append | Objects/listobject.c:list_extend", sigs)
+        self.assertEqual(len(sigs), 3)
+
+    def test_dedup_by_signature(self):
+        # the same race reported twice (here swapped-thread form) collapses to one entry
+        text = "\n".join([REPORT_TWO_SITES, REPORT_SWAPPED])
+        reps = tsan_dedup.parse_all_reports(text)
+        self.assertEqual(len(reps), 1)
+        self.assertEqual(
+            reps[0]["signature"],
+            "Objects/listobject.c:list_append | Objects/listobject.c:list_extend",
+        )
+
+    def test_single_report_and_empty(self):
+        self.assertEqual(len(tsan_dedup.parse_all_reports(REPORT_TWO_SITES)), 1)
+        self.assertEqual(tsan_dedup.parse_all_reports(NO_RACE), [])
+        self.assertEqual(tsan_dedup.parse_all_reports(""), [])
+
+    def test_parse_report_still_first_only(self):
+        # the contract for the sibling catalog: parse_report is unchanged (first report only).
+        text = "\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC])
+        self.assertEqual(
+            tsan_dedup.parse_report(text)["signature"],
+            "Objects/listobject.c:list_append | Objects/listobject.c:list_extend",
+        )
+
+
 class TestParse(unittest.TestCase):
     def test_signature_is_sorted_site_pair(self):
         r = tsan_dedup.parse_report(REPORT_TWO_SITES)


### PR DESCRIPTION
## Multi-race-per-session, part 1 of 4 (the enabling pieces)

Under `halt_on_error=1` a `--tsan` session reports only its **first** race, so distinct races in the same session are masked. An experiment on one real `_decimal` fleet session confirmed the payoff: **10 distinct races** surface when we don't halt (vs 1 halted) — including independent `_decimal` Context races that were hidden behind the count residual, plus a cascade SEGV.

This PR lands the two foundation pieces; the keep-policy sidecar (#3) and the ingest side (#4) follow in separate PRs.

### #1 — emit (`__init__.py`)
`--tsan-no-halt` sets `TSAN_OPTIONS halt_on_error=0` (report-and-continue). Opt-in; default stays `1`. Detection is textual so races still score, and exit stays `66` (TSan's `exitcode` fires at exit when any error was reported — verified in the experiment).

### #2 — parse (`tsan_dedup.py`)
`parse_all_reports(text, source_roots=None)` splits the stdout on TSan report-start headers (`WARNING`/`ERROR`, deliberately not `SUMMARY`) and parses each chunk, returning the **distinct** races in stream order with an `order` index — so a caller can flag reports that **follow a UAF/SEGV** as possible corruption artifacts (the first race is the trustworthy one). `parse_report` is **unchanged** (first-report only), so the sibling catalog's signature contract is untouched — purely additive.

Verified on the real 13-block experiment log: `parse_all_reports` returns **10 distinct races** (count residual + its UAF faces + the `_decimal` Context races + a `segv` at `order=9`) where `parse_report` returns 1.

### Tests
+4 (`multiple distinct races`, `dedup-by-signature`, `single/empty`, `parse_report-still-first-only`); suite **1131 → 1135**; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)