### PR TITLE
python: target-side --packages enumeration for --discover-in-target

### DIFF
--- a/doc/python-fuzzer.md
+++ b/doc/python-fuzzer.md
@@ -85,10 +85,12 @@ Entry point: `fuzzers/fusil-python-threaded` → `fusil.python.Fuzzer`.
     by name in the target regardless, so nothing else changes). The subprocess emits *raw*
     metadata; all fusil policy (blacklists, `--test-private`, `--fuzz-exceptions`, arity name-table
     overrides) stays in the parent, so the live and subprocess paths stay in parity (guarded by
-    `tests/python/test_target_introspect.py`). Pair with an explicit `--modules`/`--modules-file`
-    (which bypass the runner-side package walk); moving `--packages` enumeration into the target is
-    a follow-up. **Limitation:** a plugin `add_class_handler` that introspects the *live* class
-    can't run when the extension isn't in the runner (see `doc/plugins.md`).
+    `tests/python/test_target_introspect.py`). `--packages` **enumeration** also runs in the target
+    subprocess under this flag (`target_introspect.enumerate_packages` walks the packages there; the
+    parent applies the shared `ListAllModules.keep_walked_module` filter), so neither member
+    discovery nor package walking imports the extension in the runner. **Limitation:** a plugin
+    `add_class_handler` that introspects the *live* class can't run when the extension isn't in the
+    runner (see `doc/plugins.md`).
 - **`WritePythonCode`** (`write_python_code.py`, the largest/most important file): generates the
   test script — imports the target, then emits randomized function calls, class instantiations,
   method calls, objects, and thread/async wrappers. Arguments come from **`ArgumentGenerator`**

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -73,9 +73,9 @@ class Fuzzer(Application):
             "introspecting it in a SUBPROCESS running the target interpreter (--python), instead "
             "of importing it in the runner. So the runner venv need not have the target extension "
             "installed -- useful for FT/debug CPython builds with no wheels, or a target that "
-            "differs from the runner. Pair with an explicit --modules/--modules-file (which bypass "
-            "the runner-side package walk); --packages enumeration in the target is a follow-up. "
-            "Default: False (import + introspect in the runner).",
+            "differs from the runner. --packages enumeration also runs in the target subprocess "
+            "under this flag, so neither member discovery nor package walking imports the extension "
+            "in the runner. Default: False (import + introspect in the runner).",
             action="store_true",
             dest="discover_in_target",
             default=False,

--- a/fusil/python/list_all_modules.py
+++ b/fusil/python/list_all_modules.py
@@ -101,6 +101,31 @@ class ListAllModules:
 
         return True
 
