### PR TITLE
Make generated-script boilerplate portable to non-CPython interpreters

### DIFF
--- a/fusil/python/samples/tricky_objects.py
+++ b/fusil/python/samples/tricky_objects.py
@@ -91,7 +91,10 @@ try:
         # tricky_frame.f_builtins.update(tricky_dict)
         tricky_frame.f_globals.update(tricky_dict)
         tricky_frame.f_locals.update(tricky_dict)
-except RuntimeError:
+# Writing f_locals is a CPython frame detail (PEP 667 in 3.13); on interpreters where
+# it is a read-only snapshot the .update() can raise TypeError/AttributeError, not just
+# RuntimeError -- catch broadly so this best-effort frame pollution never aborts the script.
+except Exception:
     tricky_frame = None
 
 

--- a/fusil/python/samples/weird_classes.py
+++ b/fusil/python/samples/weird_classes.py
@@ -1,7 +1,6 @@
 import sys
-from _collections import OrderedDict, deque
 from abc import ABCMeta
-from collections import Counter
+from collections import Counter, OrderedDict, deque
 from queue import Queue
 from random import randint
 from string import printable
@@ -87,7 +86,11 @@ tricky_strs = (
 
 # We cannot create a Decimal larger than 10 ** 4300 with _pydecimal, only with _decimal
 max_str_digits_adjustment = 1 if has__decimal else -1
-big_int_for_decimal = 10 ** (sys.int_info.default_max_str_digits + max_str_digits_adjustment)
+# default_max_str_digits is CPython 3.11+; fall back to its 4300 default on interpreters
+# (older CPython, some PyPy) that don't expose it so this boilerplate stays importable.
+_default_max_str_digits = getattr(sys, "int_info", None)
+_default_max_str_digits = getattr(_default_max_str_digits, "default_max_str_digits", 4300)
+big_int_for_decimal = 10 ** (_default_max_str_digits + max_str_digits_adjustment)
 
 for cls in sequences:
     weird_instances[f"weird_{cls.__name__}_single"] = weird_classes[f"weird_{cls.__name__}"]("a")

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -298,7 +298,18 @@ class WritePythonCode(WriteCode):
             ),
         )
         if not self.options.no_tstrings and _ARG_GEN_USE_TEMPLATES:
-            self.write(0, "from string.templatelib import Interpolation, Template")
+            # string.templatelib is CPython 3.14+ (PEP 750). The parent decides whether to
+            # emit t-string args from ITS OWN capability (_ARG_GEN_USE_TEMPLATES), but the
+            # target may be an older CPython / PyPy without it, so guard the import: template
+            # args are emitted as Template(...)/Interpolation(...) calls that then raise a
+            # (caught) NameError at the wrapped call site instead of killing the whole script.
+            # Use --no-tstrings to skip emitting them entirely.
+            self.write(0, "try:")
+            with self.indented():
+                self.write(0, "from string.templatelib import Interpolation, Template")
+            self.write(0, "except ImportError:")
+            with self.indented():
+                self.write(0, "pass")
 
         self.write_print_to_stderr(0, f'"Importing target module: {self.module_name}"')
         # The parent discovers importable modules in ITS interpreter; the target interpreter

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -36,9 +36,8 @@ def skip_trivial_type(obj_instance_or_class):
 _FUSIL_METHOD_BLACKLIST = frozenset({'__class__', '__enter__', '__imul__', '__ipow__', '__mul__', '__pow__', '__rmul__', '_acquire_lock', '_acquire_restore', '_handle_request_noblock', '_randbelow', '_randbelow_with_getrandbits', '_read', '_rehash', '_run_once', '_serve', '_shutdown', 'accept', 'acquire', 'acquire_lock', 'cmdloop', 'copyfileobj', 'get', 'get_request', 'handle_request', 'handle_request_noblock', 'prefix', 'raise_signal', 'repeat', 'run_forever', 'select', 'serve_forever', 'shutdown', 'sleep', 'test', 'tri', 'tril_indices', 'wait', 'zfill'})
 
 import sys
-from _collections import OrderedDict, deque
 from abc import ABCMeta
-from collections import Counter
+from collections import Counter, OrderedDict, deque
 from queue import Queue
 from random import randint
 from string import printable
@@ -124,7 +123,11 @@ tricky_strs = (
 
 # We cannot create a Decimal larger than 10 ** 4300 with _pydecimal, only with _decimal
 max_str_digits_adjustment = 1 if has__decimal else -1
-big_int_for_decimal = 10 ** (sys.int_info.default_max_str_digits + max_str_digits_adjustment)
+# default_max_str_digits is CPython 3.11+; fall back to its 4300 default on interpreters
+# (older CPython, some PyPy) that don't expose it so this boilerplate stays importable.
+_default_max_str_digits = getattr(sys, "int_info", None)
+_default_max_str_digits = getattr(_default_max_str_digits, "default_max_str_digits", 4300)
+big_int_for_decimal = 10 ** (_default_max_str_digits + max_str_digits_adjustment)
 
 for cls in sequences:
     weird_instances[f"weird_{cls.__name__}_single"] = weird_classes[f"weird_{cls.__name__}"]("a")
@@ -357,7 +360,10 @@ try:
         # tricky_frame.f_builtins.update(tricky_dict)
         tricky_frame.f_globals.update(tricky_dict)
         tricky_frame.f_locals.update(tricky_dict)
-except RuntimeError:
+# Writing f_locals is a CPython frame detail (PEP 667 in 3.13); on interpreters where
+# it is a read-only snapshot the .update() can raise TypeError/AttributeError, not just
+# RuntimeError -- catch broadly so this best-effort frame pollution never aborts the script.
+except Exception:
     tricky_frame = None
 
 


### PR DESCRIPTION
## What

fusil splices the same boilerplate into every generated script based on the **parent** interpreter's capabilities, but the script runs under the **target** — which may be PyPy, RustPython, or an older CPython. Several CPython-isms in the always-spliced boilerplate killed the whole script at import/parse time, before any fuzzing ran.

Found while smoke-testing RustPython fuzzing: every session died at `from _collections import OrderedDict, deque` (RustPython's `_collections` has no `OrderedDict`), so no fuzzing happened at all.

## Fixes (all in the always-emitted boilerplate)

- **`weird_classes.py`**: `from _collections import OrderedDict, deque` → public `from collections import ...` (same C types on CPython). *This was the actual blocker.*
- **`weird_classes.py`**: `sys.int_info.default_max_str_digits` (CPython 3.11+) → `getattr(...)` fallback to its `4300` default, so older CPython / some PyPy stay importable.
- **`write_python_code.py`**: the `from string.templatelib import ...` import (PEP 750, CPython 3.14+) is now **guarded**. It was emitted whenever the *parent* had t-strings, killing targets without them. Template args are emitted as `Template(...)`/`Interpolation(...)` calls, which then raise a caught `NameError` at the wrapped call site instead of dying at import. (`--no-tstrings` still skips them entirely.)
- **`tricky_objects.py`**: the best-effort frame-globals pollution only caught `RuntimeError`; writing `f_locals` is a CPython frame detail (PEP 667) that can raise `TypeError`/`AttributeError` on other interpreters → catch broadly so it never aborts the script.

## Verification

- Boilerplate imports cleanly under **CPython 3.14** and **RustPython 0.5.0**; a generated script runs past all imports under RustPython (previously exit-1 at the first import).
- Golden snapshot regenerated (`tests/python/golden/fakemod_seed1234.py`).
- Full suite **1145 tests OK**; `ruff check` + `ruff format --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)