### PR TITLE
Generalize fleet tooling for any fuzzing mode (OOM/TSan/RustPython/normal)

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -11,11 +11,15 @@ and capture their logs — no VMs or containers needed.
   `PYTHON_GIL` modes (they find *different* crashes).
 - **Auto-restart**: if an instance crashes or hits `--success` and exits, systemd brings
   it back. This is the "is it still running?" check, done by the OS.
-- **A memory cap per instance** (`MemoryMax`) so a runaway OOM-injection child can't take
-  down the whole machine.
-- **`fleet finds`**: surfaces the `oomNEW` crash dirs — the new-bug candidates — across
-  all instances, using the labels the in-loop dedup already writes. That's your
-  "anything interesting?" answer.
+- **A memory cap per instance** (`MemoryMax`) so a runaway child (an OOM-injection sweep, a
+  RustPython balloon, …) can't take down the whole machine.
+- **`fleet finds`**: surfaces the new-bug-candidate crash dirs across all instances, using the
+  labels the in-loop dedup already writes. That's your "anything interesting?" answer.
+
+The tooling is **mode-agnostic** — `status`, `finds`, `triage` and `report` work the same for OOM,
+TSan, RustPython and plain runs, because every dedup engine labels a new-bug candidate `<prefix>NEW`
+(`oomNEW`/`tsanNEW`/`rustpyNEW`) and an unresolved segv/frame `<prefix>SEGV`/`tsanFRAME`. Run
+**`./fleet info`** to see the fleet's auto-detected mode, loaded plugins, target and paths.
 
 ## One-time setup
 
@@ -25,18 +29,20 @@ and capture their logs — no VMs or containers needed.
    `python3` from the venv that has fusil installed.
 3. `chmod +x fleet fleet-run`
 