+    def keep_walked_module(
+        self,
+        name: str,
+        is_package: bool,
+        filename: str | None,
+        search_path: str = "",
+        prefix: str = "",
+        package: str | None = None,
+        path: list[str] | None = None,
+    ) -> bool:
+        """Full keep/skip decision for a walked (sub)module: the name-based skips (blacklist /
+        ``__main__`` / ``*_d``) plus :meth:`_is_valid_module` (site_package / only_c / blacklist
+        substrings). Shared by the runner-side :meth:`discover_modules` walk and the target-
+        subprocess package enumeration (``target_introspect.enumerate_packages``), so both apply
+        identical filtering."""
+        if name in self.blacklist:
+            return False
+        if name == "__main__" or name.endswith(".__main__"):
+            return False
+        if name.endswith("_d"):
+            return False
+        return self._is_valid_module(
+            name, is_package, filename, path, package, prefix, search_path=search_path
+        )
+
     def _find_module(self, fullname: str, name: str, prefix: str) -> ModuleType | None:
         """
         Attempt to find and import a module using various strategies.
@@ -156,19 +181,9 @@ class ListAllModules:
             path = sys.path
 
         for finder, name, ispkg in pkgutil.walk_packages(path, prefix, onerror):
-            if name in self.blacklist:
-                continue
-
-            if name == "__main__" or name.endswith(".__main__"):
-                # A package's __main__ is its CLI entry point: importing it *runs* the CLI
-                # (argparse over sys.argv, then sys.exit()) -- e.g. venv.__main__, json.__main__,
-                # zipfile.__main__. It is never a useful fuzz target and its import-time exit
-                # would otherwise churn the fuzzer, so skip the whole family here.
-                continue
-
-            if name.endswith("_d"):
-                continue
-
+            # __main__ (a package's CLI entry point) / *_d / blacklisted names are skipped inside
+            # keep_walked_module; importing __main__ *runs* the CLI (argparse -> sys.exit), which
+            # would churn the fuzzer, but find_spec below does not execute it.
             filename = None
             try:
                 spec = finder.find_spec(name)
@@ -180,14 +195,14 @@ class ListAllModules:
             module_data = self._get_module_metadata(name)
             search_path = finder.path if hasattr(finder, "path") else ""
 
-            if not self._is_valid_module(
+            if not self.keep_walked_module(
                 name,
                 ispkg,
                 filename,
-                module_data.get("path"),
-                module_data.get("package"),
+                search_path,
                 prefix,
-                search_path=search_path,
+                module_data.get("package"),
+                module_data.get("path"),
             ):
                 if self.verbose:
                     print(f"SKIPPED {name}", file=sys.stderr)

--- a/fusil/python/python_source.py
+++ b/fusil/python/python_source.py
@@ -98,15 +98,21 @@ class PythonSource(ProjectAgent):
 
             packages = self.options.packages.split(",")
 
-            for package in packages:
-                package = package.strip().strip("/")
-                if not len(package):
-                    continue
-                pack = __import__(package)
-                path = pack.__path__[0]
-                self.info("Adding package: %s (%s)" % (package, path))
-                package_walker = all_modules.discover_modules([path], package + ".")
-                self.modules |= set(name for finder, name, ispgk in package_walker)
+            if getattr(self.options, "discover_in_target", False):
+                # Walk the packages in a subprocess under the target interpreter, so --packages
+                # enumeration -- like --discover-in-target's member introspection -- doesn't import
+                # the extension in the runner.
+                self._add_packages_from_target(all_modules, packages)
+            else:
+                for package in packages:
+                    package = package.strip().strip("/")
+                    if not len(package):
+                        continue
+                    pack = __import__(package)
+                    path = pack.__path__[0]
+                    self.info("Adding package: %s (%s)" % (package, path))
+                    package_walker = all_modules.discover_modules([path], package + ".")
+                    self.modules |= set(name for finder, name, ispgk in package_walker)
 
             self.info(
                 "Known modules (%d): %s" % (len(self.modules), ",".join(sorted(self.modules)))
@@ -175,6 +181,40 @@ class PythonSource(ProjectAgent):
             _async=(not self.options.no_async)
             and not (self.options.tsan or getattr(self.options, "concurrency_stress", False)),
             plugin_manager=self.plugin_manager,
+        )
+
+    def _add_packages_from_target(self, all_modules, packages) -> None:
+        """--discover-in-target: enumerate the named packages' submodules in a subprocess running
+        the target interpreter (so --packages doesn't import the extension in the runner), then
+        apply the SAME ListAllModules filtering as the runner-side walk (``keep_walked_module``)."""
+        from fusil.python.target_introspect import enumerate_packages
+
+        names = [p.strip().strip("/") for p in packages]
+        names = [p for p in names if p]
+        timeout = int(getattr(self.options, "discover_timeout", 60))
+        data = enumerate_packages(
+            self.options.python, names, env=self._target_discovery_env(), timeout=timeout
+        )
+        if data is None:
+            self.error(
+                "Target-subprocess package enumeration failed (%s); no submodules added."
+                % ",".join(names)
+            )
+            return
+        kept = 0
+        for sub in data["submodules"]:
+            if all_modules.keep_walked_module(
+                sub["name"],
+                sub.get("ispkg", False),
+                sub.get("origin"),
+                sub.get("search_path", ""),
+                "",
+                sub.get("package"),
+            ):
+                self.modules.add(sub["name"])
+                kept += 1
+        self.info(
+            "Added %d submodule(s) from %d package(s) via target introspection" % (kept, len(names))
         )
 
     def _thread_flags(self) -> tuple[bool, bool]:

--- a/fusil/python/target_introspect.py
+++ b/fusil/python/target_introspect.py
@@ -145,6 +145,90 @@ main()
 '''
 
 
+# Enumeration script: walk the named packages under the TARGET interpreter and emit each
+# submodule's (name, ispkg, origin, search_path, package) so the parent can apply the same
+# ListAllModules filtering (blacklist / only_c / site_package) it uses for the runner-side walk.
+# Mirrors ListAllModules.discover_modules' pkgutil.walk_packages loop (which imports subpackages to
+# recurse -- that happens here, in the target, where the extension is installed).
+_ENUMERATE_SRC = r"""
+import sys, json, importlib, pkgutil
+
+
+def main():
+    subs = []
+    seen = set()
+    for pkg in sys.argv[1:]:
+        pkg = pkg.strip().strip("/")
+        if not pkg or pkg in seen:
+            continue
+        try:
+            mod = importlib.import_module(pkg)
+        except BaseException:
+            continue
+        paths = getattr(mod, "__path__", None)
+        if not paths:
+            continue
+
+        def _onerror(_name):
+            return None
+
+        try:
+            walker = pkgutil.walk_packages(list(paths), pkg + ".", _onerror)
+            for finder, name, ispkg in walker:
+                if name in seen:
+                    continue
+                seen.add(name)
+                origin = None
+                try:
+                    spec = finder.find_spec(name)
+                    if spec is not None:
+                        origin = spec.origin
+                except Exception:
+                    origin = None
+                subs.append({
+                    "name": name,
+                    "ispkg": bool(ispkg),
+                    "origin": origin,
+                    "search_path": getattr(finder, "path", "") or "",
+                    "package": name.rpartition(".")[0],
+                })
+        except Exception:
+            continue
+    print(json.dumps({"ok": True, "submodules": subs}))
+
+
+main()
+"""
+
+
+def enumerate_packages(python_path, package_names, env=None, timeout=120):
+    """Walk the named packages under ``python_path`` and return ``{"ok", "submodules": [...]}`` (each
+    submodule dict is ``{name, ispkg, origin, search_path, package}`` for the parent to filter), or
+    ``None`` on timeout / non-zero / unparseable output. The runner-side analogue is
+    ``ListAllModules.discover_modules``; the parent applies ``keep_walked_module`` to the result."""
+    if not package_names:
+        return {"ok": True, "submodules": []}
+    try:
+        proc = subprocess.run(
+            [python_path, "-c", _ENUMERATE_SRC, *package_names],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        data = json.loads(proc.stdout.splitlines()[-1])
+    except (ValueError, IndexError):
+        return None
+    if not isinstance(data, dict) or not data.get("ok") or "submodules" not in data:
+        return None
+    return data
+
+
 def introspect_module(python_path, module_name, env=None, timeout=60):
     """Run the discovery script under ``python_path`` and return the parsed metadata dict.
 

--- a/tests/python/test_target_introspect.py
+++ b/tests/python/test_target_introspect.py
@@ -17,7 +17,14 @@ import unittest
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))
 
