### PR TITLE
RustPython fuzzing: generic hostile modes + panic-site dedup (core)

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -50,6 +50,17 @@ class Fuzzer(Application):
             default="*",
         )
         input_options.add_option(
+            "--modules-file",
+            help="Read tested module names from FILE (one per line; '#' comments and blank "
+            "lines ignored), bypassing discovery/blacklists. Unions with --modules. Lets a "
+            "curated set (e.g. RustPython's Rust-implemented modules, or an unwrap_scan result) "
+            "drive the fleet at the crash-rich surface instead of all discovered modules "
+            "(default: none)",
+            type="str",
+            dest="modules_file",
+            default=None,
+        )
+        input_options.add_option(
             "--packages",
             help="Tested Python packages names separated by commas (default: test all packages)",
             type="str",
@@ -490,12 +501,65 @@ class Fuzzer(Application):
             default=False,
         )
 
+        # Generic hostile modes that help any alternative interpreter (RustPython, PyPy, ...),
+        # not just a TSan-instrumented CPython. Kept in core (mirrors the OOM/TSan split); the
+        # RustPython packaging (curated module set, known-panic suppression) lives in the
+        # separate fusil_rustpython_plugin.
+        altinterp_options = OptionGroup(parser, "Alt-interpreter / generic hostile modes")
+        altinterp_options.add_option(
+            "--concurrency-stress",
+            help="Emit the concurrency-stress region (the same shared-object/many-thread hammer "
+            "as --tsan) WITHOUT requiring a TSan-instrumented target: surfaces threading "
+            "deadlocks, re-entrancy panics, and teardown crashes in any interpreter (found the "
+            "RustPython _thread RefCell double-borrow). Reuses --tsan-threads/-iterations/"
+            "-shared-objects. No setarch/TSan preflight/env. Default: False",
+            action="store_true",
+            default=False,
+        )
+        altinterp_options.add_option(
+            "--new-uninit",
+            help="Emit the uninitialized-native-object region: for each type T discovered in the "
+            "session's module(s), build obj = T.__new__(T) (bypassing __init__) and hammer its "
+            "PROTOCOL slots (subscript, iter, call, number, repr, hash, len, ...) with hostile "
+            "args -- protocol slots that touch payload without re-validating segfault a "
+            "type-confused instance (found the RustPython re.Match subscript segv). Default: False",
+            action="store_true",
+            default=False,
+        )
+        altinterp_options.add_option(
+            "--rustpython-dedup-catalog",
+            help="Path to a known_panics.tsv snapshot (from the rustpython-findings catalog). "
+            "In-loop dedupe: each crash is reduced to its panic-site signature "
+            "(crates/<path>.rs:<line>), labelled with its bug id (or rustpyNEW / rustpySEGV), "
+            "and -- with --rustpython-dedup-prune -- known duplicates past --rustpython-dedup-keep "
+            "are dropped. Default: none (label-only, keep all)",
+            type="str",
+            dest="rustpython_dedup_catalog",
+            default=None,
+        )
+        altinterp_options.add_option(
+            "--rustpython-dedup-keep",
+            help="With --rustpython-dedup-prune, keep at most N dirs per known panic (default: 5)",
+            type="int",
+            dest="rustpython_dedup_keep",
+            default=5,
+        )
+        altinterp_options.add_option(
+            "--rustpython-dedup-prune",
+            help="Drop known-panic duplicate crash dirs past --rustpython-dedup-keep "
+            "(default: False)",
+            action="store_true",
+            dest="rustpython_dedup_prune",
+            default=False,
+        )
+
         options = (
             input_options,
             running_options,
             fuzzing_options,
             oom_options,
             tsan_options,
+            altinterp_options,
         )
         for option in options:
             parser.add_option_group(option)
@@ -586,6 +650,10 @@ class Fuzzer(Application):
         # the build preflight use a DISTINCT prefix (see main() and the preflight below) so a
         # root-created cache dir never blocks a fusil-user write under a shared prefix.
         process.env.set("PYTHONPYCACHEPREFIX", "/tmp/fusil-pycache")
+        # Ask a Rust-based target (RustPython, or any PyO3 extension) to print a backtrace on
+        # panic, so the crash dir captures the panicking `crates/<path>.rs:<line>` frame (better
+        # dedup + reports). Harmless no-op for CPython/PyPy, which ignore the variable.
+        process.env.set("RUST_BACKTRACE", "1")
         # ThreadSanitizer reserves more virtual address space than any finite RLIMIT_AS allows and
         # re-execs itself to raise the cap; a finite hard cap makes that re-exec fail (setrlimit
         # EINVAL) and TSan then runs DEGRADED, detecting nothing. So leave the cap OFF under --tsan
@@ -819,6 +887,39 @@ class Fuzzer(Application):
                 )
             )
 
+        # RustPython crash dedupe: reduce each crash to its Rust panic-site signature
+        # (crates/<path>.rs:<line>), label the crash dir with its bug id (or rustpyNEW /
+        # rustpySEGV), and optionally prune known duplicates past the sample cap. Independent of
+        # the fuzzing mode (works with plain, --concurrency-stress, or --new-uninit runs against a
+        # RustPython target); installed after the OOM/TSan dedupers so it wins if both were set
+        # (they target different interpreters, so they never really coexist).
+        self._rustpython_deduper = None
+        if self.options.rustpython_dedup_catalog:
+            from fusil.python.rustpython_dedup import RustPyDeduper
+
+            self._rustpython_deduper = RustPyDeduper(
+                self.options.rustpython_dedup_catalog,
+                keep=self.options.rustpython_dedup_keep,
+                prune=self.options.rustpython_dedup_prune,
+                python_bin=self.options.python,
+                gdb_timeout=self.options.oom_dedup_gdb_timeout,
+                resolve_segv=self.options.oom_dedup_resolve_segv,
+                # Never replay a fuzzed source.py as root: drop the gdb segv re-run to the same
+                # unprivileged user the fuzzing children use.
+                drop_uid=self.config.process_uid,
+                drop_gid=self.config.process_gid,
+            )
+            self.session_keep_policy = self._rustpython_keep_policy
+            project.error(
+                "RustPython dedupe enabled: %s (keep=%d, prune=%s, resolve_segv=%s)"
+                % (
+                    self.options.rustpython_dedup_catalog,
+                    self.options.rustpython_dedup_keep,
+                    self.options.rustpython_dedup_prune,
+                    self.options.oom_dedup_resolve_segv,
+                )
+            )
+
         # Regex hit suppression (issue #53): drop known/uninteresting crashing-session hits
         # whose stdout matches a user- or plugin-supplied regex -- the general/non-OOM analogue
         # of the OOM-catalog dedupe above. Composes with it: suppression runs first (a matched
