### PR TITLE
process: --crash-drain-ms grace-drain so crash reports aren't truncated by the SIGKILL

### DIFF
--- a/fusil/process/create.py
+++ b/fusil/process/create.py
@@ -95,6 +95,11 @@ class CreateProcess(ProjectAgent):
         self.popen_args["close_fds"] = True
         self.stdin = stdin
         self.options = options
+        # Grace-drain window (seconds): on a detected crash, how long to let the child
+        # self-terminate (ASan/UBSan abort, segfault, or finish printing a Rust/Python backtrace)
+        # before we SIGKILL it, so the kept stdout -- which the child's stderr is merged into --
+        # isn't truncated mid-report. 0 disables it (kill immediately, the historical behaviour).
+        self.crash_drain = max(0.0, (getattr(options, "crash_drain_ms", 0) or 0) / 1000.0)
 
     def init(self):
         self.score = None
@@ -330,7 +335,16 @@ class CreateProcess(ProjectAgent):
         if not self.process:
             return
         if self.poll() is None:
-            # Kill the process and wait for its exit status
+            # Grace-drain: a crash is usually self-terminating (ASan/UBSan abort_on_error, a
+            # segfault, or a Rust/Python backtrace followed by exit). SIGKILLing on the first
+            # crash-word we read from stdout catches the child mid-report, so the kept stdout
+            # (its stderr is merged in) is truncated before the backtrace/SUMMARY. Give it a
+            # bounded window to finish and exit on its own first. Skipped for timeouts (the
+            # child is hung, not crashing) and when disabled (crash_drain == 0).
+            if self.crash_drain and not self.timeout_reached:
+                self._graceDrain()
+        if self.poll() is None:
+            # Still alive after the drain (or drain disabled): kill it and reap.
             self.warning("Terminate process %s" % self.process.pid)
             self._terminate()
             self.waitExit()
@@ -342,6 +356,23 @@ class CreateProcess(ProjectAgent):
         # atexit handlers of a *clean* interpreter exit, so a crashed/SIGKILLed child strands
         # them. They are then reparented to init and survive for the whole run.
         self.reapProcessGroup()
