### PR TITLE
tsan: --tsan-mutate-state — concurrent stateful-object mutation

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -148,6 +148,46 @@ Because the child is a separate process, the runner must find scenarios in its o
 generated script, since the target interpreter (`--python`) may not have the plugin
 installed. The cereggii plugin's `cereggii_scenario` mode is the worked example.
 
+### Concurrency-stress mutators (`--tsan-mutate-state`)
+
+The `--tsan` / `--concurrency-stress` region can drive **concurrent mutation** of the shared
+target objects (real-arg method calls + settable-property reassignment) on top of its
+read-heavy op-mix, so an extension's *stateful* race surface — mutating a shared object while
+another thread reads it — is exercised, not just read-only sharing. With no plugin it still
+does something useful (type-diverse method args + a self-reassign of each settable property);
+a plugin makes it *targeted* by publishing a curated per-type registry — **the same
+child-side-global pattern as scenarios** (a definitions provider, no live callable crossing
+the process boundary):
+
+```python
+def provide_mylib_mutators(config, module_name):
+    if not _is_mylib_target(config, module_name):
+        return None
+    # Keys are the child's OWN type objects (resolved via fuzz_target_module, never by
+    # importing the plugin); values are factories called fresh each use.
+    return (
+        "_FUSIL_STATEFUL_MUTATORS = {\n"
+        "    getattr(fuzz_target_module, 'Thing'): {\n"
+        "        'mutators': [\n"
+        "            ('add_item',    lambda: (['a', 'b'],)),   # (method_name, args-factory)\n"
+        "            ('set_limit',   lambda: (8,)),\n"
+        "        ],\n"
+        "        'properties': {                               # settable-prop -> value-factory\n"
+        "            'strategy': lambda: getattr(fuzz_target_module, 'Strategy')(),\n"
+        "        },\n"
+        "    },\n"
+        "}\n"
+    )
+
+manager.add_definitions_provider(provide_mylib_mutators)
+```
+
+The region reads `globals().get("_FUSIL_STATEFUL_MUTATORS", {})` defensively: for a shared
+object whose `type(obj)` is a registry key, op (b) calls its curated `mutators` with real args
+and op (j) reassigns its `properties` to fresh values; otherwise the generic fallback applies.
+Only active under `--tsan-mutate-state` (opt-in); absent the flag the registry is ignored.
+Design + phase history: [`tsan-mode-plan.md`](tsan-mode-plan.md).
+
 ## Suppression, blacklists, and dependencies
 
 - **Suppression** (`add_suppression_entry`) drops crashing-session *hits* whose stdout

--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -559,6 +559,50 @@ corruption artifacts rather than independent findings.
   `source.py`, recording the full per-race breakdown for the sibling catalog's ingest (#4). Only
   written under `--tsan-no-halt` with ≥2 distinct races, so default runs are unaffected.
 
