### PR TITLE
python: --discover-in-target — introspect the target module in a target subprocess

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -90,6 +90,14 @@ by" column is where the core reads it back, so you can see exactly what each hoo
 | `add_definitions_provider(func)` | `func(config, module) -> str \| None`: **source code** injected near the top of every generated script (setup for tricky objects, helper funcs, imports). | `WritePythonCode` (definitions block) |
 | `add_instance_dispatcher(func)` | `func(writer, prefix, target_expr, class_hint, depth) -> int \| None`: emit `elif isinstance(target, MyType): …` fuzzing branches for a live instance. Return the indent level to restore (to wrap the generic fallback in `else:`), or `None`. | `WritePythonCode._dispatch_fuzz_on_instance` |
 | `add_class_handler(func)` | `func(writer, class_name, class_type, instance_var, prefix) -> bool`: emit specialized instantiation for a class the generic `callFunc` can't build; return `True` to claim it. | `WritePythonCode._fuzz_one_class` |
+
+> **`--discover-in-target` caveat for `add_class_handler`.** Under `--discover-in-target` the runner
+> may not have imported the extension, so `class_type` is a metadata `_MetaProxy` (name + bases +
+> method names + ctor arity), not the live class. A handler that only reads those still works; one
+> that introspects the *live* class (attributes, `__mro__` beyond names, calling it) does not.
+> Such plugins need the extension in the runner venv (i.e. don't use `--discover-in-target`), or a
+> future metadata-based `class_meta` handler contract. `add_instance_dispatcher` is unaffected (its
+> arguments are already source-expression strings, never live objects).
 | `add_fuzzing_mode(name, activation_check, setup_script)` | A whole alternative main-logic generator. `activation_check(config) -> bool`; `setup_script(writer)` emits the entire fuzzing body. | `WritePythonCode` (`get_active_mode`) |
 | `add_blacklist_entry(kind, pattern, pattern_type="exact")` | Skip a discovered name. `kind` ∈ `module`/`class`/`function`/`object`/`method`; `pattern_type` `exact` or `glob`. | name filtering in `WritePythonCode` |
 | `add_whitelist_entry(kind, pattern, pattern_type="exact")` | Keep a name normally skipped (honoured for `method`, e.g. `__del__`). | method filtering in `WritePythonCode` |

--- a/doc/python-fuzzer.md
+++ b/doc/python-fuzzer.md
@@ -73,8 +73,22 @@ Entry point: `fuzzers/fusil-python-threaded` → `fusil.python.Fuzzer`.
   `WatchProcess` / `WatchStdout` (crash-detection probes).
 - **`PythonSource`** (`python_source.py`): a `ProjectAgent`. Discovers importable modules
   (`ListAllModules`, filtered by `blacklists.py`), and on each `session_start` picks one module,
-  calls `WritePythonCode.generate_fuzzing_script()` to emit `source.py`, then sends
-  `python_source` so `PythonProcess` runs it under the target interpreter.
+  imports it, introspects its members (functions/classes/objects + arities/methods), calls
+  `WritePythonCode.generate_fuzzing_script()` to emit `source.py`, then sends `python_source` so
+  `PythonProcess` runs it under the target interpreter.
+  - **`--discover-in-target`** (opt-in): do that member introspection in a **subprocess running
+    the target interpreter** (`--python`) rather than by importing the module in the *runner*, so
+    the runner venv need not have the target extension installed (FT/debug builds with no wheels, a
+    target that differs from the runner). `fusil/python/target_introspect.py` runs a stdlib-only
+    introspector under the target and returns the members as JSON; `WritePythonCode` reads that
+    metadata via `_MetaProxy` instead of a live object (the generated script re-imports the module
+    by name in the target regardless, so nothing else changes). The subprocess emits *raw*
+    metadata; all fusil policy (blacklists, `--test-private`, `--fuzz-exceptions`, arity name-table
+    overrides) stays in the parent, so the live and subprocess paths stay in parity (guarded by
+    `tests/python/test_target_introspect.py`). Pair with an explicit `--modules`/`--modules-file`
+    (which bypass the runner-side package walk); moving `--packages` enumeration into the target is
+    a follow-up. **Limitation:** a plugin `add_class_handler` that introspects the *live* class
+    can't run when the extension isn't in the runner (see `doc/plugins.md`).
 - **`WritePythonCode`** (`write_python_code.py`, the largest/most important file): generates the
   test script — imports the target, then emits randomized function calls, class instantiations,
   method calls, objects, and thread/async wrappers. Arguments come from **`ArgumentGenerator`**

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -68,6 +68,27 @@ class Fuzzer(Application):
             default="*",
         )
         input_options.add_option(
+            "--discover-in-target",
+            help="Discover each module's members (functions/classes/methods + arities) by "
+            "introspecting it in a SUBPROCESS running the target interpreter (--python), instead "
+            "of importing it in the runner. So the runner venv need not have the target extension "
+            "installed -- useful for FT/debug CPython builds with no wheels, or a target that "
+            "differs from the runner. Pair with an explicit --modules/--modules-file (which bypass "
+            "the runner-side package walk); --packages enumeration in the target is a follow-up. "
+            "Default: False (import + introspect in the runner).",
+            action="store_true",
+            dest="discover_in_target",
+            default=False,
+        )
+        input_options.add_option(
+            "--discover-timeout",
+            help="Per-module timeout (seconds) for --discover-in-target's introspection subprocess "
+            "(default: 60). A module that times out is skipped, like a failed import.",
+            type="int",
+            dest="discover_timeout",
+            default=60,
+        )
+        input_options.add_option(
             "--skip-test",
             help="Skip modules with 'test' in the name (default: False)",
             action="store_true",

--- a/fusil/python/arg_numbers.py
+++ b/fusil/python/arg_numbers.py
@@ -314,6 +314,19 @@ def get_arg_number(func, func_name, min_arg):
     except KeyError:
         pass
 
+    # Metadata proxy (discovery ran in the target subprocess, no live object): the arity was
+    # already computed there (argspec branch) as `_fusil_arity`, or is unknown (`None`, e.g. a C
+    # builtin) -> fall to the same doc/default the live branch below uses.
+    if getattr(func, "_fusil_is_meta", False):
+        ar = getattr(func, "_fusil_arity", None)
+        if ar:
+            return ar[0], ar[1]
+        if PARSE_PROTOTYPE:
+            doc_args = parseDocumentation(getattr(func, "_fusil_doc", None), MAX_VAR_ARG)
+            if doc_args:
+                return doc_args
+        return min_arg, MAX_ARG
+
     try:
         argspec = inspect.getfullargspec(func)
         has_self = 1 if "self" in argspec.args or "cls" in argspec.args else 0
@@ -336,6 +349,10 @@ def class_arg_number(class_name, cls):
     if class_name in CLASS_NB_ARG:
         min_args, max_args = CLASS_NB_ARG[class_name]
         nb_arg = randint(min_args, max_args)
+    elif getattr(cls, "_fusil_is_meta", False):
+        # Metadata proxy: ctor arity computed in the target subprocess (or unknown -> 0..3).
+        ca = getattr(cls, "_fusil_ctor_arity", None)
+        nb_arg = randint(ca[0], ca[1]) if ca else randint(0, 3)
     else:
         try:
             argspec = inspect.getfullargspec(cls.__init__)

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import time
 from os.path import exists as path_exists
@@ -176,6 +177,56 @@ class PythonSource(ProjectAgent):
             plugin_manager=self.plugin_manager,
         )
 
