### PR TITLE
fleet: --tsan preflight must not trigger on --tsan-* sub-options (unblocks --concurrency-stress fleets)

### DIFF
--- a/fleet/fleet
+++ b/fleet/fleet
@@ -59,8 +59,12 @@ cmd_check(){  # validate fleet.conf before we start anything (catches the #1 foo
     esac
     # A --tsan fleet needs a free-threaded + ThreadSanitizer TARGET (fusil's own preflight fails
     # fast otherwise, wasting the instance). Check here so the whole fleet doesn't start doomed.
+    # Match ONLY the bare `--tsan` mode flag, not the `--tsan-*` sub-options (--tsan-threads,
+    # --tsan-iterations, --tsan-dedup-*): those knobs are ALSO reused by --concurrency-stress, which
+    # runs on an ordinary interpreter and must NOT trip the ThreadSanitizer-build requirement. The
+    # bare flag appears as `--tsan ` (space) or ends the string; `[!-]` excludes the `--tsan-` forms.
     case "$FUSIL_FLAGS" in
-        *--tsan*) [ -x "$TARGET_PYTHON" ] && "$TARGET_PYTHON" -c \
+        *--tsan|*--tsan[!-]*) [ -x "$TARGET_PYTHON" ] && "$TARGET_PYTHON" -c \
             'import sys,sysconfig; ca=sysconfig.get_config_var("CONFIG_ARGS") or ""; sys.exit(0 if (not sys._is_gil_enabled() and "thread-sanitizer" in ca) else 1)' \
             2>/dev/null || {
             echo "  --tsan is set but TARGET_PYTHON is not free-threaded + --with-thread-sanitizer: '$TARGET_PYTHON'"


### PR DESCRIPTION
## Problem

Starting a `--concurrency-stress` fleet fails the preflight:
```
--tsan is set but TARGET_PYTHON is not free-threaded + --with-thread-sanitizer: '.../rustpython'
  -> use a builds/*-ft-*-tsan interpreter
fleet: preflight failed
```
even though `--tsan` is **not** set. The `cmd_check` case glob `*--tsan*` matches `--tsan-threads` / `--tsan-iterations` — the knobs `--concurrency-stress` legitimately reuses (from #226) to size its stress region. `--concurrency-stress` runs on an ordinary interpreter, so it must not require a ThreadSanitizer build.

## Fix

Narrow the build-check glob to the bare `--tsan` mode flag: `*--tsan|*--tsan[!-]*` (matches `--tsan ` with a trailing space, or `--tsan` ending the string; `[!-]` excludes the `--tsan-` sub-option forms). Verified:

| FUSIL_FLAGS | before | after |
|---|---|---|
| `--concurrency-stress --tsan-threads 4 --tsan-iterations 200` | ❌ wrongly blocked | ✅ starts |
| `--tsan --tsan-threads 4` (real TSan) | triggers check | ✅ still triggers |
| `--modules x --tsan` (bare at end) | triggers check | ✅ still triggers |
| `--concurrency-stress --tsan-dedup-catalog=…` (no bare --tsan) | ❌ wrongly blocked | ✅ starts |

`bash -n fleet/fleet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)