@@ -946,6 +1047,28 @@ class Fuzzer(Application):
             self.error("TSan keep-policy failed (%s); keeping crash dir unlabelled" % err)
             return True, None
 
+    def _rustpython_keep_policy(self, session):
+        """Return (keep, label) for a crashed RustPython session from its captured stdout: reduce
+        the Rust panic (or a resolved segfault) to a site signature, then label / prune via the
+        catalog.
+
+        Consulted synchronously by SessionDirectory.checkKeepDirectory (stdout is complete).
+        Returns (True, None) on any error so a crash is never lost to a dedupe failure.
+        """
+        import os
+
+        session_dir = session.directory.directory
+        try:
+            from fusil.python.rustpython_dedup import read_crash_stdout
+
+            text = read_crash_stdout(os.path.join(session_dir, "stdout"))
+            return self._rustpython_deduper.decide(
+                text, source_path=os.path.join(session_dir, "source.py")
+            )
+        except Exception as err:
+            self.error("RustPython keep-policy failed (%s); keeping crash dir unlabelled" % err)
+            return True, None
+
     def exit(self, keep_log: bool = True) -> None:
         """Clean up and exit the fuzzer, printing runtime statistics."""
         super().exit(keep_log=keep_log)
@@ -953,6 +1076,8 @@ class Fuzzer(Application):
             self.error(self._deduper.report())
         if getattr(self, "_tsan_deduper", None):
             self.error(self._tsan_deduper.report())
+        if getattr(self, "_rustpython_deduper", None):
+            self.error(self._rustpython_deduper.report())
         if getattr(self, "_hit_suppressor", None):
             self.error(self._hit_suppressor.report())
         self.error(print_running_time(time_start))

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -55,13 +55,24 @@ class PythonSource(ProjectAgent):
         if hasattr(project.application(), "plugin_manager"):
             self.plugin_manager = project.application().plugin_manager
 
-        if self.options.modules != "*":
+        modules_file = getattr(self.options, "modules_file", None)
+        if self.options.modules != "*" or modules_file:
+            # Explicit module set: --modules literal and/or --modules-file, bypassing
+            # discovery/blacklists. Unioned so a curated file can be augmented on the CLI.
             self.modules = set()
-            for module in self.options.modules.split(","):
-                module = module.strip()
-                if not len(module):
-                    continue
-                self.modules.add(module)
+            if self.options.modules != "*":
+                for module in self.options.modules.split(","):
+                    module = module.strip()
+                    if not len(module):
+                        continue
+                    self.modules.add(module)
+            if modules_file:
+                with open(modules_file) as module_file_handle:
+                    for line in module_file_handle:
+                        line = line.strip()
+                        if not line or line.startswith("#"):
+                            continue
+                        self.modules.add(line)
         else:
             self.error("Search all Python modules...")
             self.modules = lister_factory(
@@ -154,11 +165,14 @@ class PythonSource(ProjectAgent):
             self.filename,
             self.module,
             self.module_name,
-            # --tsan replaces the per-call one-thread-per-callsite wrappers with a concentrated
-            # concurrency-stress region (WritePythonCode._write_tsan_stress_region), so disable
-            # them here -- otherwise they would dilute the stress and double-run every call.
-            threads=(not self.options.no_threads) and not self.options.tsan,
-            _async=(not self.options.no_async) and not self.options.tsan,
+            # --tsan / --concurrency-stress replace the per-call one-thread-per-callsite wrappers
+            # with a concentrated concurrency-stress region (WritePythonCode.
+            # _write_tsan_stress_region), so disable them here -- otherwise they would dilute the
+            # stress and double-run every call.
+            threads=(not self.options.no_threads)
+            and not (self.options.tsan or getattr(self.options, "concurrency_stress", False)),
+            _async=(not self.options.no_async)
+            and not (self.options.tsan or getattr(self.options, "concurrency_stress", False)),
             plugin_manager=self.plugin_manager,
         )
 

