### PR TITLE
tsan: multi-race dedup/keep + tsan_races.tsv sidecar (--tsan-no-halt #3)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -518,6 +518,47 @@ lockstep), E later. After each slice: full suite, `test_tsan_generation` + `test
 non-`--tsan` golden check (untouched), `ruff check` + `ruff format --check`; for C/D a real
 emitted-script smoke run + a fleet re-ingest showing **0 unexpected new signatures**.
 
+## Phase 5 as-built: multi-race per session (`--tsan-no-halt`)
+
+**Status (2026-07-18):** foundation landed as PR #221, dedup/keep + sidecar as PR #222.
+
+**Motivation.** After the count-`__repr__` fast-mode fix (cpython#153917) landed and the TSan
+build was rebuilt, fleet-10 surfaced a diverse spray of *new* races (`setiter_iternext`,
+`unicodeiter_next`, `dictiter_iternext_threadsafe`, `_decimal_Context_clear_traps_impl`,
+`_PyLong_DigitCount`, `_elementtree create_extra`) — but that diversity was **across** sessions.
+Under the default `halt_on_error=1`, TSan reports only the **first** race per session and exits,
+so every other race a session could expose is thrown away. Re-running one fleet-10 `_decimal`
+`source.py` under `halt_on_error=0` produced **13 report blocks = 10 distinct races** from a
+single session (the count residual + its UAF faces + two genuine new `_decimal` Context races
+`…clear_traps_impl | context_repr` and `… | type_call` + a cascade SEGV) — proving both the
+value and the caveat: the count UAF cascaded into a SEGV, so races reported *after* a fault can be
+corruption artifacts rather than independent findings.
+
+**#1 + #2 — capture (PR #221).**
+- `--tsan-no-halt` sets `TSAN_OPTIONS halt_on_error=0` (opt-in; default stays `halt_on_error=1`;
+  exit is still 66 and detection stays textual, so a session surfaces *every* race instead of the
+  first).
+- `tsan_dedup.parse_all_reports(text, source_roots=None)` splits a report-and-continue stdout on
+  each `WARNING:`/`==PID==ERROR: ThreadSanitizer:` header, parses each chunk with the *unchanged*
+  `parse_report`, de-dupes by signature, and returns the distinct races in stream order with an
+  `order` index. `parse_report` stays first-report-only, so the sibling catalog's signature
+  contract (which imports `parse_report`) is untouched.
+
+**#3 — dedup / keep / sidecar (PR #222).**
+- `TSanDeduper.decide_all(text)` classifies **every** distinct race (via the shared
+  `_classify_report`, so tallying and the prune cap behave exactly as the single-race `decide`).
+  It returns `(keep, headline_label, races)`: **keep-if-ANY** race is worth keeping; a dir is
+  pruned only when **every** race is a known-over-cap duplicate or suppressed. The dir name takes
+  the **headline** label — the first new finding (`tsanNEW`/`tsanSEGV`), else the first kept known
+  id. For 0 or 1 parseable reports it delegates to `decide`, so the default `halt_on_error=1` path
+  (accounting, label, noparse) is byte-for-byte unchanged.
+- Each race carries `after_fault` — True once a SEGV/UAF has appeared earlier in the same stream —
+  flagging the corruption-artifact caveat above.
+- A multi-race kept session drops a **`tsan_races.tsv` sidecar** (`format_races_tsv`, columns
+  `order/label/kind/after_fault/signature`, signature last so a naïve tab-split is safe) next to
+  `source.py`, recording the full per-race breakdown for the sibling catalog's ingest (#4). Only
+  written under `--tsan-no-halt` with ≥2 distinct races, so default runs are unaffected.
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -911,19 +911,37 @@ class Fuzzer(Application):
 
     def _tsan_keep_policy(self, session):
         """Return (keep, label) for a crashed --tsan session from its captured stdout: reduce the
-        ThreadSanitizer report to its race signature, then label / prune via the catalog.
+        ThreadSanitizer report(s) to race signatures, then label / prune via the catalog.
 
-        Consulted synchronously by SessionDirectory.checkKeepDirectory (stdout is complete).
+        Under ``--tsan-no-halt`` a single session can carry MANY races (halt_on_error=0); this
+        uses ``decide_all`` to classify every distinct race, keep the dir if ANY is worth keeping,
+        label the dir with the headline (first new) race, and drop a ``tsan_races.tsv`` sidecar
+        recording the full per-race breakdown for the sibling catalog's ingest. With the default
+        halt_on_error=1 (one race per session) ``decide_all`` degrades to the single-race
+        ``decide`` and no sidecar is written, so behaviour is unchanged.
+
+        Consulted synchronously by SessionDirectory.checkKeepDirectory (stdout is complete, and
+        the dir has not yet been renamed -- a sidecar written here is carried along by the rename).
         Returns (True, None) on any error so a race is never lost to a dedupe failure.
         """
         import os
 
         session_dir = session.directory.directory
         try:
-            from fusil.python.tsan_dedup import read_crash_stdout
+            from fusil.python.tsan_dedup import format_races_tsv, read_crash_stdout
 
             text = read_crash_stdout(os.path.join(session_dir, "stdout"))
-            return self._tsan_deduper.decide(text)
+            keep, label, races = self._tsan_deduper.decide_all(text)
+            if keep and len(races) >= 2:
+                # Multi-race session (only possible under --tsan-no-halt): persist the full
+                # breakdown next to source.py so triage/ingest sees every race, not just the
+                # headline. Never let a sidecar-write failure lose the crash.
+                try:
+                    with open(os.path.join(session_dir, "tsan_races.tsv"), "w") as fh:
+                        fh.write(format_races_tsv(races))
+                except OSError as err:
+                    self.error("TSan sidecar write failed (%s); keeping crash dir" % err)
+            return keep, label
         except Exception as err:
             self.error("TSan keep-policy failed (%s); keeping crash dir unlabelled" % err)
             return True, None

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -456,12 +456,20 @@ class TSanDeduper:
         self.kept = collections.Counter()
 
     def decide(self, stdout_text):
-        """Return (keep: bool, label: str) for one crashing session."""
+        """Return (keep: bool, label: str) for one crashing session (first race only)."""
         report = parse_report(stdout_text, source_roots=self.source_roots)
         if report is None:
             # A kept --tsan session with no parseable race: keep it, unlabelled-ish, for a look.
             self.seen["noparse"] += 1
             return True, "tsanNOPARSE"
+        return self._classify_report(report)
+
+    def _classify_report(self, report):
+        """Classify one already-parsed race report into (keep, label), updating the seen/kept
+        counters and honouring suppressions, framework noise, and the catalog + prune cap.
+
+        Shared by ``decide`` (first race) and ``decide_all`` (every race under halt_on_error=0),
+        so both paths tally and prune identically."""
         if self.suppressor.suppresses(report):
             self.seen["suppressed"] += 1
             return False, None
@@ -480,8 +488,110 @@ class TSanDeduper:
         self.seen[("NEW-SEGV:" if is_segv else "NEW:") + report["signature"]] += 1
         return True, "tsanSEGV" if is_segv else "tsanNEW"
 
+    def decide_all(self, stdout_text):
+        """Multi-race decision for a report-and-continue (``--tsan-no-halt``) session.
+
+        Returns ``(keep, headline_label, races)`` where ``races`` is a list of per-race dicts
+        (``signature``, ``label``, ``kind``, ``order``, ``keep``, ``after_fault``), one per
+        DISTINCT race in the stream -- suitable for a ``tsan_races.tsv`` sidecar. ``keep`` is True
+        if ANY race is worth keeping (new / framework / known-under-cap / unparseable); the dir is
+        pruned only when EVERY race is a known-over-cap duplicate or suppressed. ``headline_label``
+        is the first NEW finding's label, else the first kept race's label (for the dir name).
+        ``after_fault`` marks a race reported AFTER a SEGV/UAF in the same stream -- possibly a
+        corruption artifact of the first fault rather than an independent race.
+
+        For 0 or 1 parseable reports this delegates to ``decide`` (so the default halt_on_error=1
+        single-race path -- accounting, label, and the noparse case -- is byte-for-byte unchanged),
+        returning a 0- or 1-element ``races`` list.
+        """
+        reports = parse_all_reports(stdout_text, source_roots=self.source_roots)
+        if len(reports) <= 1:
+            keep, label = self.decide(stdout_text)
+            races = []
+            if reports:
+                rep = reports[0]
+                races.append(
+                    {
+                        "signature": rep["signature"],
+                        "label": label,
+                        "kind": rep["kind"],
+                        "order": 0,
+                        "keep": keep,
+                        "after_fault": False,
+                    }
+                )
+            return keep, label, races
+        races = []
+        fault_seen = False
+        for rep in reports:
+            keep, label = self._classify_report(rep)
+            races.append(
+                {
+                    "signature": rep["signature"],
+                    "label": label,
+                    "kind": rep["kind"],
+                    "order": rep["order"],
+                    "keep": keep,
+                    "after_fault": fault_seen,
+                }
+            )
+            if rep["kind"] == "segv":
+                fault_seen = True  # races reported AFTER a fault may be corruption artifacts
+        keep_any = any(r["keep"] for r in races)
+        return keep_any, _headline_label(races), races
+
     def report(self):
         lines = ["TSan dedupe summary (seen / kept):"]
         for key, n in self.seen.most_common():
             lines.append("  %-40s seen=%-5d kept=%d" % (key, n, self.kept.get(key, n)))
         return "\n".join(lines)
+
+
+# ---- multi-race helpers (decide_all + the tsan_races.tsv sidecar) ----
+# A "new finding" label ranks above a known/framework one for the crash dir's HEADLINE name.
+_NEW_LABELS = ("tsanNEW", "tsanSEGV")
+
+
+def _headline_label(races):
+    """Pick the crash dir's headline label from a decided race list: the first NEW finding
+    (``tsanNEW`` / ``tsanSEGV``), else the first kept & labelled race (a known id or
+    ``tsanFRAME``), else the first labelled race at all, else None."""
+    for r in races:
+        if r["label"] in _NEW_LABELS:
+            return r["label"]
+    for r in races:
+        if r["keep"] and r["label"]:
+            return r["label"]
+    for r in races:
+        if r["label"]:
+            return r["label"]
+    return None
+
+
+# Sidecar column order; `signature` stays LAST because it is the only field that contains spaces
+# (never a tab), so a naive `line.split("\t")` recovers every column intact.
+RACES_TSV_HEADER = "order\tlabel\tkind\tafter_fault\tsignature"
+
+
+def format_races_tsv(races):
+    """Render a decided race list (from ``decide_all``) as a ``tsan_races.tsv`` sidecar string:
+    one tab-separated row per distinct race, a suppressed race's empty label rendered as
+    ``suppressed``. Pure formatting, so it unit-tests without touching the filesystem; the
+    keep-policy writes the returned string into the kept crash dir, and the sibling catalog's
+    ``ingest.py`` reads it back (a cross-repo consumer -- keep the columns stable)."""
+    lines = [
+        "# fusil tsan_races.tsv: distinct races in one session (--tsan-no-halt multi-race capture)",
+        "# " + RACES_TSV_HEADER,
+    ]
+    for r in races:
+        lines.append(
+            "%d\t%s\t%s\t%d\t%s"
+            % (
+                r["order"],
+                r["label"] or "suppressed",
+                r["kind"],
+                1 if r["after_fault"] else 0,
+                r["signature"],
+            )
+        )
+    return "\n".join(lines) + "\n"

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -299,6 +299,128 @@ class TestDecide(unittest.TestCase):
         self.assertEqual(self._deduper().decide(NO_RACE), (True, "tsanNOPARSE"))
 
 
+class TestDecideAll(unittest.TestCase):
+    """decide_all: classify EVERY distinct race in a --tsan-no-halt session, keep-if-any-new,
+    prune-if-all-known/suppressed, headline label, after_fault flag, and the tsan_races.tsv."""
+
+    def _deduper(self, catalog_rows=(), keep=5, prune=False, supp_lines=None):
+        d = tsan_dedup.TSanDeduper(keep=keep, prune=prune)
+        d.snap = tsan_dedup.load_catalog(list(catalog_rows))
+        if supp_lines is not None:
+            d.suppressor = tsan_dedup.Suppressor.from_lines(supp_lines)
+        return d
+
+    def test_all_new_kept_with_per_race_rows(self):
+        text = "\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC, REPORT_SEGV_NOFRAMES])
+        keep, headline, races = self._deduper().decide_all(text)
+        self.assertTrue(keep)
+        self.assertEqual(headline, "tsanNEW")  # first new finding wins the dir name
+        self.assertEqual([r["label"] for r in races], ["tsanNEW", "tsanNEW", "tsanSEGV"])
+        self.assertEqual([r["order"] for r in races], [0, 1, 2])
+        self.assertTrue(all(r["keep"] for r in races))
+
+    def test_after_fault_flag_set_for_races_following_a_segv(self):
+        # SEGV in the MIDDLE: the race reported after it is flagged as a possible artifact.
+        text = "\n".join([REPORT_TWO_SITES, REPORT_SEGV_NOFRAMES, REPORT_PREVIOUS_ATOMIC])
+        _keep, _headline, races = self._deduper().decide_all(text)
+        self.assertEqual([r["kind"] for r in races], ["race", "segv", "race"])
+        self.assertEqual([r["after_fault"] for r in races], [False, False, True])
+
+    def test_keep_if_any_new_even_when_one_race_is_known_over_cap(self):
+        sig = tsan_dedup.parse_report(REPORT_TWO_SITES)["signature"]
+        d = self._deduper(catalog_rows=["TSAN-0001\t%s" % sig], keep=1, prune=True)
+        d.decide(REPORT_TWO_SITES)  # take TSAN-0001 to its cap
+        keep, headline, races = d.decide_all("\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC]))
+        self.assertTrue(keep)  # the new race keeps the dir alive
+        self.assertEqual(headline, "tsanNEW")
+        self.assertEqual(
+            [(r["label"], r["keep"]) for r in races], [("TSAN-0001", False), ("tsanNEW", True)]
+        )
+
+    def test_prune_only_when_all_races_known_over_cap(self):
+        s1 = tsan_dedup.parse_report(REPORT_TWO_SITES)["signature"]
+        s2 = tsan_dedup.parse_report(REPORT_PREVIOUS_ATOMIC)["signature"]
+        d = self._deduper(
+            catalog_rows=["TSAN-0001\t%s" % s1, "TSAN-0002\t%s" % s2], keep=1, prune=True
+        )
+        d.decide(REPORT_TWO_SITES)  # both to cap
+        d.decide(REPORT_PREVIOUS_ATOMIC)
+        keep, headline, races = d.decide_all("\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC]))
+        self.assertFalse(keep)  # every race is a known-over-cap duplicate -> prune
+        self.assertEqual(headline, "TSAN-0001")  # else-first-known for the (pruned) label
+        self.assertFalse(any(r["keep"] for r in races))
+
+    def test_single_report_delegates_to_decide(self):
+        keep_all, label_all, races = self._deduper().decide_all(REPORT_TWO_SITES)
+        keep_one, label_one = self._deduper().decide(REPORT_TWO_SITES)
+        self.assertEqual((keep_all, label_all), (keep_one, label_one))
+        self.assertEqual(len(races), 1)
+        self.assertEqual(races[0]["order"], 0)
+
+    def test_duplicate_reports_collapse_then_fall_back_to_single(self):
+        # the same race twice (swapped form) dedups to one -> single-race delegate path.
+        keep, label, races = self._deduper().decide_all(
+            "\n".join([REPORT_TWO_SITES, REPORT_SWAPPED])
+        )
+        self.assertEqual((keep, label), (True, "tsanNEW"))
+        self.assertEqual(len(races), 1)
+
+    def test_noparse_delegates_and_has_empty_race_list(self):
+        self.assertEqual(self._deduper().decide_all(NO_RACE), (True, "tsanNOPARSE", []))
+
+    def test_suppressed_race_alongside_new_keeps_and_records_suppressed(self):
+        d = self._deduper(supp_lines=["race:list_append"])  # suppresses the TWO_SITES race
+        keep, headline, races = d.decide_all("\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC]))
+        self.assertTrue(keep)
+        self.assertEqual(headline, "tsanNEW")
+        self.assertEqual(
+            [(r["label"], r["keep"]) for r in races], [(None, False), ("tsanNEW", True)]
+        )
+
+
+class TestFormatRacesTsv(unittest.TestCase):
+    def test_render_rows_header_and_suppressed_and_after_fault(self):
+        races = [
+            {
+                "order": 0,
+                "label": "tsanNEW",
+                "kind": "race",
+                "keep": True,
+                "after_fault": False,
+                "signature": "A:f | B:g",
+            },
+            {
+                "order": 1,
+                "label": None,
+                "kind": "race",
+                "keep": False,
+                "after_fault": True,
+                "signature": "C:h | D:i",
+            },
+        ]
+        out = tsan_dedup.format_races_tsv(races)
+        lines = out.splitlines()
+        self.assertTrue(lines[0].startswith("#"))
+        self.assertEqual(lines[1], "# " + tsan_dedup.RACES_TSV_HEADER)
+        self.assertEqual(lines[2], "0\ttsanNEW\trace\t0\tA:f | B:g")
+        self.assertEqual(lines[3], "1\tsuppressed\trace\t1\tC:h | D:i")  # None -> suppressed
+        self.assertTrue(out.endswith("\n"))
+
+    def test_roundtrips_through_naive_tab_split(self):
+        # signature is LAST so a plain split recovers every column (signature has spaces, no tabs).
+        _keep, _headline, races = tsan_dedup.TSanDeduper().decide_all(
+            "\n".join([REPORT_TWO_SITES, REPORT_PREVIOUS_ATOMIC])
+        )
+        rows = [
+            ln.split("\t")
+            for ln in tsan_dedup.format_races_tsv(races).splitlines()
+            if not ln.startswith("#")
+        ]
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(len(cols) == 5 for cols in rows))
+        self.assertEqual([cols[4] for cols in rows], [r["signature"] for r in races])
+
+
 class TestSegv(unittest.TestCase):
     def test_segv_no_frames_keyed_on_addr_and_pc(self):
         r = tsan_dedup.parse_report(REPORT_SEGV_NOFRAMES)


### PR DESCRIPTION
Follow-up to #221 (the `--tsan-no-halt` + `parse_all_reports` foundation). Under
`--tsan-no-halt` (TSan `halt_on_error=0`) a single session surfaces **every** race, not just
the first — this teaches the deduper and keep-policy to handle that.

## What's new

**`TSanDeduper.decide_all(text)`** classifies every distinct race in a report-and-continue
stream. It shares a new `_classify_report` helper with the single-race `decide`, so the
`seen`/`kept` tally and the prune cap behave identically. Returns `(keep, headline_label, races)`:

- **keep-if-ANY** race is worth keeping; a dir is pruned only when **every** race is a
  known-over-cap duplicate or suppressed.
- the dir name takes the **headline** label — the first new finding (`tsanNEW`/`tsanSEGV`),
  else the first kept known race id.
- each race carries **`after_fault`** — True once a SEGV/UAF has appeared earlier in the same
  stream — flagging races that may be corruption artifacts of the first fault rather than
  independent findings.
- for **0 or 1** parseable reports it delegates to `decide`, so the default `halt_on_error=1`
  single-race path (accounting, label, and the noparse case) is **byte-for-byte unchanged**.

**`tsan_races.tsv` sidecar.** A multi-race kept session drops a sidecar next to `source.py`
(`format_races_tsv`; columns `order/label/kind/after_fault/signature`, signature last so a
naïve tab-split is safe) recording the full per-race breakdown for the sibling catalog's
ingest. Only written under `--tsan-no-halt` with ≥2 distinct races, so default runs are
unaffected.

## Contract / safety

- `parse_report` stays **first-report-only** — the cross-repo signature contract the sibling
  `cpython-tsan-findings/scripts/ingest.py` imports is untouched.
- With the default `halt_on_error=1`, `decide_all` always hits the ≤1-report delegate path →
  no sidecar, identical labels → behaviour unchanged.

## Validation

Ran `decide_all` on the real fleet-10 experiment log: **one `_decimal` session → 10 distinct
races**, both genuine-new `_decimal` Context races surfaced
(`…clear_traps_impl | context_repr` and `… | type_call`), the count residual labeled
`TSAN-0006`, cascade SEGV captured.

+10 unit tests (`TestDecideAll`, `TestFormatRacesTsv`); suite **1145** green; `ruff check` +
`ruff format --check` clean. Design recorded in `doc/tsan-mode-plan.md` → "Phase 5 as-built".

🤖 Generated with [Claude Code](https://claude.com/claude-code)