### PR TITLE
tsan: op (h) skips generators/coroutines (drop known gh-120321 noise)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -616,9 +616,19 @@ the worker's `_cell` is guarded against an empty iterator pool. The manifest ref
 (`shared_objects_only`, `iterators: []`, `shared_args: []`, ops without f/i; human line
 `ops=… objonly`). Off by default → normal runs unchanged. Pairs with a TSan **suppressions**
 file for the residual CPython noise that isn't from shared state — the interning/immortalize
-race from concurrent `setattr` (cpython#128137/#113956) and concurrent generator resume
-(cpython#120321) — for which the `cpython-tsan-findings` gateway carries `race:` entries.
-Tests: `test_tsan_generation.py` (`test_shared_objects_only_*`).
+race from concurrent `setattr` (cpython#128137/#113956) — for which the `cpython-tsan-findings`
+gateway carries `race:` entries. Tests: `test_tsan_generation.py` (`test_shared_objects_only_*`).
+
+**op (h) skips generators/coroutines.** The guarded `_tsan_iters` build drops any factory whose
+iterator is a `GeneratorType`/`CoroutineType`/`AsyncGeneratorType`: advancing a shared generator
+from many threads only ever reproduces CPython's known concurrent-generator-resume crash
+(**cpython#120321** — the `WITHIN_STACK_BOUNDS`/`frame->stackpointer`/`genobject.c` assert cascade,
+a SIGABRT/SIGSEGV, not a TSan race stanza, so the gateway can't suppress it), which dominated
+extension hunts (`fusil-tokenizers_07`/`_08`) and buried real extension-layer finds like a PyO3
+`PyDict::iter` "dictionary changed size during iteration" panic under concurrent `setattr`. All
+other iterator kinds (builtin cursors, ext-object `tp_iternext`) are still shared. Unconditional
+(the builtin set has no generators, so the CPython campaign's cursor-race coverage is unaffected);
+`test_generator_iterators_skipped`.
 
 ## 10. Testing
 

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -1167,6 +1167,7 @@ class WritePythonCode(WriteCode):
         self.write(0, "import gc as _tsan_gc")
         self.write(0, "import weakref as _tsan_weakref")
         self.write(0, "import operator as _tsan_operator")
+        self.write(0, "import types as _tsan_types")
         self.write_print_to_stderr(0, '"[TSAN] entering concurrency-stress region"')
         # Emit provenance FIRST (before the region runs) so it is already in the crash dir's
         # captured output no matter where a later race/abort stops the child. Human line + a
@@ -1376,9 +1377,21 @@ class WritePythonCode(WriteCode):
             """
             _tsan_iters = []
             _tsan_iter_ok = []
+            # Skip GENERATORS / coroutines: op (h) advancing one from many threads only ever hits
+            # CPython's known concurrent-generator-resume crash (gh-120321), not an extension bug,
+            # so sharing them just floods an extension hunt with that abort. Every other iterator
+            # kind (builtin cursors, ext-object tp_iternext) is still shared.
+            _TSAN_SKIP_ITER = (
+                _tsan_types.GeneratorType,
+                _tsan_types.CoroutineType,
+                _tsan_types.AsyncGeneratorType,
+            )
             for _f in _tsan_iter_factories:
                 try:
-                    _tsan_iters.append([_f()])
+                    _it0 = _f()
+                    if isinstance(_it0, _TSAN_SKIP_ITER):
+                        continue
+                    _tsan_iters.append([_it0])
                     _tsan_iter_ok.append(_f)
                 except Exception:
                     pass

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -151,12 +151,23 @@ class TestTSanGeneration(unittest.TestCase):
         # repr() reading its state -- the class behind cpython#153928/#154013/#153981.
         src = _generate_tsan()
         self.assertIn("_tsan_iter_factories", src)
-        self.assertIn("_tsan_iters.append([_f()])", src)  # guarded, length-aligned build (Slice C)
+        self.assertIn("_tsan_iters.append([_it0])", src)  # guarded, length-aligned build (Slice C)
         self.assertIn("next(_it)", src)  # concurrent cursor advance on the shared iterator
         self.assertIn("repr(_it)", src)  # state read racing the concurrent next()
         # covers the builtin iterator family + the stdlib C iterators from the linked issues
         self.assertIn("iter_unpack", src)  # struct (cpython#154013)
         self.assertIn("_tsan_itertools.count(10 ** 18, 2)", src)  # count slow mode (cpython#153981)
+
+    def test_generator_iterators_skipped(self):
+        # op (h) must NOT share generators/coroutines: advancing one from many threads only
+        # reproduces the known CPython concurrent-generator-resume crash (gh-120321), drowning an
+        # extension hunt. The guarded build drops them by type.
+        src = _generate_tsan()
+        self.assertIn("import types as _tsan_types", src)
+        self.assertIn("_TSAN_SKIP_ITER", src)
+        self.assertIn("_tsan_types.GeneratorType", src)
+        self.assertIn("_tsan_types.CoroutineType", src)
+        self.assertIn("isinstance(_it0, _TSAN_SKIP_ITER)", src)
 
     def test_read_while_mutate_op_emitted(self):
         # (i) iterate / copy / sort the shared container while siblings mutate it in (f).


### PR DESCRIPTION
## What

The concurrency-stress region's shared-iterator op (h) no longer shares **generators / coroutines / async-generators**. Every other iterator kind (builtin cursors, ext-object `tp_iternext`) is still shared.

## Why

Op (h) advances one shared iterator from every worker. When that iterator is a **generator**, concurrent `next()` from N threads only ever reproduces CPython's **known concurrent-generator-resume crash [gh-120321](https://github.com/python/cpython/issues/120321)** — the `WITHIN_STACK_BOUNDS` / `frame->stackpointer!=NULL` / `genobject.c:261` assert cascade (a SIGABRT/SIGSEGV, **not** a TSan race stanza, so the `cpython-tsan-findings` gateway can't suppress it).

On the tokenizers TSan fleets (`_07`/`_08`) this was **~500 dirs of that one known CPython bug**, drowning genuine extension-layer finds — notably a PyO3 `PyDict::iter` *"dictionary changed size during iteration"* panic surfaced by the concurrent-`setattr` (`--tsan-mutate-state`) ops. Removing the generator noise unmasks those.

## How

The guarded `_tsan_iters` build drops any factory whose iterator `isinstance` `types.GeneratorType` / `CoroutineType` / `AsyncGeneratorType`:

```python
_TSAN_SKIP_ITER = (_tsan_types.GeneratorType, _tsan_types.CoroutineType, _tsan_types.AsyncGeneratorType)
for _f in _tsan_iter_factories:
    try:
        _it0 = _f()
        if isinstance(_it0, _TSAN_SKIP_ITER):
            continue
        _tsan_iters.append([_it0]); _tsan_iter_ok.append(_f)
    except Exception:
        pass
```

**Unconditional** (not behind a flag): the builtin iterator set (`str/bytes/list/tuple/dict/range/count/struct`) has no generators, so the CPython campaign's cursor-race coverage (`striter`/`dictiter`/`count`/`rangeiter` = TSAN-0006/0037/0044/…) is unaffected — only *generator-typed ext-object* iterators are skipped, and those only ever hit the already-reported gh-120321.

## Tests / verification

New `test_generator_iterators_skipped`; updated `test_shared_iterator_op_emitted` for the new guarded-build form (`_tsan_iters.append([_it0])`). Verified at runtime: a generator factory is dropped while list/range factories are kept. Full suite + `ruff check`/`format --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)