-> The `CATALOG` (`known_sites.tsv`) is the dedup snapshot. Generate/refresh it from the
-> `cpython-oom-findings` catalog with `gen_known_sites.py`; all instances read it
-> read-only, so there's no write contention.
+> The `CATALOG` is the dedup snapshot for whichever mode you run — `known_sites.tsv` from
+> `cpython-oom-findings` (OOM), `known_races.tsv` from `cpython-tsan-findings` (TSan), or
+> `known_panics.tsv` from `rustpython-findings` (RustPython). Regenerate it with the catalog's
+> generator; all instances read it read-only, so there's no write contention.
 
 ## Daily use
 
 ```bash
 sudo ./fleet up            # start (nproc-1) instances; or: sudo ./fleet up 8
+./fleet info               # mode, plugins, target and paths for this fleet
 ./fleet status             # per-instance state + crashes kept + NEW candidates
-./fleet report             # rich observability: sessions, throughput, crash taxonomy, disk, health
+./fleet report             # rich observability: mode/plugins, sessions, throughput, crash taxonomy, health
 ./fleet report 3           # ...for one instance;  add --watch (live), --html FILE (dashboard), or --json
-./fleet finds              # list the oomNEW dirs across the whole fleet
+./fleet finds              # list the new-bug-candidate dirs across the whole fleet
 ./fleet tail 3             # follow instance 3's output live
 sudo ./fleet down          # stop everything
 sudo ./fleet restart       # restart all (e.g. after refreshing the catalog)

--- a/fleet/fleet
+++ b/fleet/fleet
@@ -4,12 +4,17 @@
 #   ./fleet check           validate fleet.conf (paths exist, runner imports fusil)
 #   sudo ./fleet up [N]      install the unit + start N instances (default: nproc-1)
 #   sudo ./fleet down        stop + disable all instances
+#   ./fleet info            show the fleet's mode, plugins, target and paths
 #   ./fleet status          per-instance state + crash/NEW-find counts
-#   ./fleet finds           list this fleet's oomNEW (new-bug candidate) dirs
+#   ./fleet finds           list this fleet's new-bug-candidate dirs (oomNEW/tsanNEW/rustpyNEW/...)
 #   ./fleet report [N]      observability report: per-instance + campaign (--watch, --json, --html PATH, --no-systemd)
-#   ./fleet triage          dedupe oomNEW/oomSEGV candidates across instances (needs INGEST); extra args pass to ingest (e.g. --gdb)
+#   ./fleet triage          dedupe *NEW/*SEGV/*FRAME candidates across instances (needs INGEST); extra args pass to ingest (e.g. --gdb)
 #   ./fleet tail [N]        follow instance N's log (default: 1)
 #   sudo ./fleet restart    restart all instances (e.g. to pick up a new catalog)
+#
+# The label prefixes are mode-agnostic: any dedup engine marks a new-bug candidate "<prefix>NEW"
+# and an unresolved segv/frame "<prefix>SEGV"/"tsanFRAME", so status/finds/triage work for OOM,
+# TSan, RustPython and normal runs alike. The active mode is auto-detected from FUSIL_FLAGS.
 #
 # All paths/flags come from fleet.conf next to this script.
 set -euo pipefail
@@ -40,6 +45,51 @@ list_crashes(){  # kept crash dirs under an instance (layout-agnostic: has sourc
         | grep -vE '/session-[0-9]+$' | sort -u || true
 }
 
+# Mode-agnostic dedup-label patterns. Every engine labels a new-bug candidate "<prefix>NEW"
+# (oomNEW/tsanNEW/rustpyNEW) and an unresolved segv/frame "<prefix>SEGV"/"tsanFRAME". Case
+# matters: labels use UPPERCASE NEW/SEGV, a signal kind is lowercase ("sigsegv"), so these
+# never match the kind field.
+NEW_RE='[a-z]+NEW'                        # new-bug candidates
+CAND_RE='[a-z]+NEW|[a-z]+SEGV|tsanFRAME'  # all triage candidates (new + unresolved)
+
+fleet_mode(){  # human mode label auto-detected from FUSIL_FLAGS ("+"-joined; "normal" if none)
+    local m=()
+    case "$FUSIL_FLAGS" in
+        *--oom-foreign*) m+=(oom-foreign) ;;
+        *--oom-fuzz*)    m+=(oom) ;;
+    esac
+    case "$FUSIL_FLAGS" in *--tsan|*--tsan[!-]*) m+=(tsan) ;; esac
+    case "$FUSIL_FLAGS" in *--rustpython*) m+=(rustpython) ;; esac
+    case "$FUSIL_FLAGS" in *--concurrency-stress*) m+=(concurrency-stress) ;; esac
+    case "$FUSIL_FLAGS" in *--new-uninit*) m+=(new-uninit) ;; esac
+    if [ "${#m[@]}" -eq 0 ]; then echo normal; else (IFS=+; echo "${m[*]}"); fi
+}
+
+fleet_plugins(){  # best-effort: loaded plugin names from the newest run's stats sidecar
+    local newest
+    newest="$(find "$FLEET_DIR"/inst-*/python* -maxdepth 1 -name fusil_stats.json 2>/dev/null \
+              | xargs -r ls -t 2>/dev/null | head -1)"
+    [ -n "$newest" ] && [ -x "$RUNNER_PY" ] || return 0
+    "$RUNNER_PY" - "$newest" 2>/dev/null <<'PY' || true
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(", ".join(d.get("plugins") or []) or "(none)")
+except Exception:
+    pass
+PY
+}
+
+cmd_info(){  # the fleet banner: what this fleet is + where it lives
+    local plugins; plugins="$(fleet_plugins)"
+    echo "mode      : $(fleet_mode)"
+    echo "plugins   : ${plugins:-(run some sessions, then ./fleet report)}"
+    echo "fleet dir : $FLEET_DIR"
+    echo "target    : ${TARGET_PYTHON:-?}"
+    echo "catalog   : ${CATALOG:-(none)}"
+    echo "gil modes : ${GIL_MODES:-1}   instances: ${INSTANCES:-nproc-1}"
+}
+
 cmd_check(){  # validate fleet.conf before we start anything (catches the #1 footgun:
               # wrong paths / a non-venv python that can't import fusil under systemd)
     local ok=1 repo
@@ -56,6 +106,11 @@ cmd_check(){  # validate fleet.conf before we start anything (catches the #1 foo
         *--tsan-dedup-catalog*) [ -f "$CATALOG" ] || {
             echo "  CATALOG not found but --tsan-dedup-catalog is set: '$CATALOG'"
             echo "    -> point CATALOG at cpython-tsan-findings/catalog/known_races.tsv"; ok=0; } ;;
+    esac
+    case "$FUSIL_FLAGS" in
+        *--rustpython-dedup-catalog*) [ -f "$CATALOG" ] || {
+            echo "  CATALOG not found but --rustpython-dedup-catalog is set: '$CATALOG'"
+            echo "    -> point CATALOG at rustpython-findings/catalog/known_panics.tsv"; ok=0; } ;;
     esac
     # A --tsan fleet needs a free-threaded + ThreadSanitizer TARGET (fusil's own preflight fails
     # fast otherwise, wasting the instance). Check here so the whole fleet doesn't start doomed.
@@ -131,6 +186,7 @@ cmd_restart(){
 cmd_status(){
     local list; list="$(units)"
     [ -n "$list" ] || { echo "no instances (run: sudo ./fleet up)"; return; }
+    echo "fleet: $(fleet_mode)   dir: $FLEET_DIR"
     printf '%-4s %-9s %-20s %8s %6s\n' '#' STATE SINCE CRASHES NEW
     local tot=0 totnew=0
     for u in $list; do
@@ -140,20 +196,20 @@ cmd_status(){
         since="$(systemctl show -p ActiveEnterTimestamp --value "$u" 2>/dev/null | cut -d' ' -f2-3)"
         dir="$(inst_dir "$i")"
         n="$(list_crashes "$dir" | wc -l)"
-        new="$(list_crashes "$dir" | grep -c oomNEW || true)"
+        new="$(list_crashes "$dir" | grep -cE "$NEW_RE" || true)"
         tot=$((tot + n)); totnew=$((totnew + new))
         printf '%-4s %-9s %-20s %8s %6s\n' "$i" "$state" "${since:-?}" "$n" "$new"
     done
-    echo "---- totals: $tot crashes kept, $totnew oomNEW candidates ----"
+    echo "---- totals: $tot crashes kept, $totnew new-bug candidates ----"
     [ "$totnew" -gt 0 ] && echo "see them with: ./fleet finds"
 }
 
 cmd_finds(){
-    echo "== oomNEW (new-bug candidates) across the fleet =="
+    echo "== new-bug candidates ($(fleet_mode)) across the fleet =="
     local any=
     for d in "$FLEET_DIR"/inst-*; do
         [ -d "$d" ] || continue
-        list_crashes "$d" | grep oomNEW | sed "s#$FLEET_DIR/##" && any=1 || true
+        list_crashes "$d" | grep -E "$NEW_RE" | sed "s#$FLEET_DIR/##" && any=1 || true
     done
     [ -n "$any" ] || echo "(none yet)"
 }
@@ -162,13 +218,14 @@ cmd_triage(){
     # Candidate crash dirs live at inst-*/python-*/<label>/ (each holds a `stdout`); ingest.py
     # checks ONE level for a stdout (it does not recurse), so it must be handed those leaf dirs.
     # The old `inst-*/` glob passed the instance roots, which contain no stdout, so ingest saw
-    # 0 dirs and triage did nothing. Collect the oomNEW/oomSEGV candidates (depth-agnostic) and
-    # dedupe those against the catalog.
+    # 0 dirs and triage did nothing. Collect the *NEW/*SEGV/*FRAME candidates (mode-agnostic,
+    # depth-agnostic) and dedupe those against the catalog.
     local dirs=()
-    mapfile -t dirs < <(find "$FLEET_DIR"/inst-* -type d \( -name '*oomNEW*' -o -name '*oomSEGV*' \) 2>/dev/null | sort)
+    mapfile -t dirs < <(find "$FLEET_DIR"/inst-* -type d 2>/dev/null \
+        | grep -E "$CAND_RE" | sort)
     if [ -n "${INGEST:-}" ] && [ -f "$INGEST" ]; then
-        if [ "${#dirs[@]}" -eq 0 ]; then echo "no oomNEW/oomSEGV candidate dirs under $FLEET_DIR"; return 0; fi
-        echo "ingesting ${#dirs[@]} oomNEW/oomSEGV candidate dirs via $INGEST ..."
+        if [ "${#dirs[@]}" -eq 0 ]; then echo "no new-bug/segv candidate dirs under $FLEET_DIR"; return 0; fi
+        echo "ingesting ${#dirs[@]} candidate dirs via $INGEST ..."
         "$RUNNER_PY" "$INGEST" "${dirs[@]}" --snapshot "$CATALOG" "$@"
     else
         echo "(no INGEST configured in fleet.conf -- listing candidates only)"
@@ -201,10 +258,11 @@ case "${1:-status}" in
     check)    cmd_check ;;
     install)  cmd_install ;;
     restart)  cmd_restart ;;
+    info)     cmd_info ;;
     status)   cmd_status ;;
     finds)    cmd_finds ;;
     triage)   shift; cmd_triage "$@" ;;
     report)   shift; cmd_report "$@" ;;
     tail)     shift; cmd_tail "$@" ;;
-    *)        sed -n '2,14p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
+    *)        sed -n '2,19p' "$HERE/fleet" | sed 's/^# \{0,1\}//' ;;
 esac

--- a/fleet/fleet.conf
+++ b/fleet/fleet.conf
@@ -11,7 +11,9 @@ CATALOG=/home/ubuntu/known_sites.tsv                          # read-only dedup 
 FLEET_DIR=/home/ubuntu/fusil-fleet                            # per-instance working dirs go here
 
 # Optional: path to the catalog repo's ingest.py, for `fleet triage` (cross-instance
-# dedup). Leave empty to disable; `fleet triage` then just lists oomNEW dirs.
+# dedup). Leave empty to disable; `fleet triage` then just lists new-bug-candidate dirs.
+# Point it at the ingest.py of whichever catalog matches the mode (cpython-oom-findings /
+# cpython-tsan-findings / rustpython-findings).
 INGEST=/home/ubuntu/projects/cpython-oom-findings/scripts/ingest.py
 
 # --- fleet size & diversity ---

--- a/fleet/fusil@.service.in
+++ b/fleet/fusil@.service.in
@@ -14,8 +14,9 @@ Environment=FLEET_CONF=@@FLEET_CONF@@
 ExecStart=@@FLEET_RUN@@ %i
 Restart=always
 RestartSec=10
-# Cap memory so a runaway OOM-injection child can't take down the host. The OOM
-# killer reaps the instance; Restart=always brings it back.
+# Cap memory so a runaway child (an OOM-injection sweep, a RustPython balloon, a huge
+# eager-collect, ...) can't take down the host. The OOM killer reaps the instance;
+# Restart=always brings it back.
 MemoryMax=@@MEM_MAX@@
 OOMPolicy=continue
 Nice=@@NICE@@

--- a/fusil/python/fleet_report.py
+++ b/fusil/python/fleet_report.py
@@ -39,7 +39,26 @@ from fusil.python.session_stats import SessionStats
 # Crash-dir label parsing. A kept crash dir is named "<module>-<kind>-<dedup-label>[-N]",
 # e.g. "_blake2-fatal_python_error-OOM-0043-2". We token-search rather than split so a
 # trailing "-N" collision suffix and multi-part kinds don't confuse attribution.
-_LABEL_RE = re.compile(r"(OOM-\d{3,}|oomNEW|oomSEGV|oomclean|oomimport)")
+#
+# Mode-agnostic: every dedup engine (oom_dedup / tsan_dedup / rustpython_dedup, and any future
+# one) shares a labelling convention -- a known bug is "<PREFIX>-NNN" (OOM-/TSAN-/RUSTPY-), a
+# new-bug candidate is "<prefix>NEW" (oomNEW/tsanNEW/rustpyNEW), and an unresolved segv/frame is
+# "<prefix>SEGV"/"tsanFRAME". Case matters: the labels use UPPERCASE NEW/SEGV while a signal
+# kind is lowercase ("sigsegv"), so "[a-z]+SEGV" never matches the kind field.
+_LABEL_RE = re.compile(
+    r"([A-Z]+-\d{3,}"  # known dedup id: OOM-0043 / TSAN-0012 / RUSTPY-0024
+    r"|[a-z]+NEW"  # new-bug candidate: oomNEW / tsanNEW / rustpyNEW
+    r"|[a-z]+SEGV"  # unresolved segv: oomSEGV / rustpySEGV / tsanSEGV
+    r"|[a-z]+FRAME"  # tsan non-race frame bucket: tsanFRAME
+    r"|oomclean|oomimport)"  # OOM-only extra buckets
+)
+
+
+def new_candidate_count(by_label: dict) -> int:
+    """Sum of all new-bug-candidate labels (any "<prefix>NEW"), mode-agnostic."""
+    return sum(v for k, v in by_label.items() if k.endswith("NEW"))
+
+
 _KIND_RE = re.compile(
     r"(fatal_python_error|systemerror|assertion|sig[a-z]{2,}|exitcode\d+|cpu_load|timeout|bug)"
 )
@@ -216,7 +235,9 @@ def collect_instance(inst_dir: str, *, now=None, systemd=True) -> dict:
         "sidecar_crashes": merged.get("crashes", 0),
         "timeouts": merged.get("timeouts", 0),
         "cpu_load_kills": merged.get("cpu_load_kills", 0),
-        "oomnew": by_label.get("oomNEW", 0),
+        "new": new_candidate_count(by_label),
+        "mode": merged.get("mode") or (current or {}).get("mode"),
+        "plugins": merged.get("plugins") or (current or {}).get("plugins") or [],
         "by_label": by_label,
         "by_kind": by_kind,
         "by_module_crash": by_module_crash,
@@ -260,13 +281,21 @@ def discover_instances(fleet_dir: str) -> list[str]:
 
 def aggregate_campaign(reports: list[dict], *, now=None) -> dict:
     now = now if now is not None else time.time()
+    # mode/plugins are constant across a fleet; take the first non-"normal" mode and the union
+    # of plugin names, so the campaign header reports what the fleet is running.
+    modes = [r.get("mode") for r in reports if r.get("mode") and r.get("mode") != "normal"]
+    plugins: set[str] = set()
+    for r in reports:
+        plugins.update(r.get("plugins") or [])
     agg = {
         "instances": len(reports),
         "running": sum(1 for r in reports if r["running"]),
         "sessions": sum(r["sessions"] for r in reports),
         "kept_crashes": sum(r["kept_crashes"] for r in reports),
         "timeouts": sum(r["timeouts"] for r in reports),
-        "oomnew": sum(r["oomnew"] for r in reports),
+        "new": sum(r["new"] for r in reports),
+        "mode": modes[0] if modes else (reports[0].get("mode") if reports else None),
+        "plugins": sorted(plugins),
         "disk_bytes": sum(r["disk_bytes"] for r in reports),
         "by_label": {},
         "by_kind": {},
@@ -370,6 +399,10 @@ def render_instance(r: dict) -> str:
     )
     L.append("=" * 72)
     L.append(
+        "mode %s   plugins %s"
+        % (r.get("mode") or "?", ", ".join(r.get("plugins") or []) or "(none)")
+    )
+    L.append(
         "uptime %-10s  restarts %-3d  heartbeat %s ago"
         % (format_duration(r["uptime_s"]), r["restarts"], format_duration(r["heartbeat_age_s"]))
     )
@@ -423,7 +456,9 @@ def render_instance(r: dict) -> str:
     return "\n".join(L)
 
 
-def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]) -> str:
+def render_campaign(
+    reports: list[dict], agg: dict, flags: list[tuple[int, str]], fleet_dir: str | None = None
+) -> str:
     L = []
     L.append("=" * 84)
     L.append(
@@ -435,15 +470,23 @@ def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]
             human_bytes(agg["disk_bytes"]),
         )
     )
+    L.append(
+        "mode %s   plugins %s%s"
+        % (
+            agg.get("mode") or "?",
+            ", ".join(agg.get("plugins") or []) or "(none)",
+            ("   dir %s" % fleet_dir) if fleet_dir else "",
+        )
+    )
     find = (1000.0 * agg["kept_crashes"] / agg["sessions"]) if agg["sessions"] else 0.0
     L.append(
-        "sessions %-9d (%s)  crashes %-6d (%.1f/1k)  oomNEW %d  timeouts %d"
+        "sessions %-9d (%s)  crashes %-6d (%.1f/1k)  NEW %d  timeouts %d"
         % (
             agg["sessions"],
             format_rate(agg["sessions"], agg["elapsed_s"]),
             agg["kept_crashes"],
             find,
-            agg["oomnew"],
+            agg["new"],
             agg["timeouts"],
         )
     )
@@ -465,7 +508,7 @@ def render_campaign(reports: list[dict], agg: dict, flags: list[tuple[int, str]]
                 r["sessions"],
                 format_rate(r["sessions"], r["uptime_s"]).replace("/m", ""),
                 r["kept_crashes"],
-                r["oomnew"],
+                r["new"],
                 to_pct,
                 human_bytes(r["mem_current"]),
                 human_bytes(r["disk_bytes"]),
@@ -580,9 +623,16 @@ def render_html(report: dict, *, generated: str | None = None) -> str:
         "<!doctype html><html lang=en><head><meta charset=utf-8>",
         "<meta name=viewport content='width=device-width,initial-scale=1'>",
         "<title>fusil fleet report</title><style>%s</style></head><body>" % _CSS,
-        "<h1>fusil fleet <span class=sub>%d instances &middot; %d running &middot; elapsed %s "
-        "&middot; generated %s</span></h1>"
-        % (agg["instances"], agg["running"], _esc(format_duration(agg["elapsed_s"])), _esc(gen)),
+        "<h1>fusil fleet <span class=sub>mode %s &middot; plugins %s &middot; %d instances "
+        "&middot; %d running &middot; elapsed %s &middot; generated %s</span></h1>"
+        % (
+            _esc(agg.get("mode") or "?"),
+            _esc(", ".join(agg.get("plugins") or []) or "(none)"),
+            agg["instances"],
+            agg["running"],
+            _esc(format_duration(agg["elapsed_s"])),
+            _esc(gen),
+        ),
         "<div class=kpis>",
     ]
     for label, value in (
@@ -590,7 +640,7 @@ def render_html(report: dict, *, generated: str | None = None) -> str:
         ("throughput", format_rate(agg["sessions"], agg["elapsed_s"])),
         ("crashes", "{:,}".format(agg["kept_crashes"])),
         ("find rate", "%.1f/1k" % find),
-        ("oomNEW", agg["oomnew"]),
+        ("NEW", agg["new"]),
         ("timeouts", agg["timeouts"]),
         ("disk", human_bytes(agg["disk_bytes"])),
     ):
@@ -636,7 +686,7 @@ def render_html(report: dict, *, generated: str | None = None) -> str:
         p.append(_num_td("{:,}".format(r["sessions"]), r["sessions"]))
         p.append(_num_td("%.1f" % spm, spm))
         p.append(_num_td("{:,}".format(r["kept_crashes"]), r["kept_crashes"]))
-        p.append(_num_td(r["oomnew"], r["oomnew"]))
+        p.append(_num_td(r["new"], r["new"]))
         p.append(_num_td("%.0f%%" % to_pct, to_pct))
         p.append(
             _num_td(human_bytes(r["mem_current"]), r["mem_current"] if r["mem_current"] else -1)
@@ -667,6 +717,7 @@ def build_report(fleet_dir: str, instance: int | None, *, systemd=True, now=None
         inst_dirs = [d for d in inst_dirs if instance_number(d) == instance]
     reports = [collect_instance(d, now=now, systemd=systemd) for d in inst_dirs]
     return {
+        "fleet_dir": fleet_dir,
         "instances": reports,
         "campaign": aggregate_campaign(reports, now=now),
         "anomalies": anomalies(reports),
@@ -679,7 +730,9 @@ def render(report: dict, instance: int | None) -> str:
         return "no instances found"
     if instance is not None:
         return "\n".join(render_instance(r) for r in reports)
-    return render_campaign(reports, report["campaign"], report["anomalies"])
+    return render_campaign(
+        reports, report["campaign"], report["anomalies"], report.get("fleet_dir")
+    )
 
 
 def main(argv=None) -> int:

--- a/fusil/python/session_stats.py
+++ b/fusil/python/session_stats.py
@@ -10,7 +10,10 @@ in isolation -- same split as ``oom_dedup.py``. The MAS wiring lives in ``stats_
 Sidecar schema (v1)::
 
     {
-      "schema": 1,
+      "schema": 2,
+      "mode": "oom",              # active fuzzing mode ("oom"/"tsan"/"rustpython"/
+                                  #   "concurrency-stress"/"normal"/a "+"-joined combo)
+      "plugins": ["cereggii"],    # names of the loaded fusil plugins (entry-point discovered)
       "gil_mode": "0",            # PYTHON_GIL for this instance ("0"/"1"/None)
       "pid": 12345,               # the fusil parent pid
       "run_dir": "python-2",      # basename of the project run directory
@@ -38,7 +41,7 @@ import os
 import time
 from typing import Callable
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2  # v2 adds "mode" + "plugins" (additive; readers use .get with defaults)
 
 
 class SessionStats:
@@ -50,6 +53,8 @@ class SessionStats:
     def __init__(
         self,
         *,
+        mode: str | None = None,
+        plugins: list[str] | None = None,
         gil_mode: str | None = None,
         pid: int | None = None,
         run_dir: str | None = None,
@@ -57,6 +62,10 @@ class SessionStats:
         clock: Callable[[], float] = time.time,
     ) -> None:
         self._clock = clock
+        # Active fuzzing mode + loaded plugin names -- per-run constants recorded so the fleet
+        # tooling can report what a run actually is (not just OOM). Set by StatsAgent.
+        self.mode = mode
+        self.plugins = list(plugins) if plugins else []
         self.gil_mode = gil_mode
         self.pid = pid
         self.run_dir = run_dir
@@ -107,6 +116,8 @@ class SessionStats:
     def to_dict(self) -> dict:
         return {
             "schema": SCHEMA_VERSION,
+            "mode": self.mode,
+            "plugins": self.plugins,
             "gil_mode": self.gil_mode,
             "pid": self.pid,
             "run_dir": self.run_dir,
@@ -142,6 +153,8 @@ class SessionStats:
         """
         out = {
             "schema": SCHEMA_VERSION,
+            "mode": None,
+            "plugins": [],
             "sessions": 0,
             "crashes": 0,
             "timeouts": 0,
@@ -156,6 +169,11 @@ class SessionStats:
             if not d:
                 continue
             out["runs"] += 1
+            # mode/plugins are per-run constants for an instance; keep the last non-empty seen.
+            if d.get("mode"):
+                out["mode"] = d["mode"]
+            if d.get("plugins"):
+                out["plugins"] = list(d["plugins"])
             for key in ("sessions", "crashes", "timeouts", "cpu_load_kills"):
                 out[key] += int(d.get(key, 0) or 0)
             for name, bucket in (d.get("modules") or {}).items():

--- a/fusil/python/stats_agent.py
+++ b/fusil/python/stats_agent.py
@@ -21,6 +21,36 @@ from fusil.python.session_stats import SessionStats
 SIDECAR_NAME = "fusil_stats.json"
 _FLUSH_INTERVAL = 1.0  # seconds; the sidecar lags in-memory counters by at most this
 
+# (option attribute, mode label) pairs, checked in order. Each store_true flag that is set
+# contributes its label; the labels are "+"-joined (e.g. "rustpython+concurrency-stress"), so
+# a run reports exactly what it is. "oom-foreign" wins over "oom" (it implies --oom-fuzz).
+_MODE_FLAGS = (
+    ("oom_foreign", "oom-foreign"),
+    ("oom_fuzz", "oom"),
+    ("tsan", "tsan"),
+    ("rustpython", "rustpython"),
+    ("concurrency_stress", "concurrency-stress"),
+    ("new_uninit", "new-uninit"),
+)
+
+
+def detect_mode(options) -> str:
+    """Human-readable active-mode label from parsed options; "normal" if no special mode.
+
+    Best-effort and defensive (observability must never break fuzzing): unknown/absent
+    options are simply skipped. ``--oom-foreign`` implies ``--oom-fuzz``, so only the more
+    specific label is emitted.
+    """
+    if options is None:
+        return "normal"
+    parts: list[str] = []
+    for attr, label in _MODE_FLAGS:
+        if getattr(options, attr, False):
+            parts.append(label)
+    if "oom-foreign" in parts and "oom" in parts:
+        parts.remove("oom")
+    return "+".join(parts) if parts else "normal"
+
 
 class StatsAgent(ProjectAgent):
     """Fold each finished session into a ``SessionStats`` and periodically write the sidecar.
@@ -38,7 +68,13 @@ class StatsAgent(ProjectAgent):
             run_dir = os.path.basename(project.directory.directory)
         except Exception:
             pass
+        # Record what this run actually is (mode + loaded plugins) so the fleet tooling reports
+        # any fuzzing kind, not just OOM. Both are best-effort -- a failure here must not break
+        # fuzzing, so we swallow and fall back to unknown/empty.
+        mode, plugins = self._detect_mode_and_plugins()
         self.stats = SessionStats(
+            mode=mode,
+            plugins=plugins,
             gil_mode=os.environ.get("PYTHON_GIL"),
             pid=os.getpid(),
             run_dir=run_dir,
@@ -46,6 +82,33 @@ class StatsAgent(ProjectAgent):
         self._path = None  # resolved lazily on first flush
         self._rename_parts: list[str] = []
         self._last_flush = 0.0
+
+    def _detect_mode_and_plugins(self) -> tuple[str, list[str]]:
+        """(mode, plugin-names) for this run, from the application's options + plugin manager.
+
+        Fully defensive: any failure returns ("normal", []) rather than raising, since a stats
+        agent must never take down a fuzzing run.
+        """
+        mode, plugins = "normal", []
+        try:
+            app = self.application()
+            options = getattr(app, "options", None)
+            mode = detect_mode(options)
+            # A plugin can also register a fuzzing mode with no core option (e.g. a future
+            # plugin-only mode); prefer the explicit flags above, but fall back to it.
+            pm = getattr(app, "plugin_manager", None)
+            if pm is not None:
+                if mode == "normal":
+                    try:
+                        active = pm.get_active_mode(getattr(app, "config", None) or options)
+                        if active is not None and getattr(active, "name", None):
+                            mode = active.name
+                    except Exception:
+                        pass
+                plugins = sorted(getattr(pm, "plugins", {}) or {})
+        except Exception:
+            pass
+        return mode, plugins
 
     # --- session event stream ---------------------------------------------------------
 

--- a/tests/python/test_fleet_report.py
+++ b/tests/python/test_fleet_report.py
@@ -50,9 +50,21 @@ class TestClassify(unittest.TestCase):
             "json-sigsegv-oomNEW": ("json", "sigsegv", "oomNEW"),
             "mod-exitcode127-oomclean": ("mod", "exitcode127", "oomclean"),
             "weird_name_only": ("weird_name_only", "other", "other"),
+            # mode-agnostic: TSan / RustPython dedup labels classify the same way.
+            "unicode-panicked-TSAN-0012": ("unicode", "other", "TSAN-0012"),
+            "_thread-sigsegv-tsanNEW": ("_thread", "sigsegv", "tsanNEW"),
+            "email-timeout-tsanFRAME-3": ("email", "timeout", "tsanFRAME"),
+            "_asyncio-sigsegv-rustpySEGV": ("_asyncio", "sigsegv", "rustpySEGV"),
+            "sys-panicked-RUSTPY-0024": ("sys", "other", "RUSTPY-0024"),
+            "itertools-panicked-rustpyNEW-2": ("itertools", "other", "rustpyNEW"),
         }
         for name, expected in cases.items():
             self.assertEqual(fr.classify_crash_dir(name), expected, name)
+
+    def test_new_candidate_count_is_mode_agnostic(self):
+        by_label = {"oomNEW": 2, "tsanNEW": 1, "rustpyNEW": 3, "OOM-0043": 5, "oomSEGV": 4}
+        # counts every "<prefix>NEW", ignores known ids and segv/frame buckets
+        self.assertEqual(fr.new_candidate_count(by_label), 6)
 
 
 class TestCollectAndAggregate(unittest.TestCase):
@@ -94,7 +106,7 @@ class TestCollectAndAggregate(unittest.TestCase):
             self.assertEqual(r["sessions"], 150)  # summed across the two run dirs
             self.assertEqual(r["restarts"], 2)
             self.assertEqual(r["kept_crashes"], 2)
-            self.assertEqual(r["oomnew"], 1)
+            self.assertEqual(r["new"], 1)
             self.assertEqual(r["by_kind"].get("sigsegv"), 1)
             self.assertEqual(r["by_label"].get("oomclean"), 1)
             self.assertEqual(r["modules"]["json"]["hits"], 60)
@@ -110,7 +122,7 @@ class TestCollectAndAggregate(unittest.TestCase):
             self.assertEqual(agg["instances"], 2)
             self.assertEqual(agg["sessions"], 150)  # inst-02 has no sidecar
             self.assertEqual(agg["kept_crashes"], 3)
-            self.assertEqual(agg["oomnew"], 1)
+            self.assertEqual(agg["new"], 1)
             self.assertEqual(agg["by_label"].get("OOM-0043"), 1)
 
     def test_single_instance_filter(self):
@@ -125,6 +137,32 @@ class TestCollectAndAggregate(unittest.TestCase):
             self._fleet(tmp)
             insts = fr.discover_instances(os.path.join(tmp, "inst-01"))
             self.assertEqual(len(insts), 1)
+
+    def test_mode_and_plugins_flow_through_and_render(self):
+        # v2 sidecars record the active mode + loaded plugins; they must reach the per-instance
+        # dict, the campaign aggregate, and both text renders (the mode/plugins banner).
+        with tempfile.TemporaryDirectory() as tmp:
+            r1 = os.path.join(tmp, "inst-01", "python")
+            os.makedirs(r1)
+            _sidecar(
+                os.path.join(r1, "fusil_stats.json"),
+                schema=2,
+                sessions=10,
+                mode="rustpython+concurrency-stress",
+                plugins=["cereggii", "rustpython"],
+            )
+            r = fr.collect_instance(os.path.join(tmp, "inst-01"), now=2000.0, systemd=False)
+            self.assertEqual(r["mode"], "rustpython+concurrency-stress")
+            self.assertEqual(r["plugins"], ["cereggii", "rustpython"])
+            report = fr.build_report(tmp, None, systemd=False, now=2000.0)
+            self.assertEqual(report["campaign"]["mode"], "rustpython+concurrency-stress")
+            self.assertEqual(report["campaign"]["plugins"], ["cereggii", "rustpython"])
+            camp = fr.render(report, None)
+            self.assertIn("rustpython+concurrency-stress", camp)
+            self.assertIn("cereggii", camp)
+            self.assertIn(tmp, camp)  # fleet dir in the banner
+            inst = fr.render(report, 1)
+            self.assertIn("rustpython+concurrency-stress", inst)
 
     def test_tsan_kinds_flow_through_and_render(self):
         # Slice B: the --tsan shared-object distribution rides the sidecar through

--- a/tests/python/test_session_stats.py
+++ b/tests/python/test_session_stats.py
@@ -62,12 +62,20 @@ class TestRecord(unittest.TestCase):
 class TestSerialization(unittest.TestCase):
     def test_to_dict_schema(self):
         s = SessionStats(
-            gil_mode="1", pid=42, run_dir="python-2", started_at=5.0, clock=lambda: 9.0
+            mode="tsan",
+            plugins=["cereggii"],
+            gil_mode="1",
+            pid=42,
+            run_dir="python-2",
+            started_at=5.0,
+            clock=lambda: 9.0,
         )
         s.record("m", crash=True)
         d = s.to_dict()
         self.assertEqual(d["schema"], SCHEMA_VERSION)
         for key in (
+            "mode",
+            "plugins",
             "gil_mode",
             "pid",
             "run_dir",
@@ -80,9 +88,19 @@ class TestSerialization(unittest.TestCase):
             "modules",
         ):
             self.assertIn(key, d)
+        self.assertEqual(d["mode"], "tsan")
+        self.assertEqual(d["plugins"], ["cereggii"])
         self.assertEqual(d["gil_mode"], "1")
         self.assertEqual(d["pid"], 42)
         self.assertEqual(d["sessions"], 1)
+
+    def test_plugins_default_empty_and_copied(self):
+        # plugins defaults to [] (not None), and the constructor copies the list it's given
+        src = ["a"]
+        s = SessionStats(plugins=src)
+        self.assertEqual(SessionStats().plugins, [])
+        src.append("b")
+        self.assertEqual(s.plugins, ["a"])  # not aliased to the caller's list
 
     def test_write_is_atomic_and_roundtrips(self):
         s = SessionStats(started_at=1.0, clock=lambda: 2.0)
@@ -100,12 +118,15 @@ class TestSerialization(unittest.TestCase):
 
 class TestMerge(unittest.TestCase):
     def test_merge_sums_and_unions(self):
-        a = SessionStats(started_at=10.0, clock=lambda: 20.0)
+        a = SessionStats(mode="oom", plugins=["numpy"], started_at=10.0, clock=lambda: 20.0)
         a.record("json", crash=True)
         b = SessionStats(started_at=5.0, clock=lambda: 30.0)
         b.record("json")
         b.record("sqlite3", timeout=True)
         merged = SessionStats.merge([a.to_dict(), b.to_dict()])
+        # mode/plugins are per-run constants: the last non-empty seen wins
+        self.assertEqual(merged["mode"], "oom")
+        self.assertEqual(merged["plugins"], ["numpy"])
         self.assertEqual(merged["sessions"], 3)
         self.assertEqual(merged["crashes"], 1)
         self.assertEqual(merged["timeouts"], 1)

--- a/tests/python/test_stats_agent.py
+++ b/tests/python/test_stats_agent.py
@@ -17,11 +17,44 @@ sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
 
 try:
     from fusil.python.session_stats import SessionStats
-    from fusil.python.stats_agent import StatsAgent
+    from fusil.python.stats_agent import StatsAgent, detect_mode
 
     HAVE = True
 except Exception:  # noqa: BLE001 -- runtime stack (python-ptrace) may be absent
     HAVE = False
+
+
+@unittest.skipUnless(HAVE, "requires the fusil runtime stack (python-ptrace)")
+class TestDetectMode(unittest.TestCase):
+    def _opts(self, **kw):
+        base = dict(
+            oom_fuzz=False,
+            oom_foreign=False,
+            tsan=False,
+            rustpython=False,
+            concurrency_stress=False,
+            new_uninit=False,
+        )
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    def test_modes(self):
+        self.assertEqual(detect_mode(None), "normal")
+        self.assertEqual(detect_mode(self._opts()), "normal")
+        self.assertEqual(detect_mode(self._opts(oom_fuzz=True)), "oom")
+        self.assertEqual(detect_mode(self._opts(tsan=True)), "tsan")
+        self.assertEqual(detect_mode(self._opts(rustpython=True)), "rustpython")
+        # --oom-foreign implies --oom-fuzz; only the specific label is emitted
+        self.assertEqual(detect_mode(self._opts(oom_fuzz=True, oom_foreign=True)), "oom-foreign")
+        # combined flags are "+"-joined in a stable order
+        self.assertEqual(
+            detect_mode(self._opts(rustpython=True, concurrency_stress=True)),
+            "rustpython+concurrency-stress",
+        )
+
+    def test_missing_attrs_are_tolerated(self):
+        # an options object lacking a flag attr must not raise (getattr default False)
+        self.assertEqual(detect_mode(SimpleNamespace(tsan=True)), "tsan")
 
 
 @unittest.skipUnless(HAVE, "requires the fusil runtime stack (python-ptrace)")


### PR DESCRIPTION
The `fleet` tooling's `status`/`finds`/`triage`/`report` commands hardcoded OOM dedup labels (`oomNEW`/`oomSEGV`), so they only worked for OOM runs — even though we also fleet TSan, RustPython (`--rustpython`/`--concurrency-stress`) and plain modes. This generalizes the tooling to any fuzzing mode and surfaces what a run actually is.

### The insight
Every dedup engine (`oom_dedup`/`tsan_dedup`/`rustpython_dedup`, and any future one) already shares a labelling convention:

| | OOM | TSan | RustPython |
|---|---|---|---|
| new candidate | `oomNEW` | `tsanNEW` | `rustpyNEW` |
| unresolved | `oomSEGV` | `tsanFRAME`/`tsanSEGV` | `rustpySEGV` |
| known id | `OOM-###` | `TSAN-###` | `RUSTPY-###` |