+
+    def _graceDrain(self):
+        """Wait up to ``crash_drain`` seconds for a self-terminating crash to exit on its own.
+
+        Polls the child; the moment it exits (``poll()`` returns a status) the full report has
+        been flushed to the stdout file and we return without killing it. Bounded: a soft crash
+        (a caught ``PanicException`` whose process keeps running) or a hang never self-exits, so
+        the window elapses and the caller falls through to the normal SIGKILL -- an added cost of
+        at most ``crash_drain`` seconds for those.
+        """
+        deadline = time() + self.crash_drain
+        while time() < deadline:
+            if self.poll() is not None:
+                self.info("Crash self-terminated within grace-drain window; full report captured")
+                return
+            sleep(0.010)
+        self.info("Grace-drain window elapsed; child still alive, forcing kill")
 
     def reapProcessGroup(self):
         """SIGKILL any descendants of the child that outlived it (see terminate())."""

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -126,6 +126,17 @@ class Fuzzer(Application):
             default=TIMEOUT,
         )
         running_options.add_option(
+            "--crash-drain-ms",
+            help="On a detected crash, wait up to N milliseconds for the child to self-terminate "
+            "(ASan/UBSan abort, segfault, or finish printing a Rust/Python backtrace) before "
+            "SIGKILLing it, so the kept stdout (the child's stderr is merged in) is not truncated "
+            "mid-backtrace/SUMMARY and can be triaged without re-running. 0 = kill immediately "
+            "(default). Bounded: a soft crash or hang that never self-exits just costs N ms. "
+            "Recommended ~300 for sanitizer or panic-heavy targets.",
+            type="int",
+            default=0,
+        )
+        running_options.add_option(
             "--python",
             help="Python executable program path (default: %s)" % PYTHON,
             type="str",

--- a/tests/test_process_create.py
+++ b/tests/test_process_create.py
@@ -814,6 +814,72 @@ class TestTerminate(unittest.TestCase):
         killpg.assert_called_once_with(321, create.SIGKILL)
 
 
+# =========================================================================== grace-drain
+@unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")
+class TestGraceDrain(unittest.TestCase):
+    def test_crash_drain_stored_from_options_in_seconds(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(crash_drain_ms=250))
+        self.assertEqual(agent.crash_drain, 0.25)
+
+    def test_disabled_by_default(self):
+        agent, _ = _make(arguments=["python"], name="p")  # no crash_drain_ms -> 0
+        self.assertEqual(agent.crash_drain, 0.0)
+        agent.process = _FakePopen(pid=7, poll_status=None)
+        agent._drained = False
+        agent._graceDrain = lambda: setattr(agent, "_drained", True)
+        agent._terminate = lambda: None
+        agent.waitExit = lambda: None
+        with patch.object(create, "killpg"), patch.object(create, "getpgrp", return_value=1):
+            agent.terminate()
+        self.assertFalse(agent._drained)  # crash_drain == 0 -> no drain, immediate kill path
+
+    def test_skipped_on_timeout(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(crash_drain_ms=300))
+        agent.timeout_reached = True  # a hang, not a crash: don't waste the window
+        agent.process = _FakePopen(pid=7, poll_status=None)
+        agent._drained = False
+        agent._graceDrain = lambda: setattr(agent, "_drained", True)
+        agent._terminate = lambda: None
+        agent.waitExit = lambda: None
+        with patch.object(create, "killpg"), patch.object(create, "getpgrp", return_value=1):
+            agent.terminate()
+        self.assertFalse(agent._drained)
+
+    def test_captures_self_exit_without_killing(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(crash_drain_ms=300))
+        # poll(): terminate's outer check -> None; then the drain sees None, then -11 (self-exit).
+        statuses = iter([None, None, -11])
+        agent.process = _FakePopen(pid=7)
+        agent.process.poll = lambda: next(statuses)
+        agent._killed = False
+        agent._terminate = lambda: setattr(agent, "_killed", True)
+        agent.waitExit = lambda: None
+        with (
+            patch.object(create, "sleep", lambda _s: None),
+            patch.object(create, "killpg"),
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.terminate()
+        self.assertFalse(agent._killed)  # exited on its own during the drain -> no SIGKILL
+        self.assertEqual(agent.status, -11)
+
+    def test_forces_kill_if_never_exits(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(crash_drain_ms=300))
+        agent.process = _FakePopen(pid=7, poll_status=None)  # never self-exits (soft crash / hang)
+        agent._killed = False
+        agent._terminate = lambda: setattr(agent, "_killed", True)
+        agent.waitExit = lambda: None
+        # time(): deadline = 0.0 + 0.3; first loop check 0.0 < 0.3 (drain once), second 0.5 >= 0.3 (give up).
+        with (
+            patch.object(create, "time", side_effect=[0.0, 0.0, 0.5]),
+            patch.object(create, "sleep", lambda _s: None),
+            patch.object(create, "killpg"),
+            patch.object(create, "getpgrp", return_value=1),
+        ):
+            agent.terminate()
+        self.assertTrue(agent._killed)  # still alive after the window -> SIGKILL as before
+
+
 # =========================================================================== waitExit
 @unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")
 class TestWaitExit(unittest.TestCase):


### PR DESCRIPTION
## Problem

`FileWatch.live()` stops scoring on the first score-1.0 crash word, and the session-stop path **SIGKILLs the child during teardown** — catching it *mid-report*. The kept `stdout` (the child's stderr is merged into it via `stderr=STDOUT`) is truncated before the backtrace/`SUMMARY`. Every sanitizer/panic pile in the extension campaign (tokenizers SEGVs, cryptography `memoryview` UAF, the 398 pydantic-core stack overflows) then had to be **re-run under gdb or the venv** just to resolve the site — the single most-repeated triage step.

## Fix

A crash is usually **self-terminating**: ASan/UBSan `abort_on_error`, a segfault, or a Rust/Python backtrace followed by exit. `--crash-drain-ms N` (default `0` = today's behaviour) makes `CreateProcess.terminate()` poll the child for up to N ms and let it exit on its own — flushing the full report to the file — before force-killing.

- **Bounded.** A soft crash (a caught `PanicException` whose process keeps running) or a hang never self-exits, so the window elapses and the normal SIGKILL runs, at a cost of at most N ms.
- **Skipped for timeouts** (the child is hung, not crashing) and when disabled (`0`).
- Recommended `~300` for sanitizer/panic-heavy targets; leave `0` for high-throughput dedup fleets.

### Why no separate ASan `log_path` ("belt-and-braces")

Unnecessary: the child's stderr is already redirected to the kept `stdout` file (`popen stderr=STDOUT`), so once the drain lets the child finish, the full report is right there — a dedicated ASan log file would only duplicate it (and complicate the env plumbing).

## Proof

Direct, through the **real** `terminate()` path with a self-terminating subprocess and fusil's exact redirection:

| `crash_drain_ms` | result |
|---|---|
| `0` (today) | **1 line — truncated** (killed right after the header) |
| `500` | **22 lines, 20 frames, `SUMMARY` captured** — full report |

Unit tests (`TestGraceDrain`): self-exit captured without a kill, force-kill after the window, skipped on timeout, disabled by default. 172 process/watch/file_watch/session tests pass; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERs92u7FghG2D7VdrwRLuo