-from fusil.python.target_introspect import _DISCOVERY_SRC, introspect_module
+from fusil.python.blacklists import MODULE_BLACKLIST
+from fusil.python.list_all_modules import ListAllModules
+from fusil.python.target_introspect import (
+    _DISCOVERY_SRC,
+    _ENUMERATE_SRC,
+    enumerate_packages,
+    introspect_module,
+)
 from fusil.python.write_python_code import WritePythonCode
 
 # Introspect using THIS interpreter (it can import `json`); no separate target needed for the unit.
@@ -151,6 +158,41 @@ class TestParity(unittest.TestCase):
         w, _ = _generate(None, "json", meta)
         got = (sorted(w.module_functions), sorted(w.module_classes), sorted(w.module_objects))
         self.assertEqual(live, got)
+
+
+class TestPackageEnumeration(unittest.TestCase):
+    def test_enumerate_script_is_valid_python(self):
+        ast.parse(_ENUMERATE_SRC)
+
+    def test_empty_and_bad_packages(self):
+        self.assertEqual(enumerate_packages(PYEXE, [])["submodules"], [])
+        # a single-file module (no __path__) yields no submodules; a missing package is skipped
+        data = enumerate_packages(PYEXE, ["bisect", "no_such_pkg_zzz"])
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["submodules"], [])
+
+    def test_enumeration_matches_runner_walk(self):
+        # Parity: subprocess enumeration + the SHARED keep_walked_module filter yields the same
+        # submodule set as the runner-side ListAllModules.discover_modules walk.
+        import email
+
+        lm = ListAllModules(None, False, True, MODULE_BLACKLIST, False, verbose=False)
+        live = {name for _f, name, _p in lm.discover_modules(list(email.__path__), "email.")}
+        data = enumerate_packages(PYEXE, ["email"])
+        meta = {
+            s["name"]
+            for s in data["submodules"]
+            if lm.keep_walked_module(
+                s["name"],
+                s["ispkg"],
+                s.get("origin"),
+                s.get("search_path", ""),
+                "",
+                s.get("package"),
+            )
+        }
+        self.assertTrue(live)  # sanity: email has submodules
+        self.assertEqual(live, meta)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Phase 2 of `--discover-in-target` (follows #235): the `--packages` **package walk** also runs in a subprocess under the target interpreter. So under `--discover-in-target`, **neither member introspection nor package enumeration imports the extension in the runner** — completing the "runner needn't have the extension" story. An extension hunt can now use `--packages=<ext>` instead of only an explicit `--modules-file`.

## How

- **`target_introspect.py`**: `_ENUMERATE_SRC` — a stdlib-only `pkgutil.walk_packages` over the named packages under the target — plus `enumerate_packages(...)`, emitting each submodule's `{name, ispkg, origin, search_path, package}` as JSON. (walk_packages imports subpackages to recurse — now in the *target*, where the extension is installed.)
- **`list_all_modules.py`**: extract **`keep_walked_module()`** — the exact keep/skip predicate `discover_modules` already applied (name-blacklist / `__main__` / `*_d` + `_is_valid_module`'s site_package/only_c/blacklist checks). `discover_modules` now calls it, and so does the subprocess-fed path, so **both filter identically**.
- **`python_source.py`**: under `--discover-in-target`, the `--packages` branch calls `_add_packages_from_target` (enumerate in target → `keep_walked_module` → union into the module set); otherwise the existing runner walk. A failed subprocess adds no submodules (logged), same disposition as before.

## Split preserved

The subprocess emits **raw** walked submodules; **all fusil policy** (blacklist / `--only-c` / site-packages) stays in the parent via `keep_walked_module`, so the runner-walk and target-subprocess paths stay in parity (guarded by a test).

## Tests / verification

New `test_target_introspect.py` cases: enumeration script shape; empty / missing / non-package inputs; **live-vs-subprocess submodule-set parity** for `email` (`discover_modules` == `enumerate_packages` + `keep_walked_module`). Existing `list_all_modules` tests still green (validate the `discover_modules` refactor). Full suite + `ruff check`/`format --check` clean. E2E: `--discover-in-target --packages=email --modules=email --only-generate` ran a session on `email.mime.base` (a submodule found by the target-side walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)