+## Phase 6 as-built: concurrent stateful-object mutation (`--tsan-mutate-state`)
+
+The base op-mix is tuned for **CPython-level** races (managed-dict, refcount, container,
+iterator, gc, weakref) and is **argument-starved** on the target object: op (b) calls methods
+with four fixed generic containers (`_tsan_shared_args`), so an extension's real mutators
+(`Tokenizer.add_tokens(list[str])`, `enable_truncation(int)`, …) `TypeError` on the wrong
+arg types and are swallowed *before mutating*; op (d) only reassigns a synthetic `_tsan_aN`
+int, never a real settable property (`.normalizer` / `.model`). Consequence, proven on the
+tokenizers fleet (`fusil-tokenizers_01`): a 32-dir gdb sample was **32/32 CPython, 0/32
+tokenizers** — the interesting *mutate-while-read* extension race surface was never exercised.
+
+`--tsan-mutate-state` (opt-in, `store_true`, default off; in the `tsan_options` group so it
+applies to `--tsan` **and** `--concurrency-stress`) adds it via a runtime `_MUTATE_STATE` gate
+in the single worker body — off ⇒ op (b) runs today's container-arg path verbatim and op (j)
+is skipped, so existing campaigns and the dedup catalog are unchanged:
+
+- **op (b) enriched** — when a plugin registry entry exists for `type(_obj)`, call its curated
+  `mutators` with real args; else draw from a type-diverse pool `_tsan_call_args` (str/int/
+  float/bool/list/tuple/dict/bytes/None) so generic single-arg mutators actually fire.
+- **op (j) property reassign** (new) — writers reassign a settable property while readers read
+  it. Curated tier: a fresh value from the plugin registry (`.normalizer = Lowercase()`).
+  Generic fallback (any object): **self-reassign** `setattr(o, n, getattr(o, n))` over the
+  type's settable descriptors (`hasattr(getattr(type(o), n), "__set__")`) — always type-valid,
+  still races the setter's internal lock / pointer-swap against a concurrent reader.
+
+**Core/plugin split.** The mechanism + generic fallback are in core (module-agnostic); the
+curated per-type *mutators / property factories* live in a plugin, published as the child-side
+global `_FUSIL_STATEFUL_MUTATORS` via `add_definitions_provider` (the scenario pattern — no
+live callable crosses the process boundary). The region reads `globals().get(
+"_FUSIL_STATEFUL_MUTATORS", {})` defensively, exactly as it reads optional `plugin_factories`.
+Contract + recipe: [`plugins.md`](plugins.md) (*Concurrency-stress mutators*).
+
+**Provenance.** The manifest gains `"mutate_state": bool` and appends `"j:prop-reassign"` to
+`ops` (human line `ops=a-i` → `ops=a-j`) only when the flag is on. Tests:
+`test_tsan_generation.py` (`test_mutate_state_off_by_default`,
+`test_mutate_state_ops_emitted_when_enabled`, `test_plugin_mutator_registry_spliced_and_consulted`).
+
+**Caveats / EV.** Mutations succeed, so they cut swallowed-exception noise but reduce
+reproducibility (state diverges per run) and can wedge slow mutators; the generic tier is a
+blind `dir()`/descriptor sweep. And real *race detection* for a lock-correct extension (HF
+tokenizers wraps state in `Arc<RwLock<…>>`) wants a **TSan-instrumented** extension build
+(`.so` compiled `-fsanitize=thread`) — on a plain ASan/FT build only genuine memory-safety
+bugs in the extension's `unsafe` code surface.
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -504,6 +504,20 @@ class Fuzzer(Application):
             default=False,
         )
         tsan_options.add_option(
+            "--tsan-mutate-state",
+            action="store_true",
+            help="Also drive CONCURRENT MUTATION of the shared target objects (not just reads + "
+            "generic-arg method calls): the writer method-call op gets type-diverse args so real "
+            "mutators actually fire, and a new op reassigns each object's settable properties "
+            "(self-reassign generically; a fresh value when a plugin supplies one) while readers "
+            "touch them -- the mutate-while-read race an extension's stateful API exposes (e.g. a "
+            "tokenizer's add_tokens / .normalizer= during encode). A plugin can publish a curated "
+            "per-type mutator/property map via the child-side _FUSIL_STATEFUL_MUTATORS registry "
+            "(see doc/plugins.md); with none, the generic fallback still applies. Opt-in (default "
+            "off): mutations reduce reproducibility and raise more benign exceptions.",
+            default=False,
+        )
+        tsan_options.add_option(
             "--tsan-no-halt",
             action="store_true",
             help="Run TSan with halt_on_error=0 (report-and-continue) instead of stopping at the "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -910,6 +910,10 @@ class WritePythonCode(WriteCode):
         funcs = [f for f in (self.module_functions or []) if f not in TSAN_UNSAFE_CALLS][:40]
         # Slice E (opt-in): also share hostile subclasses of the target's own C types.
         weird_subclasses = bool(getattr(self.options, "tsan_weird_subclasses", False))
+        # Opt-in: drive concurrent MUTATION of the shared objects (real-arg method calls +
+        # settable-property reassignment) on top of the read-heavy op-mix. Off => the emitted
+        # worker runs exactly today's op (b) and skips op (j) (the _MUTATE_STATE gate below).
+        mutate_state = bool(getattr(self.options, "tsan_mutate_state", False))
 
         # Slice C: build a richer, guarded set of shared-object FACTORIES (source_expr, label,
         # iterable) -- real target objects rather than only bare Class() instances. The same
@@ -988,6 +992,9 @@ class WritePythonCode(WriteCode):
             "weird_subclasses": list(shared_classes) if weird_subclasses else [],
             "iter_off": iter_off,
             "roles": {"0": "writer", "1": "reader", "2": "both"},
+            # Opt-in concurrent-mutation ops: op (b) gets real args + curated mutators, and op (j)
+            # (property reassignment) is added. Reflected in the ops list only when actually on.
+            "mutate_state": mutate_state,
             "ops": [
                 "a:read-churn",
                 "b:method",
@@ -998,7 +1005,8 @@ class WritePythonCode(WriteCode):
                 "g:gc",
                 "h:shared-iter",
                 "i:read-while-mutate",
-            ],
+            ]
+            + (["j:prop-reassign"] if mutate_state else []),
             "workers_per_obj": workers_per_obj,
             "iters": iters,
             "func_count": len(funcs),
