### PR TITLE
tsan: --tsan-shared-objects-only — restrict the stress region to target objects

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -603,6 +603,23 @@ tokenizers wraps state in `Arc<RwLock<…>>`) wants a **TSan-instrumented** exte
 (`.so` compiled `-fsanitize=thread`) — on a plain ASan/FT build only genuine memory-safety
 bugs in the extension's `unsafe` code surface.
 
+### `--tsan-shared-objects-only` (extension-hunt companion)
+
+Even on a TSan build, the region shares *generic builtins* — the str/bytes/list/tuple/dict/
+range/count/struct iterators (op h) and the shared list/dict/set/bytearray containers (ops
+f/i) — which race in CPython's own code and flood an *extension* hunt with core races
+(rangeiter/count-repr cursors, shared-list resize, …) that dedupe/suppress but still dominate.
+`--tsan-shared-objects-only` (opt-in, `tsan_options`) restricts the region to the **target
+module's own objects + their iterators**: gen-time it emits an empty builtin-iterator list (op
+h then races only ext-object iterators), and a `_TSAN_OBJ_ONLY` runtime gate skips ops f/i;
+the worker's `_cell` is guarded against an empty iterator pool. The manifest reflects it
+(`shared_objects_only`, `iterators: []`, `shared_args: []`, ops without f/i; human line
+`ops=… objonly`). Off by default → normal runs unchanged. Pairs with a TSan **suppressions**
+file for the residual CPython noise that isn't from shared state — the interning/immortalize
+race from concurrent `setattr` (cpython#128137/#113956) and concurrent generator resume
+(cpython#120321) — for which the `cpython-tsan-findings` gateway carries `race:` entries.
+Tests: `test_tsan_generation.py` (`test_shared_objects_only_*`).
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -518,6 +518,18 @@ class Fuzzer(Application):
             default=False,
         )
         tsan_options.add_option(
+            "--tsan-shared-objects-only",
+            action="store_true",
+            help="Restrict the stress region to racing the TARGET module's objects: drop the "
+            "generic-builtin shared state (the str/bytes/list/tuple/dict/range/count/struct "
+            "iterators feeding op h, and the shared list/dict/set/bytearray container ops f/i) "
+            "that otherwise flood an EXTENSION hunt with CPython-core races (rangeiter/count-repr "
+            "cursors, shared-list resize, etc.). Only the extension's own objects + their "
+            "iterators are shared. Opt-in (default off); pairs with an extension-noise TSan "
+            "suppressions file for the residual interning/generator races.",
+            default=False,
+        )
+        tsan_options.add_option(
             "--tsan-no-halt",
             action="store_true",
             help="Run TSan with halt_on_error=0 (report-and-continue) instead of stopping at the "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -914,6 +914,10 @@ class WritePythonCode(WriteCode):
         # settable-property reassignment) on top of the read-heavy op-mix. Off => the emitted
         # worker runs exactly today's op (b) and skips op (j) (the _MUTATE_STATE gate below).
         mutate_state = bool(getattr(self.options, "tsan_mutate_state", False))
+        # Opt-in: share ONLY the target module's objects (+ their iterators); drop the generic
+        # builtin iterators (op h) and shared containers (ops f/i) that flood an extension hunt
+        # with CPython-core races. See the ops-list / iterator-factory / worker gates below.
+        objects_only = bool(getattr(self.options, "tsan_shared_objects_only", False))
 
         # Slice C: build a richer, guarded set of shared-object FACTORIES (source_expr, label,
         # iterable) -- real target objects rather than only bare Class() instances. The same
@@ -963,6 +967,32 @@ class WritePythonCode(WriteCode):
             else "module-only"
         )
         ext_iterators = sum(1 for _s, _l, it in obj_factory_specs if it)
+        # --tsan-shared-objects-only drops the generic builtin iterators (op h) and the shared
+        # container ops (f/i); the manifest reflects only what actually runs.
+        builtin_iterators = (
+            []
+            if objects_only
+            else [
+                "str",
+                "bytes",
+                "list",
+                "tuple",
+                "dict",
+                "range",
+                "itertools.count",
+                "struct.iter_unpack",
+            ]
+        )
+        ops_list = ["a:read-churn", "b:method", "c:module-func", "d:attr-dict", "e:weakref"]
+        if not objects_only:
+            ops_list.append("f:container-mutate")
+        ops_list.append("g:gc")
+        if ext_iterators or not objects_only:
+            ops_list.append("h:shared-iter")
+        if not objects_only:
+            ops_list.append("i:read-while-mutate")
+        if mutate_state:
+            ops_list.append("j:prop-reassign")
         self.tsan_shared_kind = shared_kind
         self.tsan_manifest = {
             "kind": "tsan-provenance",
@@ -972,19 +1002,13 @@ class WritePythonCode(WriteCode):
             "shared_classes": list(shared_classes),
             "plugin_factories": [label for _s, label, _i in plugin_factories],
             "shared_kind": shared_kind,
-            "shared_args": ["list", "dict", "set", "bytearray"],
-            # builtin iterator kinds always in the shared-iterator pool (op h); the last two are
-            # attempted under try/except in the script (near-always present on the target).
-            "iterators": [
-                "str",
-                "bytes",
-                "list",
-                "tuple",
-                "dict",
-                "range",
-                "itertools.count",
-                "struct.iter_unpack",
-            ],
+            # generic shared containers (ops f/i) + builtin iterators (op h); both dropped under
+            # --tsan-shared-objects-only (extension hunt: only the target's own objects race).
+            "shared_objects_only": objects_only,
+            "shared_args": [] if objects_only else ["list", "dict", "set", "bytearray"],
+            # builtin iterator kinds in the shared-iterator pool (op h); the last two are attempted
+            # under try/except in the script (near-always present on the target). [] under obj-only.
+            "iterators": builtin_iterators,
             # extension-object iterators (iter(factory())) folded into op (h) on top of builtins.
             "ext_iterators": ext_iterators,
             # hostile subclasses of these target C types shared too (Slice E, opt-in; guarded so
@@ -995,26 +1019,15 @@ class WritePythonCode(WriteCode):
             # Opt-in concurrent-mutation ops: op (b) gets real args + curated mutators, and op (j)
             # (property reassignment) is added. Reflected in the ops list only when actually on.
             "mutate_state": mutate_state,
-            "ops": [
-                "a:read-churn",
-                "b:method",
-                "c:module-func",
-                "d:attr-dict",
-                "e:weakref",
-                "f:container-mutate",
-                "g:gc",
-                "h:shared-iter",
-                "i:read-while-mutate",
-            ]
-            + (["j:prop-reassign"] if mutate_state else []),
+            "ops": ops_list,
             "workers_per_obj": workers_per_obj,
             "iters": iters,
             "func_count": len(funcs),
         }
         provenance_line = (
             "[TSAN] provenance module=%s shared=%s(%dobj+%dcls+%dplugin+module) weird=%d "
-            "args=list,dict,set,bytearray iterators=8+%dext iter_off=%d roles=r/w/both "
-            "ops=%s workers=%d iters=%d funcs=%d"
+            "args=%s iterators=%d+%dext iter_off=%d roles=r/w/both "
+            "ops=%s%s workers=%d iters=%d funcs=%d"
             % (
                 self.module_name,
                 shared_kind,
@@ -1022,9 +1035,12 @@ class WritePythonCode(WriteCode):
                 len(shared_classes),
                 len(plugin_factories),
                 len(shared_classes) if weird_subclasses else 0,
+                "none" if objects_only else "list,dict,set,bytearray",
+                len(builtin_iterators),
                 ext_iterators,
                 iter_off,
                 "a-j" if mutate_state else "a-i",
+                " objonly" if objects_only else "",
                 workers_per_obj,
                 iters,
                 len(funcs),
@@ -1075,6 +1091,9 @@ class WritePythonCode(WriteCode):
         # present use it, else nothing.
         self.write(0, "_MUTATE_STATE = %r" % mutate_state)
         self.write(0, '_MUT_REG = globals().get("_FUSIL_STATEFUL_MUTATORS", {})')
+        # --tsan-shared-objects-only: skip the generic shared-container ops (f/i) at runtime (the
+        # builtin iterators for op h are dropped gen-time from _tsan_iter_factories below).
+        self.write(0, "_TSAN_OBJ_ONLY = %r" % objects_only)
         # Type-diverse argument pool for op (b)'s generic tier, so real single-arg mutators
         # (add_tokens([...]), enable_truncation(int), ...) actually fire instead of TypeError-ing
         # on the four generic containers.
@@ -1218,6 +1237,10 @@ class WritePythonCode(WriteCode):
                 pass
             """,
         )
+        if objects_only:
+            # Extension hunt: drop the generic builtins just built (rangeiter/count-repr/... are
+            # CPython-core noise) -- op (h) races only the target's OWN iterators, folded next.
+            self.write(0, "_tsan_iter_factories = []")
         # Extension-object iterators (Slice C): fold iter(factory()) for each iterable shared-obj
         # factory into the pool, pointing op (h) at the TARGET's own tp_iternext on top of the
         # builtins above. Guarded build below drops non-iterables (a Widget() etc.) so the
@@ -1267,7 +1290,9 @@ class WritePythonCode(WriteCode):
                 # This worker's GROUP (every _wid on this _idx) shares ONE container and ONE
                 # iterator, so the complementary roles below race the SAME resource.
                 _bag = _tsan_shared_args[_idx % len(_tsan_shared_args)]
-                _cell = _tsan_iters[(_idx + _ITER_OFF) % len(_tsan_iters)]
+                # _cell may be None under --tsan-shared-objects-only if the target exposes no
+                # iterables (builtin iterators dropped); op (h) below guards on it.
+                _cell = _tsan_iters[(_idx + _ITER_OFF) % len(_tsan_iters)] if _tsan_iters else None
                 # Role by _wid: readers (_role != 1) inspect/iterate/read; writers (_role != 0)
                 # mutate/advance; _role == 2 does both. With >=2 workers per object both sides are
                 # present, so a reader always races a writer on the object / container / iterator.
@@ -1338,7 +1363,7 @@ class WritePythonCode(WriteCode):
                         _tsan_weakref.ref(_obj)
                     except Exception:
                         pass
-                    if _role != 0:
+                    if _role != 0 and not _TSAN_OBJ_ONLY:
                         # (f) writer: hammer ONE shared container from every writer in the group
                         try:
                             if isinstance(_bag, list):
@@ -1364,23 +1389,24 @@ class WritePythonCode(WriteCode):
                     # readers read its cursor state (repr for count slow-mode; length_hint reads
                     # it_index) while it is advanced -- non-atomic it_index / iternext / it_seq
                     # (cpython#153928 bytes/str, #154013 struct, #153981 count).
-                    try:
-                        _it = _cell[0]
-                        if _role != 0:
-                            for _ in range(4):
-                                next(_it)
-                        if _role != 1:
-                            repr(_it)
-                            try:
-                                _tsan_operator.length_hint(_it, 0)
-                            except Exception:
-                                pass
-                    except StopIteration:
-                        _cell[0] = _tsan_iter_factories[
-                            (_idx + _ITER_OFF) % len(_tsan_iter_factories)]()
-                    except Exception:
-                        pass
-                    if _role != 1:
+                    if _cell is not None:
+                        try:
+                            _it = _cell[0]
+                            if _role != 0:
+                                for _ in range(4):
+                                    next(_it)
+                            if _role != 1:
+                                repr(_it)
+                                try:
+                                    _tsan_operator.length_hint(_it, 0)
+                                except Exception:
+                                    pass
+                        except StopIteration:
+                            _cell[0] = _tsan_iter_factories[
+                                (_idx + _ITER_OFF) % len(_tsan_iter_factories)]()
+                        except Exception:
+                            pass
+                    if _role != 1 and not _TSAN_OBJ_ONLY:
                         # (i) reader: iterate / copy / sort the shared container while writers
                         # mutate it in (f) -- the non-atomic reader-vs-writer class (list Py_SIZE +
                         # binarysort/list.sort, bytes_join, dict/odict/set iter-vs-resize).

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -57,7 +57,12 @@ def _tsan_module():
 
 
 def _make_tsan_options(
-    threads=4, iterations=200, shared_objects=3, weird_subclasses=False, mutate_state=False
+    threads=4,
+    iterations=200,
+    shared_objects=3,
+    weird_subclasses=False,
+    mutate_state=False,
+    shared_objects_only=False,
 ):
     o = MagicMock()
     o.tsan = True
@@ -83,6 +88,7 @@ def _make_tsan_options(
     # Opt-in concurrent-mutation ops. MUST be set explicitly: a bare MagicMock would auto-vivify
     # a truthy attribute and turn the machinery on in every test.
     o.tsan_mutate_state = mutate_state
+    o.tsan_shared_objects_only = shared_objects_only  # same auto-vivify caveat
     return o
 
 
@@ -392,6 +398,49 @@ class TestTSanGeneration(unittest.TestCase):
         # the worker consults the curated mutators (op b) and properties (op j)
         self.assertIn('_mut["mutators"]', src)
         self.assertIn('_mut["properties"]', src)
+
+    def test_shared_objects_only_off_by_default(self):
+        # Default: the generic builtin iterators (op h) and shared-container ops (f/i) are present.
+        src = _generate_tsan()
+        self.assertIn("_TSAN_OBJ_ONLY = False", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertFalse(manifest["shared_objects_only"])
+        self.assertIn("f:container-mutate", manifest["ops"])
+        self.assertIn("i:read-while-mutate", manifest["ops"])
+        self.assertEqual(len(manifest["iterators"]), 8)  # the builtin iterator pool
+        self.assertEqual(manifest["shared_args"], ["list", "dict", "set", "bytearray"])
+        self.assertIn("iterators=8+", src)  # human provenance line
+
+    def test_shared_objects_only_drops_generic_state(self):
+        # --tsan-shared-objects-only: builtin iterators gone (op h races only ext-object iters),
+        # container ops f/i dropped, so an extension hunt stops flooding with CPython-core races.
+        src = _generate_tsan(shared_objects_only=True)
+        ast.parse(src)  # still valid Python
+        self.assertIn("_TSAN_OBJ_ONLY = True", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertTrue(manifest["shared_objects_only"])
+        self.assertNotIn("f:container-mutate", manifest["ops"])
+        self.assertNotIn("i:read-while-mutate", manifest["ops"])
+        self.assertEqual(manifest["iterators"], [])  # no builtin iterators
+        self.assertEqual(manifest["shared_args"], [])
+        self.assertIn("iterators=0+", src)
+        self.assertIn("objonly", src)  # human provenance marker
+        # the builtin iterator factory list is reset before the ext-object iterators are folded in
+        self.assertIn("_tsan_iter_factories = []", src)
+        # ops f/i are gated off; op (h) guards an empty iterator pool
+        self.assertIn("if _role != 0 and not _TSAN_OBJ_ONLY:", src)
+        self.assertIn("if _role != 1 and not _TSAN_OBJ_ONLY:", src)
+        self.assertIn("if _cell is not None:", src)
+
+    def test_shared_objects_only_composes_with_mutate_state(self):
+        # The two extension-hunt levers stack: obj-only drops generics, mutate-state adds op j.
+        src = _generate_tsan(shared_objects_only=True, mutate_state=True)
+        ast.parse(src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertTrue(manifest["shared_objects_only"])
+        self.assertTrue(manifest["mutate_state"])
+        self.assertNotIn("f:container-mutate", manifest["ops"])
+        self.assertIn("j:prop-reassign", manifest["ops"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds `--tsan-shared-objects-only` (opt-in, default off): restrict the `--tsan` / `--concurrency-stress` region to racing the **target module's own objects + their iterators**, dropping the generic-builtin shared state that floods an *extension* hunt with CPython-core races.

## Why

The region shares generic builtins — the str/bytes/list/tuple/dict/range/count/struct iterators (op h) and the shared list/dict/set/bytearray containers (ops f/i). Those race in CPython's own code. On a tokenizers TSan fleet the kept pile was **~all CPython** (`rangeiter_len|rangeiter_next`, `gen_send_ex2`, interning/`_Py_SetImmortalUntracked`) — known/dedupable, but they dominate and drown any actual extension race. For an extension hunt we want the region to race *only* the extension's objects.

## How

- **gen-time:** emit an empty builtin-iterator factory list, so op (h) races only ext-object iterators (`iter(target_obj)` — the target's own `tp_iternext`).
- **runtime `_TSAN_OBJ_ONLY` gate:** skip the generic shared-container ops (f) and (i).
- **guard** the worker's `_cell` against an empty iterator pool (target may expose no iterables).

Off by default ⇒ the normal region is byte-for-behaviour unchanged. Composes with `--tsan-mutate-state`.

## Provenance

Manifest gains `shared_objects_only` and, when on, sets `iterators: []` / `shared_args: []` and omits `f:container-mutate` / `i:read-while-mutate` from `ops`; human line appends ` objonly` and shows `iterators=0+Next`.

## Note

This kills the *shared-state* CPython races (rangeiter, container). The residual CPython noise that isn't from shared state — the interning/immortalize race from concurrent `setattr` (cpython#128137/#113956) and concurrent generator resume (cpython#120321) — is handled by a TSan **suppressions** file; the sibling `cpython-tsan-findings` gateway now carries `race:` entries for those.

## Tests / verification

3 new `test_tsan_generation.py` tests (off-by-default, drops-generic-state, composes-with-mutate-state). Full suite green; `ruff check` + `ruff format --check` clean; `--tsan-shared-objects-only` appears in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)