### PR TITLE
AUTHORS: credit @weixlu, list @devdanzin as maintainer, markdown format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,14 +1,11 @@
-Main developers
-===============
+# Authors
 
-Victor Stinner aka haypo <victor.stinner AT haypocalc.com>
+## Main developers
 
-Contributor
-===========
+- Victor Stinner aka @vstinner (creator)
+- Daniel Diniz aka @devdanzin (maintainer)
 
-Geoffroy Couprie aka geal <geal AT videolan.org>
+## Contributors
 
-Others
-======
-
-Daniel Diniz aka @devdanzin
+- Geoffroy Couprie aka geal <geal AT videolan.org>
+- Xiaowei Lu aka @weixlu


### PR DESCRIPTION
Updates `AUTHORS` per the discussion in #238:

- **Add** "Xiaowei Lu aka @weixlu" to **Contributors** — for the `--only-generate` keep-output fix (#238).
- **Move** "Daniel Diniz aka @devdanzin (maintainer)" up to **Main developers** (second entry, below Victor).
- **Restyle** "Victor Stinner aka @vstinner (creator)".
- **Convert** the file to Markdown and drop the now-empty "Others" section.

Filename kept as `AUTHORS` (it's referenced by `MANIFEST.in`); only the contents changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERs92u7FghG2D7VdrwRLuo