+    def _thread_flags(self) -> tuple[bool, bool]:
+        """(threads, async) for the writer -- disabled under --tsan/--concurrency-stress (which
+        replace the per-call wrappers with the concentrated stress region)."""
+        stress = self.options.tsan or getattr(self.options, "concurrency_stress", False)
+        return (
+            (not self.options.no_threads) and not stress,
+            (not self.options.no_async) and not stress,
+        )
+
+    def _target_discovery_env(self) -> dict:
+        """Minimal env for the discovery subprocess running the TARGET interpreter. Inherits the
+        current env (so a fleet's exported PYTHON_GIL etc. carry over) + the pycache/debuginfod
+        overrides fusil already uses for target children, and forces PYTHON_GIL=0 under --tsan."""
+        env = dict(os.environ)
+        env["PYTHONPYCACHEPREFIX"] = "/tmp/fusil-pycache-root"
+        env["DEBUGINFOD_URLS"] = ""  # dodge the llvm-symbolizer debuginfod hang; harmless otherwise
+        if getattr(self.options, "tsan", False):
+            env["PYTHON_GIL"] = "0"
+        return env
+
+    def discoverInTarget(self, module_name: str) -> bool:
+        """Discover a module's members by introspecting it in a subprocess running the TARGET
+        interpreter (``--discover-in-target``), so the runner venv need not have the extension
+        installed. Sets up ``self.write`` from the returned metadata and returns True; returns
+        False if the subprocess failed (import error / timeout / bad output) so the caller skips
+        the module -- the same disposition as a failed runner import."""
+        from fusil.python.target_introspect import introspect_module
+
+        self.module_name = module_name
+        self.module = None
+        timeout = int(getattr(self.options, "discover_timeout", 60))
+        metadata = introspect_module(
+            self.options.python, module_name, env=self._target_discovery_env(), timeout=timeout
+        )
+        if metadata is None:
+            return False
+        threads, _async = self._thread_flags()
+        write_code_factory = self.write_code_factory or WritePythonCode
+        self.write = write_code_factory(
+            self,
+            self.filename,
+            None,  # no live module: generation reads member_metadata via _MetaProxy
+            module_name,
+            threads=threads,
+            _async=_async,
+            plugin_manager=self.plugin_manager,
+            member_metadata=metadata,
+        )
+        return True
+
     def on_session_start(self) -> None:
         """Start a new fuzzing session by selecting a module and generating test code."""
         if self.source_output_path:
@@ -187,10 +238,17 @@ class PythonSource(ProjectAgent):
         old_sys_modules = sys.modules.copy()
 
         name = "NO_MODULES!"
+        discover_in_target = getattr(self.options, "discover_in_target", False)
         while self.modules_list:
             name = choice(self.modules_list)
             try:
-                self.loadModule(name)
+                if discover_in_target:
+                    # Introspect in a subprocess running the target interpreter (runner needn't
+                    # have the extension). A failed subprocess is an unloadable module.
+                    if not self.discoverInTarget(name):
+                        raise ImportError("target-subprocess discovery failed for %s" % name)
+                else:
+                    self.loadModule(name)
                 break
             except (Exception, SystemExit) as err:
                 # Catch Exception plus SystemExit: a module that runs argparse/optparse on

--- a/fusil/python/target_introspect.py
+++ b/fusil/python/target_introspect.py
@@ -1,0 +1,175 @@
+"""Discover a target module's members by introspecting it in a subprocess running the TARGET
+interpreter (`--python`), instead of importing the extension in the runner venv.
+
+Motivation: fusil normally imports the target module in the *runner* process to enumerate its
+functions/classes/objects and their arities/methods, which forces the runner venv to have the
+target extension installed -- painful for FT/debug CPython builds with no wheels, or when the
+runner and target are different interpreters. But the generated ``source.py`` already re-imports
+the module *by name in the target*, so the extension is present where the fuzzing runs; only the
+runner-side introspection needs it. This module moves that introspection into the target.
+
+Design: the subprocess (``_DISCOVERY_SRC``) is a **stdlib-only** introspector -- it imports the
+module and emits *raw* per-member metadata as JSON on stdout. It applies **no fusil policy**
+(blacklists, ``--test-private``, ``--fuzz-exceptions``, name-table arity overrides); the parent
+(:class:`WritePythonCode`) keeps all of that. So the script needs none of fusil's tables and stays
+stable. Arity mirrors :func:`fusil.python.arg_numbers.get_arg_number`'s argspec branch
+(``args - defaults, args`` with ``self``/``cls`` discounted); when ``getfullargspec`` fails (C /
+PyO3 builtins) it emits ``arity: null`` plus the raw ``__doc__`` so the parent can run its own
+``parseDocumentation`` and otherwise fall back to the default range -- faithful to the live path.
+
+The emitted schema (see ``_DISCOVERY_SRC``), one entry per fuzzable member::
+
+    {"module": "<name>", "ok": true, "members": [
+        {"name": "f", "kind": "function", "arity": [1, 3], "doc": null},
+        {"name": "C", "kind": "class", "is_exception": false,
+         "ctor_arity": [1, 2], "ctor_doc": null,
+         "methods": [{"name": "m", "arity": [1, 1], "doc": null}, ...]},
+        {"name": "OBJ", "kind": "object", "is_module": false, "is_exception": false,
+         "class_name": "Foo", "methods": [...]}]}
+
+Module-level members that classify as a bare module or a trivial-typed value (int/str/list/...) are
+dropped by the subprocess (never fuzzable), matching ``_get_module_members``'s object branch.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+# The introspection script, run as `python -c _DISCOVERY_SRC <module_name>` under the TARGET
+# interpreter. Stdlib-only; prints exactly one JSON object to stdout. Kept deliberately close to
+# WritePythonCode._get_module_members / _get_object_methods / arg_numbers.get_arg_number so the
+# two discovery paths (runner-live vs target-subprocess) stay in parity.
+_DISCOVERY_SRC = r'''
+import sys, json, inspect, importlib
+from types import FunctionType, BuiltinFunctionType, ModuleType, MethodType
+
+# Mirror WritePythonCode.TRIVIAL_TYPES (top-level object branch skips these).
+_TRIVIAL = {int, str, float, bool, bytes, tuple, list, dict, set, type(None)}
+_MAX_METHODS = 300
+
+
+def _arity(obj):
+    """(-> [lo, hi] | None, doc). Mirrors arg_numbers.get_arg_number's argspec branch; on failure
+    returns (None, first-line-of-__doc__) so the parent can parseDocumentation / default."""
+    try:
+        spec = inspect.getfullargspec(obj)
+    except TypeError:
+        doc = getattr(obj, "__doc__", None)
+        return None, (doc if isinstance(doc, str) else None)
+    has_self = 1 if ("self" in spec.args or "cls" in spec.args) else 0
+    args = (len(spec.args) - has_self) if spec.args else 0
+    defaults = (len(spec.defaults) - has_self) if spec.defaults else 0
+    return [args - defaults, args], None
+
+
+def _ctor_arity(cls):
+    try:
+        spec = inspect.getfullargspec(cls.__init__)
+    except TypeError:
+        doc = getattr(cls, "__doc__", None)
+        return None, (doc if isinstance(doc, str) else None)
+    args = (len(spec.args) - 1) if spec.args else 0  # drop self
+    defaults = len(spec.defaults) if spec.defaults else 0
+    return [args - defaults, args], None
+
+
+def _methods(owner):
+    """All callable members of a class/instance (raw; parent applies blacklist/private/plugin
+    filtering). Mirrors _get_object_methods' dir()+callable() walk."""
+    out = []
+    if type(owner) in _TRIVIAL:
+        return out
+    try:
+        names = dir(owner)
+    except Exception:
+        return out
+    for name in names:
+        try:
+            attr = getattr(owner, name, None)
+        except Exception:
+            continue
+        if attr is None or not callable(attr):
+            continue
+        ar, doc = _arity(attr)
+        out.append({"name": name, "arity": ar, "doc": doc})
+        if len(out) >= _MAX_METHODS:
+            break
+    return out
+
+
+def main():
+    module_name = sys.argv[1]
+    try:
+        mod = importlib.import_module(module_name)
+    except BaseException as exc:  # SystemExit on import, etc.
+        print(json.dumps({"module": module_name, "ok": False,
+                          "error": "%s: %s" % (type(exc).__name__, exc)}))
+        return
+    members = []
+    try:
+        names = dir(mod)
+    except Exception as exc:
+        print(json.dumps({"module": module_name, "ok": False, "error": str(exc)}))
+        return
+    for name in names:
+        try:
+            attr = getattr(mod, name)
+        except Exception:
+            continue
+        try:
+            if isinstance(attr, (FunctionType, BuiltinFunctionType, MethodType)) or (
+                callable(attr) and not isinstance(attr, type) and not inspect.isclass(attr)
+                and type(attr).__name__ in ("builtin_function_or_method", "method_descriptor")
+            ):
+                ar, doc = _arity(attr)
+                members.append({"name": name, "kind": "function", "arity": ar, "doc": doc})
+            elif isinstance(attr, type) or inspect.isclass(attr):
+                is_exc = isinstance(attr, type) and issubclass(attr, BaseException)
+                car, cdoc = _ctor_arity(attr)
+                members.append({"name": name, "kind": "class", "is_exception": is_exc,
+                                "ctor_arity": car, "ctor_doc": cdoc, "methods": _methods(attr)})
+            else:
+                if isinstance(attr, ModuleType) or type(attr) in _TRIVIAL:
+                    continue  # not fuzzable (matches _get_module_members object branch)
+                is_exc = isinstance(attr, BaseException)
+                members.append({"name": name, "kind": "object", "is_module": False,
+                                "is_exception": is_exc,
+                                "class_name": type(attr).__name__, "methods": _methods(type(attr))})
+        except Exception:
+            continue
+    print(json.dumps({"module": module_name, "ok": True, "members": members}))
+
+
+main()
+'''
+
+
+def introspect_module(python_path, module_name, env=None, timeout=60):
+    """Run the discovery script under ``python_path`` and return the parsed metadata dict.
+
+    Returns the ``{"module","ok","members"}`` dict on success, or ``None`` on timeout / non-zero
+    exit / unparseable output / ``ok: False`` (the caller then skips the module, exactly like the
+    runner-import failure path in ``PythonSource.on_session_start``). ``env`` is the child
+    environment (the caller supplies the minimal target env -- ``PYTHON_GIL`` etc.); ``None`` uses
+    the current environment.
+    """
+    try:
+        proc = subprocess.run(
+            [python_path, "-c", _DISCOVERY_SRC, module_name],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        data = json.loads(proc.stdout.splitlines()[-1])
+    except (ValueError, IndexError):
+        return None
+    if not isinstance(data, dict) or not data.get("ok") or "members" not in data:
+        return None
+    return data

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -78,6 +78,30 @@ TSAN_UNSAFE_CALLS = frozenset(
 )  # fmt: skip
 
 
+class _MetaProxy:
+    """Stand-in for a live target member when module discovery ran in the target subprocess
+    (see ``target_introspect``). Carries the serializable metadata the generation path needs; the
+    duck-typed ``_fusil_*`` attributes are recognised by ``get_arg_number`` / ``class_arg_number``
+    / ``_get_object_methods``, so the live-object path is unchanged. Never a ``FunctionType`` /
+    ``type`` / ``ModuleType`` -- the classification already happened in the subprocess."""
+
+    _fusil_is_meta = True
+
+    def __init__(self, name: str, meta: dict):
+        self._name = name
+        self._meta = meta
+        self._fusil_arity = meta.get("arity")  # function/method: [lo, hi] or None (C builtin)
+        self._fusil_doc = meta.get("doc")
+        self._fusil_ctor_arity = meta.get("ctor_arity")  # class: [lo, hi] or None
+        self._fusil_is_exception = bool(meta.get("is_exception"))
+        self._fusil_class_name = meta.get("class_name", name)
+
+    def _fusil_raw_methods(self):
+        """(name, method-proxy) candidates for ``_get_object_methods`` to filter (blacklist /
+        private / plugin / exception-``__init__`` filtering stays in the parent)."""
+        return [(m["name"], _MetaProxy(m["name"], m)) for m in self._meta.get("methods", [])]
+
+
 class PythonFuzzerError(Exception):
     """Custom exception raised when fuzzer encounters unrecoverable errors."""
 
@@ -89,19 +113,33 @@ class WritePythonCode(WriteCode):
         self,
         parent_python_source: "PythonSource",
         filename: str,
-        module: ModuleType,
+        module: ModuleType | None,
         module_name: str,
         threads: bool = True,
         _async: bool = True,
         plugin_manager=None,
+        member_metadata: dict | None = None,
     ):
-        """Initialize the Python code writer."""
+        """Initialize the Python code writer.
+
+        ``member_metadata`` is the JSON discovery payload from
+        :func:`fusil.python.target_introspect.introspect_module` when discovery ran in the target
+        subprocess (``--discover-in-target``); then ``module`` may be ``None`` and generation reads
+        arities/methods from the metadata via ``_MetaProxy`` instead of introspecting a live object
+        the runner venv would have to import.
+        """
         super().__init__()  # Initialize base WriteCode
         self.parent_python_source = parent_python_source
         self.plugin_manager = plugin_manager
         self.options = parent_python_source.options
         self.filenames = parent_python_source.filenames
         self.module = module
+        self._meta_mode = member_metadata is not None
+        self._members = (
+            {m["name"]: m for m in member_metadata.get("members", [])}
+            if member_metadata is not None
+            else {}
+        )
         self.module_name = module_name
         self.enable_threads = threads
         self.enable_async = _async
@@ -144,8 +182,68 @@ class WritePythonCode(WriteCode):
             self.write(level, code)
         return ""
 
+    def _member(self, name: str):
+        """Fetch a module member for generation: a live object (default) or a ``_MetaProxy`` when
+        discovery ran in the target subprocess. Raises ``AttributeError`` if absent (so the call
+        sites' existing ``except AttributeError`` handling is unchanged)."""
+        if self._meta_mode:
+            try:
+                return _MetaProxy(name, self._members[name])
+            except KeyError:
+                raise AttributeError(name) from None
+        return getattr(self.module, name)
+
+    def _classify_from_meta(self) -> tuple[list[str], list[str], list[str]]:
+        """Metadata-mode ``_get_module_members``: apply the SAME fusil filtering to the subprocess
+        member list (using each member's ``kind``/``is_exception`` instead of live ``isinstance``).
+        The subprocess already dropped module/trivial-typed members (object branch)."""
+        classes: list[str] = []
+        functions: list[str] = []
+        objects: list[str] = []
+        try:
+            module_blacklist = BLACKLIST.get(self.module_name, set())
+        except KeyError:
+            module_blacklist = set()
+        current_blacklist = module_blacklist | METHOD_BLACKLIST
+        names = set(self._members)
+        names -= {
+            "__builtins__", "__doc__", "__file__", "__name__",
+            "__package__", "__loader__", "__spec__", "__cached__",
+        }  # fmt: skip
+        names -= {"True", "None", "False", "Ellipsis"}
+        if not self.options.fuzz_exceptions:
+            names -= EXCEPTION_NAMES
+        names -= current_blacklist
+        pm = self.plugin_manager
+        for name in sorted(names):
+            if name.startswith("_") and not self.options.test_private:
+                if not (name.startswith("__") and name.endswith("__")):
+                    continue
+            meta = self._members[name]
+            kind = meta.get("kind")
+            is_exc = bool(meta.get("is_exception"))
+            if kind == "function":
+                if pm and pm.is_blacklisted("function", name):
+                    continue
+                functions.append(name)
+            elif kind == "class":
+                if not self.options.fuzz_exceptions and is_exc:
+                    continue
+                if pm and pm.is_blacklisted("class", name):
+                    continue
+                classes.append(name)
+            elif kind == "object":
+                if not self.options.fuzz_exceptions and is_exc:
+                    continue
+                if pm and pm.is_blacklisted("object", name):
+                    continue
+                objects.append(name)
+        return functions, classes, objects
+
     def _get_module_members(self) -> tuple[list[str], list[str], list[str]]:
         """Extracts fuzzable functions, classes, and objects from the current module."""
+        if self._meta_mode:
+            return self._classify_from_meta()
         _EXCEPTION_NAMES = EXCEPTION_NAMES
 
         classes = []
@@ -221,9 +319,16 @@ class WritePythonCode(WriteCode):
     def _get_object_methods(
         self, obj_instance_or_class: Any, owner_name: str
     ) -> dict[str, Callable[..., Any]]:
-        """Extracts callable methods from an object or class, respecting blacklists."""
+        """Extracts callable methods from an object or class, respecting blacklists.
+
+        Live: walk ``dir()`` + ``getattr`` + ``callable``. Metadata (``_MetaProxy``): the callable
+        set was already discovered in the target subprocess -- take its ``_fusil_raw_methods`` as
+        candidates. Either way the SAME fusil filtering (blacklist / private / plugin / exception-
+        ``__init__``) is applied here, and the values are the objects/proxies the arity code reads.
+        """
         methods: dict[str, Callable[..., Any]] = {}
-        if type(obj_instance_or_class) in TRIVIAL_TYPES:
+        is_meta = getattr(obj_instance_or_class, "_fusil_is_meta", False)
+        if not is_meta and type(obj_instance_or_class) in TRIVIAL_TYPES:
             return methods
 
         try:
@@ -233,13 +338,18 @@ class WritePythonCode(WriteCode):
             blacklist = set()
         blacklist |= METHOD_BLACKLIST
 
-        is_exception_type_or_instance = (
-            isinstance(obj_instance_or_class, type)
-            and issubclass(obj_instance_or_class, BaseException)
-        ) or isinstance(obj_instance_or_class, BaseException)
+        if is_meta:
+            is_exception_type_or_instance = obj_instance_or_class._fusil_is_exception
+            candidates = obj_instance_or_class._fusil_raw_methods()  # [(name, method_proxy)]
+        else:
+            is_exception_type_or_instance = (
+                isinstance(obj_instance_or_class, type)
+                and issubclass(obj_instance_or_class, BaseException)
+            ) or isinstance(obj_instance_or_class, BaseException)
+            candidates = [(name, None) for name in dir(obj_instance_or_class)]
 
         pm = self.plugin_manager
-        for name in dir(obj_instance_or_class):
+        for name, method_proxy in candidates:
             if name in blacklist:
                 continue
             if pm and pm.is_blacklisted("method", name):
@@ -256,6 +366,9 @@ class WritePythonCode(WriteCode):
             if is_exception_type_or_instance and name == "__init__":  # Avoid re-initing exceptions
                 continue
 
+            if is_meta:
+                methods[name] = method_proxy
+                continue
             try:
                 attr = getattr(obj_instance_or_class, name, None)
                 if attr is None or not callable(attr):
@@ -1487,7 +1600,7 @@ class WritePythonCode(WriteCode):
             # OOM injection: wrap a function call in a dense set_nomemory sweep
             func_name = choice(self.module_functions)
             try:
-                func_obj = getattr(self.module, func_name)
+                func_obj = self._member(func_name)
             except AttributeError:
                 return
             self._generate_oom_function_call(prefix, func_name, func_obj)
@@ -1496,7 +1609,7 @@ class WritePythonCode(WriteCode):
         # Standard function call fuzzing
         func_name = choice(self.module_functions)
         try:
-            func_obj = getattr(self.module, func_name)
+            func_obj = self._member(func_name)
         except AttributeError:
             return
         self._generate_and_write_call(
@@ -1522,7 +1635,7 @@ class WritePythonCode(WriteCode):
             if class_name in OBJECT_BLACKLIST:
                 continue
             try:
-                class_obj = getattr(self.module, class_name)
+                class_obj = self._member(class_name)
             except AttributeError:
                 continue
             self._generate_oom_class_fuzzing(f"oc{i + 1}", class_name, class_obj)
@@ -1542,7 +1655,7 @@ class WritePythonCode(WriteCode):
             if class_name in OBJECT_BLACKLIST:
                 continue
             try:
-                class_obj = getattr(self.module, class_name)
+                class_obj = self._member(class_name)
             except AttributeError:
                 continue
 
@@ -1563,7 +1676,7 @@ class WritePythonCode(WriteCode):
             if obj_name in OBJECT_BLACKLIST:
                 continue
             try:
-                obj_instance = getattr(self.module, obj_name)
+                obj_instance = self._member(obj_name)
             except AttributeError:
                 continue
             if isinstance(obj_instance, ModuleType):
@@ -1878,11 +1991,21 @@ class WritePythonCode(WriteCode):
         prefix = f"obj{obj_idx + 1}"
         obj_expr_in_script = f"fuzz_target_module.{obj_name_str}"
 
+        # Metadata mode: the proxy carries the class name + method set; live mode reads them off
+        # the instance. Pass the proxy itself as the "type" so _get_object_methods finds its
+        # _fusil_raw_methods (type(proxy) would be _MetaProxy, not the target's type).
+        if getattr(obj_instance, "_fusil_is_meta", False):
+            class_name = obj_instance._fusil_class_name
+            type_for_methods = obj_instance
+        else:
+            class_name = obj_instance.__class__.__name__
+            type_for_methods = type(obj_instance)
+
         self._fuzz_methods_on_object_or_specific_types(
             current_prefix=f"obj{obj_idx}m",  # Prefix for this object
             target_obj_expr_str=obj_expr_in_script,
-            target_obj_class_name=obj_instance.__class__.__name__,  # Get class name from instance
-            target_obj_actual_type_obj=type(obj_instance),  # Get type from instance
+            target_obj_class_name=class_name,
+            target_obj_actual_type_obj=type_for_methods,
             num_method_calls_to_make=self.options.methods_number,
         )
         self.write_print_to_stderr(
@@ -1996,7 +2119,7 @@ class WritePythonCode(WriteCode):
         for j in range(self._oom_pick_seq_len()):
             func_name = choice(self.module_functions)
             try:
-                func_obj = getattr(self.module, func_name)
+                func_obj = self._member(func_name)
             except AttributeError:
                 continue
             min_arg, max_arg = get_arg_number(func_obj, func_name, 1)

--- a/tests/python/test_python_source.py
+++ b/tests/python/test_python_source.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 import tempfile
+import types
 import unittest
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -23,6 +24,9 @@ def _bare_source(modules_list):
     """A PythonSource with just the state on_session_start touches (no MAS/project)."""
     ps = PythonSource.__new__(PythonSource)
     ps.source_output_path = "unused.py"  # truthy -> skip session().createFilename()
+    # on_session_start reads options.discover_in_target to choose runner-import vs target-subprocess
+    # discovery; default off keeps this exercising the runner-import (loadModule) path.
+    ps.options = types.SimpleNamespace(discover_in_target=False)
     ps.modules_list = list(modules_list)
     ps.sent = []
     ps.debug = lambda *a, **k: None

--- a/tests/python/test_target_introspect.py
+++ b/tests/python/test_target_introspect.py
@@ -1,0 +1,157 @@
+"""Tests for target-subprocess module discovery (``--discover-in-target``).
+
+Three angles:
+- the stdlib-only introspection script emits the expected JSON shape (run under this interpreter);
+- generation from that metadata needs NO live module (``WritePythonCode(module=None, ...)``);
+- parity: for a module importable in both, subprocess metadata yields the SAME fuzzable name
+  lists as live introspection -- the guard against the two discovery paths drifting apart.
+"""
+
+import ast
+import os
+import random
+import sys
+import tempfile
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
+
+from fusil.python.target_introspect import _DISCOVERY_SRC, introspect_module
+from fusil.python.write_python_code import WritePythonCode
+
+# Introspect using THIS interpreter (it can import `json`); no separate target needed for the unit.
+PYEXE = sys.executable
+
+
+class _Options:
+    """Fully-pinned options the generator reads (mirrors test_golden_output._Options)."""
+
+    functions_number = 3
+    classes_number = 1
+    objects_number = 1
+    methods_number = 2
+    deep_dive = False
+    gc_aggressive = False
+    fuzz_exceptions = False
+    test_private = False
+    no_numpy = True
+    no_tstrings = True
+    external_references = True
+    no_threads = True
+    no_async = True
+    oom_fuzz = False
+    oom_max_start = 50
+    oom_calls = 3
+    oom_classes = 0
+    oom_methods = 0
+    oom_verbose = False
+    oom_seq = False
+    oom_seq_len = 3
+    oom_window = 1
+    oom_foreign = False
+    oom_foreign_pythonmalloc = False
+    tsan = False
+
+
+class _Parent:
+    def __init__(self):
+        self.options = _Options()
+        self.filenames = ["/tmp/fuzz_fixture"]
+
+    def warning(self, *a, **k):
+        pass
+
+
+def _generate(module, module_name, member_metadata):
+    parent = _Parent()
+    fd, path = tempfile.mkstemp(suffix=".py")
+    os.close(fd)
+    try:
+        writer = WritePythonCode(
+            parent, path, module, module_name,
+            threads=False, _async=False, plugin_manager=None,
+            member_metadata=member_metadata,
+        )  # fmt: skip
+        random.seed(1234)
+        writer.generate_fuzzing_script()
+        with open(path) as fh:
+            return writer, fh.read()
+    finally:
+        os.unlink(path)
+
+
+class TestDiscoveryScript(unittest.TestCase):
+    def test_script_emits_expected_shape_for_json(self):
+        data = introspect_module(PYEXE, "json")
+        self.assertIsNotNone(data)
+        self.assertTrue(data["ok"])
+        by_kind = {}
+        for m in data["members"]:
+            by_kind.setdefault(m["kind"], {})[m["name"]] = m
+        # functions with arity ranges
+        self.assertIn("dumps", by_kind["function"])
+        self.assertEqual(by_kind["function"]["dumps"]["arity"], [1, 1])
+        # a class carries ctor arity + a method set + the exception flag
+        enc = by_kind["class"]["JSONEncoder"]
+        self.assertIsInstance(enc["ctor_arity"], list)
+        self.assertTrue(any(mm["name"] == "encode" for mm in enc["methods"]))
+        self.assertTrue(by_kind["class"]["JSONDecodeError"]["is_exception"])
+        self.assertFalse(enc["is_exception"])
+
+    def test_failed_import_returns_none(self):
+        self.assertIsNone(introspect_module(PYEXE, "no_such_module_zzz_1234"))
+
+    def test_script_is_valid_python(self):
+        ast.parse(_DISCOVERY_SRC)
+
+
+class TestGenerationFromMetadata(unittest.TestCase):
+    def test_generation_needs_no_live_module(self):
+        # The payoff: build a valid fuzzing script from metadata alone, module=None (the runner
+        # never imported the target).
+        meta = introspect_module(PYEXE, "json")
+        writer, src = _generate(None, "json", meta)
+        ast.parse(src)  # valid Python
+        self.assertTrue(writer._meta_mode)
+        self.assertTrue(writer.module_functions or writer.module_classes)
+        # a fabricated single-class module drives instantiation + method calls with no live object
+        fake = {
+            "module": "fakeext",
+            "ok": True,
+            "members": [
+                {"name": "Widget", "kind": "class", "is_exception": False,
+                 "ctor_arity": [0, 2], "ctor_doc": None,
+                 "methods": [{"name": "poke", "arity": [1, 2], "doc": None}]},
+                {"name": "do_it", "kind": "function", "arity": None, "doc": None},  # C-builtin-like
+            ],
+        }  # fmt: skip
+        _writer2, src2 = _generate(None, "fakeext", fake)
+        ast.parse(src2)
+        self.assertIn("Widget", src2)
+
+
+class TestParity(unittest.TestCase):
+    def _live_lists(self, module):
+        parent = _Parent()
+        fd, path = tempfile.mkstemp(suffix=".py")
+        os.close(fd)
+        try:
+            w = WritePythonCode(parent, path, module, module.__name__,
+                                threads=False, _async=False, plugin_manager=None)  # fmt: skip
+            return (sorted(w.module_functions), sorted(w.module_classes), sorted(w.module_objects))
+        finally:
+            os.unlink(path)
+
+    def test_live_vs_subprocess_name_lists_match(self):
+        import json as jsonmod
+
+        live = self._live_lists(jsonmod)
+        meta = introspect_module(PYEXE, "json")
+        w, _ = _generate(None, "json", meta)
+        got = (sorted(w.module_functions), sorted(w.module_classes), sorted(w.module_objects))
+        self.assertEqual(live, got)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `--discover-in-target` (opt-in, default off): discover a target module's members (functions/classes/objects + arities/methods) by introspecting it in a **subprocess running the target interpreter** (`--python`), instead of importing it in the runner. **So the runner venv no longer needs the target extension installed.**

## Why

The runner-must-have-the-extension requirement is the biggest recurring friction in the extension campaign (solders/tokenizers/rustpython/h5py): FT/debug CPython builds have no wheels, and a runner that differs from the target introspects the wrong build. But the generated `source.py` already re-imports the module **by name in the target**, so the extension is present where fuzzing runs — only the runner-side *introspection* needs it. This moves that introspection into the target.

## How

- **`fusil/python/target_introspect.py`** (new): a **stdlib-only** introspector (`_DISCOVERY_SRC`) run as `python -c ... <module>` under `--python`; emits raw per-member metadata as JSON. `introspect_module(...)` runs it (`subprocess.run` under the target env, modeled on the `--tsan` preflight) and returns the parsed dict, or `None` on failure.
- **`WritePythonCode`**: accepts `member_metadata`; a duck-typed **`_MetaProxy`** stands in for each live member and is recognised by `get_arg_number` / `class_arg_number` / `_get_object_methods` via `_fusil_*` attributes — so the **live-object path is unchanged** (golden output byte-identical). `_get_module_members` gains a metadata branch applying the *same* fusil filtering.
- **Split of responsibility**: the subprocess emits *raw* metadata; **all fusil policy** (blacklists, `--test-private`, `--fuzz-exceptions`, `METHODS_NB_ARG`/`CLASS_NB_ARG` overrides) stays in the parent → the two paths stay in parity. Arity mirrors `get_arg_number` exactly, including the C/PyO3-builtin fallback (`arity: null` → doc/default range), which a synthetic-object shortcut couldn't reproduce.
- **`PythonSource.discoverInTarget`**: runs the subprocess and builds `WritePythonCode(module=None, member_metadata=...)`; a failed subprocess is an unloadable module (same disposition as a failed import).

## Scope

Phase 1 handles the explicit `--modules` / `--modules-file` path (which bypass the runner-side package walk). Target-side `--packages` enumeration (so `--packages` needn't import in the runner either) is a noted follow-up; until then use an explicit list.

**Limitation:** an `add_class_handler` plugin that introspects the *live* class can't run when the extension isn't in the runner (it gets a `_MetaProxy`) — documented in `doc/plugins.md`. `add_instance_dispatcher` is unaffected (string args only).

## Tests / verification

- New `test_target_introspect.py`: script shape; **`module=None` generation needs no live module** (the payoff); live-vs-subprocess **name-list parity** for `json`.
- Golden output **byte-identical** (live path untouched); full suite **1184** green; `ruff check` + `ruff format --check` clean.
- Manual e2e: `--discover-in-target --modules=json --only-generate` completes a session (discovery ran in the target, generation drove from metadata). The runner-lacks-extension payoff is covered by the `module=None` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)