@@ -1006,7 +1014,7 @@ class WritePythonCode(WriteCode):
         provenance_line = (
             "[TSAN] provenance module=%s shared=%s(%dobj+%dcls+%dplugin+module) weird=%d "
             "args=list,dict,set,bytearray iterators=8+%dext iter_off=%d roles=r/w/both "
-            "ops=a-i workers=%d iters=%d funcs=%d"
+            "ops=%s workers=%d iters=%d funcs=%d"
             % (
                 self.module_name,
                 shared_kind,
@@ -1016,6 +1024,7 @@ class WritePythonCode(WriteCode):
                 len(shared_classes) if weird_subclasses else 0,
                 ext_iterators,
                 iter_off,
+                "a-j" if mutate_state else "a-i",
                 workers_per_obj,
                 iters,
                 len(funcs),
@@ -1058,6 +1067,22 @@ class WritePythonCode(WriteCode):
         # Runtime skip set: the worker introspects dir(shared_object), so a shared MODULE object
         # would still expose fork/exec/... by name -- filter them there too.
         self.write(0, "_tsan_unsafe = frozenset(%r)" % (tuple(sorted(TSAN_UNSAFE_CALLS)),))
+        # Concurrent-mutation support (op b enriched + op j), inert unless --tsan-mutate-state.
+        # _MUT_REG is the OPTIONAL plugin-supplied curated registry (type -> {"mutators":[(name,
+        # args-factory)], "properties":{name: value-factory}}), published as a child-side global
+        # by a plugin's definitions provider (doc/plugins.md); absent => {} and the generic
+        # fallback (type-diverse args + self-reassign) applies. Read like plugin_factories: if
+        # present use it, else nothing.
+        self.write(0, "_MUTATE_STATE = %r" % mutate_state)
+        self.write(0, '_MUT_REG = globals().get("_FUSIL_STATEFUL_MUTATORS", {})')
+        # Type-diverse argument pool for op (b)'s generic tier, so real single-arg mutators
+        # (add_tokens([...]), enable_truncation(int), ...) actually fire instead of TypeError-ing
+        # on the four generic containers.
+        self.write(
+            0,
+            "_tsan_call_args = "
+            '["x", "fusil", 1, 2, 0, -1, 1.5, True, ["a", "b"], ("a",), {"a": 1}, b"x", None]',
+        )
         # Build the shared objects from the guarded factories (Slice C): a few real target
         # objects (module-level instances, class instances w/ & w/o args, plugin objects),
         # capped for CONCENTRATION (few objects, many workers = what trips a race), plus the
@@ -1247,6 +1272,17 @@ class WritePythonCode(WriteCode):
                 # mutate/advance; _role == 2 does both. With >=2 workers per object both sides are
                 # present, so a reader always races a writer on the object / container / iterator.
                 _role = _wid % 3
+                # Concurrent-mutation state (op b curated tier + op j), cached once per worker;
+                # both inert unless _MUTATE_STATE. _mut = this type's curated registry entry (or
+                # None); _settable = its reassignable properties (getset/property with a setter),
+                # for the generic self-reassign fallback when no curated entry exists.
+                _mut = _MUT_REG.get(type(_obj)) if _MUTATE_STATE else None
+                _settable = (
+                    [_n for _n in dir(type(_obj))
+                     if not _n.startswith("_")
+                     and hasattr(getattr(type(_obj), _n, None), "__set__")]
+                    if _MUTATE_STATE else []
+                )
                 _tsan_barrier.wait()
                 for _i in range(_ITERS):
                     if _role != 1:
@@ -1256,12 +1292,26 @@ class WritePythonCode(WriteCode):
                                 _op(_obj)
                             except Exception:
                                 pass
-                    if _role != 0 and _names:
-                        # (b) writer: a method call with shared (mutable) arguments
+                    if _role != 0 and (_names or _mut):
+                        # (b) writer: a method call. Default: a dir() method with the shared
+                        # containers. --tsan-mutate-state: prefer a plugin-curated mutator with
+                        # real args, else a dir() method with TYPE-DIVERSE args so an extension's
+                        # actual state-mutators fire instead of TypeError-ing on the containers.
                         try:
-                            _m = getattr(_obj, _names[(_wid + _i) % len(_names)])
-                            if callable(_m):
-                                _m(*_tsan_shared_args[: (_i % 3)])
+                            if _MUTATE_STATE and _mut and _mut.get("mutators"):
+                                _mn, _af = _mut["mutators"][(_wid + _i) % len(_mut["mutators"])]
+                                _m = getattr(_obj, _mn, None)
+                                if callable(_m):
+                                    _m(*_af())
+                            elif _MUTATE_STATE and _names:
+                                _m = getattr(_obj, _names[(_wid + _i) % len(_names)])
+                                if callable(_m):
+                                    _off = (_wid + _i) % len(_tsan_call_args)
+                                    _m(*_tsan_call_args[_off:][: 1 + (_i % 2)])
+                            elif _names:
+                                _m = getattr(_obj, _names[(_wid + _i) % len(_names)])
+                                if callable(_m):
+                                    _m(*_tsan_shared_args[: (_i % 3)])
                         except Exception:
                             pass
                     if _role != 0 and _tsan_funcs:
@@ -1344,6 +1394,29 @@ class WritePythonCode(WriteCode):
                                 list(_bag)
                             elif isinstance(_bag, bytearray):
                                 bytes(_bag)
+                        except Exception:
+                            pass
+                    if _MUTATE_STATE and (_settable or (_mut and _mut.get("properties"))):
+                        # (j) property reassignment: writers reassign a settable property while
+                        # readers read it -- the mutate-while-read race an extension's stateful API
+                        # (a tokenizer's .normalizer= / .model= during encode) exposes. Curated:
+                        # cross-assign a fresh value from the plugin registry; generic fallback:
+                        # self-reassign (getattr then setattr), which still races the setter's
+                        # internal lock / pointer-swap against a concurrent reader.
+                        try:
+                            if _mut and _mut.get("properties"):
+                                _props = _mut["properties"]
+                                _pn = list(_props)[(_wid + _i) % len(_props)]
+                                if _role != 0:
+                                    setattr(_obj, _pn, _props[_pn]())
+                                if _role != 1:
+                                    getattr(_obj, _pn, None)
+                            elif _settable:
+                                _pn = _settable[(_wid + _i) % len(_settable)]
+                                if _role != 0:
+                                    setattr(_obj, _pn, getattr(_obj, _pn))
+                                if _role != 1:
+                                    getattr(_obj, _pn, None)
                         except Exception:
                             pass
             """,

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -56,7 +56,9 @@ def _tsan_module():
     return mod
 
 
-def _make_tsan_options(threads=4, iterations=200, shared_objects=3, weird_subclasses=False):
+def _make_tsan_options(
+    threads=4, iterations=200, shared_objects=3, weird_subclasses=False, mutate_state=False
+):
     o = MagicMock()
     o.tsan = True
     o.tsan_threads = threads
@@ -78,6 +80,9 @@ def _make_tsan_options(threads=4, iterations=200, shared_objects=3, weird_subcla
     o.objects_number = 0
     o.methods_number = 2
     o.tsan_weird_subclasses = weird_subclasses  # Slice E, opt-in
+    # Opt-in concurrent-mutation ops. MUST be set explicitly: a bare MagicMock would auto-vivify
+    # a truthy attribute and turn the machinery on in every test.
+    o.tsan_mutate_state = mutate_state
     return o
 
 
@@ -329,6 +334,64 @@ class TestTSanGeneration(unittest.TestCase):
         # region, so its banner must be absent.
         src = _generate_tsan()
         self.assertNotIn("functions in tsanmod", src)
+
+    def test_mutate_state_off_by_default(self):
+        # --tsan-mutate-state is opt-in: the default script does not run op (j) or the enriched
+        # op (b) (the _MUTATE_STATE runtime gate is False), so the manifest advertises neither.
+        src = _generate_tsan()
+        self.assertIn("_MUTATE_STATE = False", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertFalse(manifest["mutate_state"])
+        self.assertNotIn("j:prop-reassign", manifest["ops"])
+        self.assertIn("ops=a-i", src)  # human provenance line
+        # op (b) still uses the original shared-container args when the gate is off
+        self.assertIn("_m(*_tsan_shared_args[: (_i % 3)])", src)
+
+    def test_mutate_state_ops_emitted_when_enabled(self):
+        # With --tsan-mutate-state the worker gains a property-reassign op (j) and op (b) draws
+        # type-diverse args; the manifest and provenance advertise op j.
+        src = _generate_tsan(mutate_state=True)
+        ast.parse(src)  # still valid Python
+        self.assertIn("_MUTATE_STATE = True", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertTrue(manifest["mutate_state"])
+        self.assertIn("j:prop-reassign", manifest["ops"])
+        self.assertIn("ops=a-j", src)  # human provenance line
+        # generic tiers: type-diverse call args + the self-reassign property fallback
+        self.assertIn("_tsan_call_args = ", src)
+        self.assertIn("setattr(_obj, _pn, getattr(_obj, _pn))", src)
+        # settable-property discovery is emitted
+        self.assertIn('hasattr(getattr(type(_obj), _n, None), "__set__")', src)
+
+    def test_plugin_mutator_registry_spliced_and_consulted(self):
+        # A plugin publishes a curated per-type registry via a definitions provider; it is spliced
+        # into the child BEFORE the stress region, and the region reads it defensively (the
+        # sanctioned child-side-global pattern -- no live callable crosses the process boundary).
+        from fusil.plugin_manager import PluginManager
+
+        pm = PluginManager()
+        pm.add_definitions_provider(
+            lambda config, module_name: (
+                "_FUSIL_STATEFUL_MUTATORS = {\n"
+                "    getattr(fuzz_target_module, 'Widget'): {\n"
+                "        'mutators': [('op', lambda: ('x',))],\n"
+                "        'properties': {},\n"
+                "    },\n"
+                "}\n"
+            )
+        )
+        src = _generate_tsan(plugin_manager=pm, mutate_state=True)
+        ast.parse(src)
+        # the registry is defined in the child, and core reads it AFTER (ordering guarantee)
+        self.assertIn("_FUSIL_STATEFUL_MUTATORS = {", src)
+        self.assertIn('_MUT_REG = globals().get("_FUSIL_STATEFUL_MUTATORS", {})', src)
+        self.assertLess(
+            src.index("_FUSIL_STATEFUL_MUTATORS = {"),
+            src.index('_MUT_REG = globals().get("_FUSIL_STATEFUL_MUTATORS"'),
+        )
+        # the worker consults the curated mutators (op b) and properties (op j)
+        self.assertIn('_mut["mutators"]', src)
+        self.assertIn('_mut["properties"]', src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds `--tsan-mutate-state` (opt-in, default off) to the `--tsan` / `--concurrency-stress` region: it drives **concurrent mutation** of the shared target objects — real-arg method calls + settable-property reassignment — on top of the read-heavy op-mix, so an extension's **stateful** race surface (mutate a shared object while another thread reads/encodes it) is actually exercised.

## Why

The region was tuned for CPython-level races and is **argument-starved** on the target object:
- **op (b)** calls methods with four fixed generic containers (`_tsan_shared_args`), so an extension's real mutators (`Tokenizer.add_tokens(list[str])`, `enable_truncation(int)`, …) `TypeError` on the wrong arg types and are swallowed **before mutating**.
- **op (d)** only reassigns a synthetic `_tsan_aN` int — never a real settable property (`.normalizer` / `.model`).

Proven on the tokenizers fleet (`fusil-tokenizers_01`): a 32-dir gdb sample of the SEGVs was **32/32 CPython, 0/32 tokenizers** — the mutate-while-read extension surface was never hit.

## How

A runtime `_MUTATE_STATE` gate in the **single** worker body. **Off ⇒ op (b) runs today's container-arg path verbatim and op (j) is skipped**, so existing campaigns and the dedup catalog are byte-for-behaviour unchanged.

- **op (b) enriched** — curated mutators with real args when a plugin registry entry exists for `type(_obj)`; else a type-diverse arg pool (`_tsan_call_args`) so generic single-arg mutators fire.
- **op (j) property reassign** (new) — writers reassign a settable property while readers read it. Curated tier: a fresh value from the registry; generic fallback (any object): **self-reassign** `setattr(o, n, getattr(o, n))` over the type's settable descriptors — still races the setter's internal lock / pointer-swap.

### Core / plugin split
The **mechanism + generic fallback** are in core (module-agnostic). The **curated per-type mutators / property factories** live in a plugin, published as the child-side global `_FUSIL_STATEFUL_MUTATORS` via `add_definitions_provider` (the scenario pattern — no live callable crosses the process boundary). Core reads `globals().get("_FUSIL_STATEFUL_MUTATORS", {})` defensively, exactly as it reads optional `plugin_factories`. **No new `PluginManager` hook.**

## Provenance
Manifest gains `"mutate_state": bool` and appends `"j:prop-reassign"` to `ops` (human line `ops=a-i` → `ops=a-j`) **only when on**.

## Tests / verification
- New `test_tsan_generation.py` tests: `test_mutate_state_off_by_default`, `test_mutate_state_ops_emitted_when_enabled`, `test_plugin_mutator_registry_spliced_and_consulted`.
- Full suite **1176 OK**; `ruff check` + `ruff format --check` clean. `--tsan-mutate-state` appears in `--help` and maps to `options.tsan_mutate_state`.

## Docs
`doc/tsan-mode-plan.md` (Phase 6 as-built) + `doc/plugins.md` (*Concurrency-stress mutators* — the `_FUSIL_STATEFUL_MUTATORS` contract).

## Scope / follow-up
This PR is the **core mechanism + generic fallback + contract + in-repo test fixture** — no real plugin. First consumer will be a `fusil_tokenizers_plugin` (curated `Tokenizer` registry), pointed at a **TSan-instrumented** extension build where a lock-correct extension's races can actually be detected (a plain ASan/FT build only surfaces genuine `unsafe`-code memory bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)