--- a/fusil/python/rustpython_dedup.py
+++ b/fusil/python/rustpython_dedup.py
@@ -1,0 +1,298 @@
+"""In-loop dedupe for RustPython (and other Rust-based interpreter) crash fuzzing.
+
+Pure-Python and free of any runtime (python-ptrace) dependency, so it unit-tests in isolation
+-- the RustPython analogue of ``oom_dedup.py`` / ``tsan_dedup.py``. RustPython crashes are
+overwhelmingly ``.unwrap()`` / ``.expect()`` / ``panic!`` / unchecked-index sites reachable from
+Python (a Rust *panic*) plus a smaller class of memory-unsafety *segfaults* (unguarded native
+recursion, uninitialised-object protocol slots). This module reduces a crashing session's
+captured stdout to a stable **signature** and decides whether that crash is already known, so a
+fleet can prune duplicates in-loop and self-label each crash dir.
+
+Signatures:
+
+- **panic**: Rust prints ``thread '<name>' [(<tid>)] panicked at <path>.rs:<line>:<col>:`` (the
+  ``(tid)`` group is present on newer toolchains, absent on older ones). The signature is
+  ``<path>.rs:<line>`` -- the column is dropped (it drifts with formatting) and the path is
+  normalised to start at ``crates/`` so a checkout-absolute path and a relative one dedupe
+  together. A worker-thread panic can be printed anywhere in stdout (not just the tail), so the
+  first panic in the whole text is used.
+- **segv/abort**: a bare SIGSEGV/SIGABRT prints no panic line. With an (injectable) ``segv_resolver``
+  -- a gdb re-run of ``source.py``, deterministic on the same binary -- the top Rust frame becomes
+  the signature (``SEGV <frame>``); otherwise the crash buckets as ``rustpySEGV``.
+
+The catalog snapshot (``known_panics.tsv``, produced by the sibling ``rustpython-findings``
+catalog) maps each known signature to a bug id (``RUSTPY-00NN``). Matching is exact on the
+signature. This format is a cross-repo contract (the catalog's ingest imports this module), so a
+change here must keep existing signatures stable.
+"""
+
+import collections
+import os
+import re
+
+# ---- report parsing ----
+# A Rust panic header. Handles both the newer ``thread 'main' (12345) panicked at ...`` form and
+# the older ``thread 'main' panicked at ...`` form. The path runs up to the first ``:`` (Rust
+# source paths have no spaces), then ``:line`` and an optional ``:col`` we discard.
+PANIC = re.compile(r"panicked at\s+([^\s:]+\.rs):(\d+)(?::\d+)?")
+
+
+def _norm_panic_path(path):
+    """Normalise a panic source path so a checkout-absolute path and a build-relative one dedupe.
+
+    RustPython's compile-time panic locations are usually already ``crates/...rs``; a build that
+    baked in an absolute path (``/home/.../checkouts/rustpython-abc123/crates/vm/src/x.rs``) is
+    trimmed to the ``crates/...`` tail. Anything without a ``crates/`` segment is returned as-is.
+    """
+    idx = path.find("crates/")
+    return path[idx:] if idx != -1 else path
+
+
+def parse_report(text):
+    """Parse the FIRST Rust panic in ``text``.
+
+    Returns ``{signature, site, kind}`` (``kind == "panic"``) or ``None`` if there is no panic
+    line (a bare segfault/abort prints none -- the deduper routes that to the segv path). ``site``
+    is ``(file, line)`` for the report; ``signature`` is ``file:line``.
+    """
+    m = PANIC.search(text)
+    if not m:
+        return None
+    path = _norm_panic_path(m.group(1))
+    line = int(m.group(2))
+    signature = "%s:%d" % (path, line)
+    return dict(signature=signature, site=(path, line), kind="panic")
+
+
+def parse_all_panics(text):
+    """Every DISTINCT panic signature in ``text``, in first-seen order.
+
+    A ``--concurrency-stress`` session can emit several worker-thread panics; this lets a caller
+    tally them all. ``parse_report`` stays first-panic-only (the catalog's signature contract), so
+    this is purely additive.
+    """
+    out = []
+    seen = set()
+    for m in PANIC.finditer(text):
+        sig = "%s:%d" % (_norm_panic_path(m.group(1)), int(m.group(2)))
+        if sig not in seen:
+            seen.add(sig)
+            out.append(sig)
+    return out
+
+
+# ---- gdb segv resolution (best-effort, real-path default; injectable for tests) ----
+# The top frame in a RustPython backtrace we key a segv on: the innermost frame whose function is
+# NOT libc/allocator/panic plumbing. Frame lines from `bt` look like
+# ``#12 0x... in rustpython_vm::...::hash (...) at crates/vm/src/.../x.rs:123``.
+_GDB_FRAME = re.compile(r"^#\d+\s+(?:0x[0-9a-fA-F]+\s+in\s+)?(\S+)")
+# Plumbing to skip when picking the top real frame (libc abort/raise, Rust panic runtime, alloc).
+_SEGV_PLUMBING = re.compile(
+    r"^(?:__|_?abort\b|_?raise\b|core::panic|std::panic|rust_panic|"
+    r"core::result::unwrap|core::option::|alloc::alloc|__rust_|handle_alloc_error)"
+)
+
+
+def _gdb_top_frame(bt_text):
+    """Given gdb backtrace text, return the top non-plumbing frame function, or None."""
+    frames = []
+    for line in bt_text.splitlines():
+        fm = _GDB_FRAME.match(line.strip())
+        if fm:
+            frames.append(fm.group(1))
+    if not frames:
+        return None
+    for fn in frames:
+        if not _SEGV_PLUMBING.match(fn):
+            return fn
+    return frames[0]
+
+
+def gdb_crash_site(python_bin, source_path, timeout=120, drop_uid=None, drop_gid=None):
+    """Re-run ``source_path`` under gdb with ``python_bin`` and return the top Rust crash frame
+    (a string) or ``None``. Deterministic on the same binary. Best-effort: any failure -> None.
+
+    Drops to ``drop_uid``/``drop_gid`` when running as root (never replay a fuzzed script as root),
+    mirroring ``oom_dedup.gdb_crash_site``.
+    """
+    import subprocess
+
+    if not (python_bin and source_path):
+        return None
+    cmd = [
+        "gdb",
+        "-batch",
+        "-nx",
+        "-ex",
+        "run",
+        "-ex",
+        "bt",
+        "--args",
+        python_bin,
+        source_path,
+    ]
+    popen_kwargs = {}
+    if os.getuid() == 0 and (drop_uid is not None or drop_gid is not None):
+        if drop_uid is not None:
+            popen_kwargs["user"] = drop_uid
+        if drop_gid is not None:
+            popen_kwargs["group"] = drop_gid
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env={**os.environ, "RUST_BACKTRACE": "1", "PYTHONPYCACHEPREFIX": "/tmp/fusil-pycache"},
+            **popen_kwargs,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return _gdb_top_frame(out)
+
+
+# ---- catalog snapshot ----
+def load_catalog(lines):
+    """Load ``known_panics.tsv`` rows (iterable of lines) -> {signature: bug_id}.
+
+    Row format (tab-separated):  ``<bug_id>\\t<signature>``  (``#`` comment lines ignored).
+    """
+    by_sig = {}
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        rid, sig = parts
+        by_sig[sig.strip()] = rid.strip()
+    return by_sig
+
+
+def load_catalog_file(path):
+    with open(path) as fh:
+        return load_catalog(fh)
+
+
+# ---- bounded stdout reader (shared contract with oom_dedup / tsan_dedup) ----
+_STDOUT_HEAD = int(os.environ.get("RUSTPY_STDOUT_HEAD", 256 * 1024))
+_STDOUT_TAIL = int(os.environ.get("RUSTPY_STDOUT_TAIL", 1024 * 1024))
+
+
+def read_crash_stdout(path):
+    """Read a crash's captured stdout, bounding huge files to head+tail (a panic line can be at
+    either end -- a worker panic mid-run, a main-thread panic at the tail). Decoded, errors
+    replaced. Mirrors ``oom_dedup.read_crash_stdout``."""
+    with open(path, "rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        if size <= _STDOUT_HEAD + _STDOUT_TAIL:
+            fh.seek(0)
+            return fh.read().decode("utf-8", "replace")
+        fh.seek(0)
+        head = fh.read(_STDOUT_HEAD)
+        fh.seek(size - _STDOUT_TAIL)
+        tail = fh.read(_STDOUT_TAIL)
+    return head.decode("utf-8", "replace") + "\n...[elided]...\n" + tail.decode("utf-8", "replace")
+
+
+# ---- the deduper ----
+class RustPyDeduper:
+    """Stateful in-loop deduper: feed each crash's stdout (+ source.py), get ``(keep, label)``.
+
+    ``keep=False`` is only returned for a confidently-known crash already at its sample cap, and
+    only when ``prune`` is on -- new / unresolved-segv / unparseable crashes are always kept.
+    ``segv_resolver`` (``source_path -> 'frame' | ['frame', ...] | None``) is injectable for
+    testing; it defaults to :func:`gdb_crash_site` when ``resolve_segv`` and a ``python_bin`` are
+    set.
+    """
+
+    def __init__(
+        self,
+        catalog_path=None,
+        keep=5,
+        prune=False,
+        python_bin=None,
+        gdb_timeout=120,
+        resolve_segv=False,
+        segv_resolver=None,
+        drop_uid=None,
+        drop_gid=None,
+    ):
+        self.snap = load_catalog_file(catalog_path) if catalog_path else {}
+        self.keep_cap = keep
+        self.prune = prune
+        self.python_bin = python_bin
+        self.gdb_timeout = gdb_timeout
+        self.resolve_segv = resolve_segv
+        self._resolver = segv_resolver
+        self.drop_uid = drop_uid
+        self.drop_gid = drop_gid
+        self.seen = collections.Counter()
+        self.kept = collections.Counter()
+
+    def _resolve(self, source_path):
+        """Return the resolved top-frame string for a segv, or None. Any resolver failure is
+        swallowed -- resolution is best-effort and decide() must never raise into keep/rename."""
+        try:
+            r = (
+                self._resolver(source_path)
+                if self._resolver is not None
+                else (
+                    gdb_crash_site(
+                        self.python_bin,
+                        source_path,
+                        self.gdb_timeout,
+                        drop_uid=self.drop_uid,
+                        drop_gid=self.drop_gid,
+                    )
+                    if (self.python_bin and source_path)
+                    else None
+                )
+            )
+        except Exception:
+            return None
+        if not r:
+            return None
+        return r[0] if isinstance(r, (list, tuple)) else r
+
+    def decide(self, stdout_text, source_path=None):
+        """Return ``(keep, label)`` for one crashing session.
+
+        A panic keys on its site (``crates/...rs:line``); a bare segfault/abort with no panic
+        line routes to the segv path -- resolved to its top frame via ``segv_resolver`` when
+        ``resolve_segv`` is set, else bucketed as ``rustpySEGV``.
+        """
+        report = parse_report(stdout_text)
+        if report is not None:
+            return self._classify(report["signature"], kind="panic")
+        # No panic line -> a memory-unsafety segfault/abort. Try to resolve a site for dedup.
+        if self.resolve_segv:
+            frame = self._resolve(source_path)
+            if frame:
+                return self._classify("SEGV %s" % frame, kind="segv")
+        self.seen["rustpySEGV"] += 1
+        return True, "rustpySEGV"
+
+    def _classify(self, signature, kind):
+        """Map a signature to ``(keep, label)`` via the catalog + prune cap, updating counters."""
+        rid = self.snap.get(signature)
+        if rid:
+            self.seen[rid] += 1
+            if self.prune and self.kept[rid] >= self.keep_cap:
+                return False, rid  # known + over cap -> prune duplicate
+            self.kept[rid] += 1
+            return True, rid
+        # New (uncatalogued) finding.
+        if kind == "segv":
+            self.seen["NEW-SEGV:" + signature] += 1
+            return True, "rustpySEGV"
+        self.seen["NEW:" + signature] += 1
+        return True, "rustpyNEW"
+
+    def report(self):
+        lines = ["RustPython dedupe summary (seen / kept):"]
+        for key, n in self.seen.most_common():
+            lines.append("  %-48s seen=%-5d kept=%d" % (key, n, self.kept.get(key, n)))
+        return "\n".join(lines)

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -656,11 +656,19 @@ class WritePythonCode(WriteCode):
         """Writes the core fuzzing loops for functions, classes, and objects."""
         self._write_fuzzing_logic_preamble()
 
-        # TSan mode: skip the single-threaded function/class/object sweeps and emit only the
-        # concurrency-stress region -- it instantiates its own shared objects and hammers them
-        # from many threads, which is the whole point (and keeps the instrumented script small).
-        if self.options.tsan:
+        # TSan / --concurrency-stress mode: skip the single-threaded function/class/object sweeps
+        # and emit only the concurrency-stress region -- it instantiates its own shared objects and
+        # hammers them from many threads, which is the whole point (and keeps the script small).
+        # --concurrency-stress reuses the same region without any TSan build (see the flag).
+        if self.options.tsan or getattr(self.options, "concurrency_stress", False):
             self._write_tsan_stress_region()
+            return
+
+        # --new-uninit mode: build T.__new__(T) for every discovered type and hammer its protocol
+        # slots -- a type-confused (uninitialized) instance whose protocol touches payload without
+        # re-validating can segfault an alternative interpreter (the RustPython re.Match seam).
+        if getattr(self.options, "new_uninit", False):
+            self._write_new_uninit_region()
             return
 
         self._write_function_fuzzing_loop()
@@ -721,6 +729,162 @@ class WritePythonCode(WriteCode):
             if len(lines) == 1 and lines[0].strip():
                 parts.append(lines[0].strip())
         return ", ".join(parts)
+
+    def _write_new_uninit_region(self) -> None:
+        """Emit the --new-uninit uninitialized-native-object region.
+
+        For every type T discovered in the session's module namespace -- including hidden
+        RESULT types reached via a light call sweep (e.g. ``type(re.match('a','a'))`` is never a
+        module attribute; the RUSTPY-0008 re.Match seam) -- build ``obj = T.__new__(T)`` to get a
+        type-confused instance whose payload was never initialised, then hammer its PROTOCOL slots
+        (subscript, iter/next, call, number, comparison, buffer, context-manager) plus every
+        ``dir(obj)`` method with hostile args. On CPython these downcast-guard into clean
+        exceptions; on an alternative interpreter a protocol slot that dereferences payload
+        without re-validating can segfault (the whole point of the mode). All operations are
+        wrapped so one bad slot never stops the sweep; budgets bound the runtime.
+        """
+        self.emptyLine()
+        self.write(0, "# --- Uninitialized-native-object region (--new-uninit) ---")
+        self.write(0, "import operator as _nu_operator")
+        # Skip process-lifecycle calls in the discovery sweep (forking/execing the harness is
+        # never a useful target and would kill the child) -- same set the TSan region filters.
+        self.write(0, "_NU_UNSAFE = frozenset(%r)" % (tuple(sorted(TSAN_UNSAFE_CALLS)),))
+        self.write_print_to_stderr(0, '"[NEW-UNINIT] entering uninitialized-object region"')
+        self.write_block(
+            0,
+            """
+            # 1) Collect candidate types: every `type` reachable from the target module namespace,
+            #    the types of its module-level objects, and -- via a bounded call sweep -- the
+            #    types of objects its callables RETURN (reaches hidden result types like re.Match
+            #    that are never exposed as a module attribute).
+            _nu_types = {}
+            def _nu_add(_t):
+                try:
+                    if isinstance(_t, type):
+                        _nu_types.setdefault(getattr(_t, "__qualname__", None) or repr(_t), _t)
+                except BaseException:
+                    pass
+
+            _nu_bomb = SuperBomb()
+            _nu_arg_combos = [
+                (), ("a",), ("a", "a"), (0,), (0, 0), (b"a",), (b"a", b"a"),
+                ([],), ({},), (_nu_bomb,), (1, 2, 3),
+            ]
+            _nu_budget = [3000]  # global cap on discovery-sweep calls (list = mutable in closures)
+
+            for _name in list(dir(fuzz_target_module)):
+                try:
+                    _attr = getattr(fuzz_target_module, _name)
+                except BaseException:
+                    continue
+                _nu_add(_attr)          # the attribute itself may be a type
+                _nu_add(type(_attr))    # the type of a module-level instance
+                if _name in _NU_UNSAFE or _name.startswith("_") or not callable(_attr):
+                    continue
+                for _combo in _nu_arg_combos:
+                    if _nu_budget[0] <= 0:
+                        break
+                    _nu_budget[0] -= 1
+                    try:
+                        _res = _attr(*_combo)
+                    except BaseException:
+                        continue
+                    _nu_add(type(_res))
+                    try:
+                        _res.close()   # be a good citizen if it opened something
+                    except BaseException:
+                        pass
+
+            _nu_types_items = list(_nu_types.items())[:200]
+            """,
+        )
+        self.write_print_to_stderr(
+            0, '"[NEW-UNINIT] discovered %d candidate types" % len(_nu_types)'
+        )
+        self.write_block(
+            0,
+            """
+            # 2) For each type, build an UNINITIALIZED instance (bypass __init__) and poke it.
+            def _nu_poke(_obj):
+                for _f in (repr, str, ascii, hash, len, bool, iter, dir, bytes, hex, oct,
+                           int, float, complex, abs, round):
+                    try:
+                        _f(_obj)
+                    except BaseException:
+                        pass
+                # subscript / mapping / sequence (the Match seam) -- read, write, delete
+                for _k in (0, -1, _nu_bomb, "x", slice(None), (0, 0)):
+                    try:
+                        _obj[_k]
+                    except BaseException:
+                        pass
+                    try:
+                        _obj[_k] = 1
+                    except BaseException:
+                        pass
+                    try:
+                        del _obj[_k]
+                    except BaseException:
+                        pass
+                # iteration / next
+                try:
+                    next(_obj)
+                except BaseException:
+                    pass
+                try:
+                    for _i, _x in enumerate(_obj):
+                        if _i > 3:
+                            break
+                except BaseException:
+                    pass
+                # call
+                for _combo in ((), (_nu_bomb,), (0,)):
+                    try:
+                        _obj(*_combo)
+                    except BaseException:
+                        pass
+                # binary / comparison ops against hostile operands
+                for _other in (1, _nu_bomb, _obj, "x", b"x"):
+                    for _op in (_nu_operator.add, _nu_operator.sub, _nu_operator.mul,
+                                _nu_operator.and_, _nu_operator.or_, _nu_operator.lt,
+                                _nu_operator.eq, _nu_operator.contains):
+                        try:
+                            _op(_obj, _other)
+                        except BaseException:
+                            pass
+                # context manager
+                try:
+                    with _obj:
+                        pass
+                except BaseException:
+                    pass
+                # every attribute/method called with hostile args
+                for _an in dir(_obj):
+                    try:
+                        _av = getattr(_obj, _an)
+                    except BaseException:
+                        continue
+                    if callable(_av):
+                        for _combo in ((), (_nu_bomb,), (0,), ("a",)):
+                            try:
+                                _av(*_combo)
+                            except BaseException:
+                                pass
+
+            for _tname, _t in _nu_types_items:
+                try:
+                    _obj = _t.__new__(_t)
+                except BaseException:
+                    continue
+                print("[NEW-UNINIT] poking " + _tname, file=stderr)
+                try:
+                    _nu_poke(_obj)
+                except BaseException:
+                    pass
+            """,
+        )
+        self.write_print_to_stderr(0, '"[NEW-UNINIT] region complete"')
+        self.emptyLine()
 
     def _write_tsan_stress_region(self) -> None:
         """Emit the --tsan concurrency-stress region.
@@ -871,13 +1035,23 @@ class WritePythonCode(WriteCode):
         # machine-parseable JSON line (both literals -- no runtime json import in the script).
         self.write_print_to_stderr(0, repr(provenance_line))
         self.write_print_to_stderr(0, repr(manifest_line))
-        # Free-threading is mandatory: without it the whole region is GIL-serialised noise.
+        # Under --tsan, free-threading is MANDATORY: with the GIL on, ThreadSanitizer sees a
+        # serialised run and detects nothing, so bail loudly. Under --concurrency-stress (no TSan)
+        # the region is still useful GIL-on -- threading teardown / re-entrancy bugs (RUSTPY-0001)
+        # surface via context switches, not just true parallelism -- so only WARN and continue.
         self.write(0, 'if getattr(sys, "_is_gil_enabled", lambda: True)():')
         with self.indented():
-            self.write_print_to_stderr(
-                0, '"[TSAN] FATAL: GIL enabled; need PYTHON_GIL=0 + a --disable-gil build"'
-            )
-            self.write(0, "raise SystemExit(3)")
+            if self.options.tsan:
+                self.write_print_to_stderr(
+                    0, '"[TSAN] FATAL: GIL enabled; need PYTHON_GIL=0 + a --disable-gil build"'
+                )
+                self.write(0, "raise SystemExit(3)")
+            else:
+                self.write_print_to_stderr(
+                    0,
+                    '"[CSTRESS] note: GIL enabled; running serialised (concurrency-stress '
+                    'still exercises threading teardown/re-entrancy)"',
+                )
         # Mutable containers shared BY REFERENCE across every worker (shared-argument races).
         self.write(0, '_tsan_shared_args = [[1, 2, 3], {"k": 1}, {1, 2, 3}, bytearray(b"fusil")]')
         self.write(0, "_tsan_funcs = %r" % (funcs,))

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -47,6 +47,9 @@ def _make_options(oom_fuzz, oom_verbose=False):
     o.oom_foreign_pythonmalloc = False
     # TSan mode OFF (explicit: a bare MagicMock attr would be truthy and divert generation).
     o.tsan = False
+    # Alt-interpreter generic modes OFF too (same MagicMock-is-truthy divert hazard as tsan).
+    o.concurrency_stress = False
+    o.new_uninit = False
     o.test_private = False
     o.no_numpy = True
     o.no_tstrings = True

--- a/tests/python/test_rustpython_dedup.py
+++ b/tests/python/test_rustpython_dedup.py
@@ -1,0 +1,235 @@
+"""Unit tests for the in-loop RustPython crash deduper (fusil.python.rustpython_dedup).
+
+Pure-Python: parse canned RustPython panic/segfault stdout into site signatures and exercise the
+catalog dedupe / prune / segv-resolution decisions without the runtime stack. Mirrors
+test_tsan_dedup / test_oom_dedup.
+"""
+
+import unittest
+
+from fusil.python import rustpython_dedup as rd
+
+# Real RustPython panic headers (captured from rustpython 0.5.0). The newer toolchain prints a
+# thread-id in parens; the older one does not -- both must parse to the same site signature.
+PANIC_STRUCTSEQ_TID = "\n".join(
+    [
+        "",
+        "thread 'main' (2430955) panicked at crates/vm/src/types/structseq.rs:311:21:",
+        "index out of bounds: the len is 0 but the index is 0",
+        "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+    ]
+)
+PANIC_STRUCTSEQ_NO_TID = "\n".join(
+    [
+        "thread 'main' panicked at crates/vm/src/types/structseq.rs:311:21:",
+        "index out of bounds: the len is 0 but the index is 0",
+    ]
+)
+PANIC_STATICMETHOD = (
+    "thread 'main' (7) panicked at crates/vm/src/builtins/staticmethod.rs:182:54:\n"
+    "called `Result::unwrap()` on an `Err` value: PyBaseException"
+)
+# A worker-thread panic that prints MID-stdout (RUSTPY-0001 class), with real output after it.
+PANIC_WORKER_MIDSTREAM = "\n".join(
+    [
+        "[CSTRESS] entering region",
+        "some worker output",
+        "thread '<unnamed>' (99) panicked at crates/vm/src/stdlib/thread.rs:977:13:",
+        "already borrowed: BorrowMutError",
+        "more output printed after the panic",
+    ]
+)
+# A build that baked in an absolute checkout path -> must normalise to the crates/ tail.
+PANIC_ABSOLUTE_PATH = (
+    "thread 'main' panicked at "
+    "/home/x/.cargo/git/checkouts/rustpython-abc123/a9c2c52/crates/vm/src/x.rs:42:1:\n"
+    "boom"
+)
+# A bare segfault: no panic line at all.
+SEGV_NO_PANIC = "\n".join(
+    [
+        "Importing target module: re",
+        "[NEW-UNINIT] entering uninitialized-object region",
+        "[NEW-UNINIT] poking Match",
+    ]
+)
+# A gdb backtrace whose top real frame is a RustPython hash function (plumbing above it skipped).
+GDB_BT = "\n".join(
+    [
+        "Program received signal SIGSEGV, Segmentation fault.",
+        "#0  0x00007f00 in __memmove_avx_unaligned ()",
+        "#1  0x00007f01 in core::panicking::panic ()",
+        "#2  0x00007f02 in rustpython_vm::builtins::int::PyInt::hash () at crates/vm/src/x.rs:9",
+        "#3  0x00007f03 in _PyEval_EvalFrameDefault ()",
+    ]
+)
+
+
+class TestParseReport(unittest.TestCase):
+    def test_panic_with_tid(self):
+        rep = rd.parse_report(PANIC_STRUCTSEQ_TID)
+        self.assertIsNotNone(rep)
+        self.assertEqual(rep["kind"], "panic")
+        self.assertEqual(rep["signature"], "crates/vm/src/types/structseq.rs:311")
+
+    def test_panic_without_tid(self):
+        rep = rd.parse_report(PANIC_STRUCTSEQ_NO_TID)
+        self.assertEqual(rep["signature"], "crates/vm/src/types/structseq.rs:311")
+
+    def test_tid_and_no_tid_dedupe_identically(self):
+        self.assertEqual(
+            rd.parse_report(PANIC_STRUCTSEQ_TID)["signature"],
+            rd.parse_report(PANIC_STRUCTSEQ_NO_TID)["signature"],
+        )
+
+    def test_column_is_dropped(self):
+        # :182:54 -> drop the :54 column.
+        self.assertEqual(
+            rd.parse_report(PANIC_STATICMETHOD)["signature"],
+            "crates/vm/src/builtins/staticmethod.rs:182",
+        )
+
+    def test_worker_panic_midstream(self):
+        rep = rd.parse_report(PANIC_WORKER_MIDSTREAM)
+        self.assertEqual(rep["signature"], "crates/vm/src/stdlib/thread.rs:977")
+
+    def test_absolute_path_normalised(self):
+        rep = rd.parse_report(PANIC_ABSOLUTE_PATH)
+        self.assertEqual(rep["signature"], "crates/vm/src/x.rs:42")
+
+    def test_no_panic_returns_none(self):
+        self.assertIsNone(rd.parse_report(SEGV_NO_PANIC))
+
+    def test_first_panic_wins(self):
+        two = PANIC_STATICMETHOD + "\n" + PANIC_STRUCTSEQ_NO_TID
+        self.assertEqual(
+            rd.parse_report(two)["signature"], "crates/vm/src/builtins/staticmethod.rs:182"
+        )
+
+
+class TestParseAllPanics(unittest.TestCase):
+    def test_distinct_panics_collected_in_order(self):
+        text = PANIC_STATICMETHOD + "\n" + PANIC_STRUCTSEQ_NO_TID + "\n" + PANIC_STATICMETHOD
+        sigs = rd.parse_all_panics(text)
+        self.assertEqual(
+            sigs,
+            [
+                "crates/vm/src/builtins/staticmethod.rs:182",
+                "crates/vm/src/types/structseq.rs:311",
+            ],
+        )
+
+    def test_none_when_no_panic(self):
+        self.assertEqual(rd.parse_all_panics(SEGV_NO_PANIC), [])
+
+
+class TestCatalog(unittest.TestCase):
+    def test_load_catalog_skips_comments_and_bad_rows(self):
+        lines = [
+            "# a comment",
+            "RUSTPY-0002\tcrates/vm/src/types/structseq.rs:311",
+            "RUSTPY-0009\tcrates/vm/src/builtins/staticmethod.rs:182",
+            "malformed line without tab",
+            "",
+        ]
+        cat = rd.load_catalog(lines)
+        self.assertEqual(cat["crates/vm/src/types/structseq.rs:311"], "RUSTPY-0002")
+        self.assertEqual(cat["crates/vm/src/builtins/staticmethod.rs:182"], "RUSTPY-0009")
+        self.assertEqual(len(cat), 2)
+
+
+class TestGdbTopFrame(unittest.TestCase):
+    def test_skips_plumbing_to_real_frame(self):
+        self.assertEqual(rd._gdb_top_frame(GDB_BT), "rustpython_vm::builtins::int::PyInt::hash")
+
+    def test_none_when_no_frames(self):
+        self.assertIsNone(rd._gdb_top_frame("no frames here"))
+
+
+class TestDeduperPanics(unittest.TestCase):
+    def _cat(self):
+        return {
+            "crates/vm/src/types/structseq.rs:311": "RUSTPY-0002",
+            "crates/vm/src/builtins/staticmethod.rs:182": "RUSTPY-0009",
+        }
+
+    def test_known_panic_labelled(self):
+        d = rd.RustPyDeduper()
+        d.snap = self._cat()
+        keep, label = d.decide(PANIC_STRUCTSEQ_TID)
+        self.assertTrue(keep)
+        self.assertEqual(label, "RUSTPY-0002")
+
+    def test_new_panic_labelled_rustpynew(self):
+        d = rd.RustPyDeduper()
+        d.snap = self._cat()
+        keep, label = d.decide(PANIC_WORKER_MIDSTREAM)  # thread.rs:977 not in catalog
+        self.assertTrue(keep)
+        self.assertEqual(label, "rustpyNEW")
+
+    def test_prune_past_keep_cap(self):
+        d = rd.RustPyDeduper(keep=2, prune=True)
+        d.snap = self._cat()
+        labels = [d.decide(PANIC_STRUCTSEQ_TID) for _ in range(4)]
+        # First 2 kept, rest pruned (keep=False) but still labelled with the id.
+        self.assertEqual([k for k, _ in labels], [True, True, False, False])
+        self.assertTrue(all(lbl == "RUSTPY-0002" for _, lbl in labels))
+        self.assertEqual(d.seen["RUSTPY-0002"], 4)
+        self.assertEqual(d.kept["RUSTPY-0002"], 2)
+
+    def test_no_prune_keeps_all(self):
+        d = rd.RustPyDeduper(keep=2, prune=False)
+        d.snap = self._cat()
+        keeps = [d.decide(PANIC_STRUCTSEQ_TID)[0] for _ in range(4)]
+        self.assertEqual(keeps, [True, True, True, True])
+
+
+class TestDeduperSegv(unittest.TestCase):
+    def test_segv_without_resolver_buckets(self):
+        d = rd.RustPyDeduper()  # resolve_segv defaults False
+        keep, label = d.decide(SEGV_NO_PANIC, source_path="/x/source.py")
+        self.assertTrue(keep)
+        self.assertEqual(label, "rustpySEGV")
+
+    def test_segv_resolved_new(self):
+        d = rd.RustPyDeduper(resolve_segv=True, segv_resolver=lambda p: "PyInt::hash")
+        keep, label = d.decide(SEGV_NO_PANIC, source_path="/x/source.py")
+        self.assertTrue(keep)
+        self.assertEqual(label, "rustpySEGV")
+        self.assertIn("NEW-SEGV:SEGV PyInt::hash", d.seen)
+
+    def test_segv_resolved_known(self):
+        d = rd.RustPyDeduper(resolve_segv=True, segv_resolver=lambda p: "PyInt::hash")
+        d.snap = {"SEGV PyInt::hash": "RUSTPY-0007a"}
+        keep, label = d.decide(SEGV_NO_PANIC, source_path="/x/source.py")
+        self.assertTrue(keep)
+        self.assertEqual(label, "RUSTPY-0007a")
+
+    def test_resolver_failure_falls_back_to_bucket(self):
+        def boom(_p):
+            raise RuntimeError("gdb blew up")
+
+        d = rd.RustPyDeduper(resolve_segv=True, segv_resolver=boom)
+        keep, label = d.decide(SEGV_NO_PANIC, source_path="/x/source.py")
+        self.assertTrue(keep)
+        self.assertEqual(label, "rustpySEGV")
+
+    def test_resolver_returns_list(self):
+        d = rd.RustPyDeduper(resolve_segv=True, segv_resolver=lambda p: ["top::frame", "next"])
+        d.snap = {"SEGV top::frame": "RUSTPY-0099"}
+        keep, label = d.decide(SEGV_NO_PANIC, source_path="/x/source.py")
+        self.assertEqual(label, "RUSTPY-0099")
+
+
+class TestReport(unittest.TestCase):
+    def test_report_lists_seen_and_kept(self):
+        d = rd.RustPyDeduper()
+        d.snap = {"crates/vm/src/types/structseq.rs:311": "RUSTPY-0002"}
+        d.decide(PANIC_STRUCTSEQ_TID)
+        text = d.report()
+        self.assertIn("RustPython dedupe summary", text)
+        self.assertIn("RUSTPY-0002", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The first two RustPython fleets converged fast on the same ~9 crashes, and neither `--tsan` (Rust's `Arc`/`Send`/`Sync` prevent the C-style races TSan hunts) nor `--oom` (Rust OOM aborts rather than exposing continuable error paths) applies. Every RustPython finding is instead a `.unwrap()`/`.expect()`/`panic!`/unchecked-index reachable from Python, or unguarded native recursion — all in the ~96 Rust-implemented modules.

This PR adds four **generic** hostile capabilities (they help any alternative interpreter — RustPython, PyPy) in **core** fusil, plus an in-loop **dedup catalog** so fleets keep only NEW panic sites. RustPython-specific packaging (curated module list, known-panic suppression) will land in a separate `fusil_rustpython_plugin`.

## What

**New modes / options**
- `--concurrency-stress` — emit the `--tsan` shared-object/many-thread stress region **without** a TSan build or the free-threaded/`--with-thread-sanitizer` preflight (reuses `--tsan-threads`/`-iterations`/`-shared-objects`). The GIL guard is hard only under `--tsan`; under `--concurrency-stress` it warns and runs serialised — threading teardown/re-entrancy bugs surface via context switches (the class that produced the RustPython `_thread` `RefCell` double-borrow).
- `--new-uninit` — for each type `T` discovered in the session's module(s), including hidden **result** types reached via a bounded call sweep (e.g. `type(re.match('a','a'))`, never a module attribute), build `obj = T.__new__(T)` and hammer its **protocol slots** (subscript, iter/next, call, number, comparison, buffer, context-manager) plus every `dir()` method with hostile args. Protocol slots that touch payload without re-validating segfault a type-confused instance where ordinary methods downcast-fail cleanly.
- `--modules-file FILE` — read a curated module list (one per line, `#` comments), bypassing discovery/blacklists; unions with `--modules`.
- `RUST_BACKTRACE=1` in the target env (harmless no-op for CPython/PyPy) for richer panic frames.

**Dedup engine** — `fusil/python/rustpython_dedup.py`, mirroring `tsan_dedup.py`/`oom_dedup.py`:
- `parse_report` → panic-site signature `crates/<path>.rs:<line>` (drops the column, normalises absolute checkout paths to the `crates/` tail, handles the newer `thread 'NAME' (tid) panicked` form and worker panics printed mid-stdout).
- `RustPyDeduper.decide` → `(keep, label)`: catalog hit → `RUSTPY-00NN`, new panic → `rustpyNEW`, bare segfault → `rustpySEGV` (or a gdb-resolved top frame via an injectable resolver). Wired via `--rustpython-dedup-catalog`/`-keep`/`-prune` on the existing `application.session_keep_policy` hook.

## Testing
- Pure-Python engine unit-tested in `tests/python/test_rustpython_dedup.py` (23 tests).
- The two new mode flags are set `False` in `test_oom_fuzz`'s `MagicMock` fixture (a bare Mock attr is truthy and would divert generation into the stress region — the same hazard the existing `o.tsan = False` guards).
- Verified end-to-end against RustPython 0.5.0: `--new-uninit` reproduces the `re.Match.__new__` subscript segfault **and** a new `structseq.__new__` panic face; `--concurrency-stress` runs the stress region on RustPython with no TSan preflight; the dedup keep-policy labels crash dirs `rustpyNEW` / `RUSTPY-id`.
- `ruff check` + `ruff format --check` clean; full `unittest` suite (1168 tests) green.

Non-`--tsan`/non-`--new-uninit` output is unchanged (both are gated early-return branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)