So the label handling becomes **mode-agnostic regexes** (`[a-z]+NEW`, `[a-z]+(NEW\|SEGV\|FRAME)`, `[A-Z]+-\d{3,}`) — future-proof, no per-mode table. Case matters in our favour: labels use uppercase `NEW`/`SEGV`, signal kinds are lowercase (`sigsegv`), so they never collide.

### What changed (two commits)
**1. Tooling-only (parts 1/3/4) — no fuzzer change**
- `fleet` (bash): generic NEW/candidate greps in `status`/`finds`/`triage`; new **`fleet info`** + a `status` banner showing the auto-detected mode (from `FUSIL_FLAGS`) and `FLEET_DIR`; `fleet check` now validates `--rustpython-dedup-catalog` too.
- `fleet_report.py`: `_LABEL_RE` recognizes every family; `oomnew` → generic `new` count; campaign/instance/HTML views render a **mode · plugins · fleet-dir** banner.
- Docs (README/`fleet.conf`/service unit) reworded OOM-only → mode-agnostic.

**2. Fuzzer records mode + plugins**
- `SessionStats` gains `mode` + `plugins` (schema 2, additive); `detect_mode(options)` derives the label, `StatsAgent` records it plus the loaded plugin names. Fully defensive — a failure falls back to `("normal", [])` so observability never breaks a run.

### Verification
- Full suite green (1173 tests) + new coverage for TSan/RustPython label classification, the generic `new` count, `detect_mode`, and the mode/plugins banner flow. `ruff check` + `ruff format --check` clean.
- End-to-end smoke test on a synthetic RustPython-mode fleet: banner shows `mode rustpython+concurrency-stress · plugins cereggii, rustpython · dir …`, `NEW` correctly counts `rustpyNEW`, `fleet info`/`finds`/`check` all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)