### PR TITLE
--tsan: add op (l) shared-type mutation (--tsan-mutate-types)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -630,6 +630,33 @@ other iterator kinds (builtin cursors, ext-object `tp_iternext`) are still share
 (the builtin set has no generators, so the CPython campaign's cursor-race coverage is unaffected);
 `test_generator_iterators_skipped`.
 
+## Phase 7 as-built: shared-type mutation (`--tsan-mutate-types`, op l)
+
+**Motivation.** The op-mix through Phase 6 is *object-state / container / iterator*-centric: op
+(d) churns a shared **instance**'s `__dict__`, ops f/i/h race shared containers and iterators. It
+never mutates a **type object**, so the whole type-system FT surface — the `tp_version_tag`
+method-cache, `_PyType_Lookup`, and `tp_mro` recomputation — is untouched. That surface is exactly
+the "per-object mutable C state, no critical section" shape the iterator family kept yielding on,
+and it's where the magalu `--tsan` primary config had converged (fleet_tsan03–05 = 0 new).
+
+**op (l)** (opt-in, `--tsan-mutate-types`, `store_true`, default off; `tsan_options` group). A
+fresh **generic** shared class `_TsanSharedType(_TsanTypeBaseA)` (a couple of methods, a class
+attribute, a swappable base) + one shared instance are emitted always (inert under the
+`_MUTATE_TYPES` runtime gate, exactly like `_MUTATE_STATE`/op j). When on, the worker:
+- **writers** (`_role != 0`) `setattr`/`delattr` methods on the *class* (version-tag invalidation
+  via `type_modified`), reassign a class attribute, and periodically swap `__bases__` between two
+  layout-compatible bases (`tp_mro` recompute + propagation to the subclass);
+- **readers** (`_role != 1`) resolve+call those methods on the shared instance and run
+  `isinstance(inst, _TsanSharedType)` — the `_PyType_Lookup` method-cache read racing the writers'
+  invalidations.
+
+Generic (not the target's own class), so it works for every target and never corrupts the module
+under test. The manifest advertises it (`mutate_types`, `l:type-mutate` in `ops`, human line
+`ops=…+l`); default runs are unchanged (gate `False`). Tests: `test_tsan_generation.py`
+(`test_mutate_types_off_by_default` / `_op_emitted_when_enabled` / `_composes_with_mutate_state`).
+Distinct from generators (op h skip above → cpython#120321): type mutation is *not* already
+covered by the mix or the skip list, so it opens genuinely new surface.
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -550,6 +550,19 @@ class Fuzzer(Application):
             default=False,
         )
         tsan_options.add_option(
+            "--tsan-mutate-types",
+            action="store_true",
+            help="Also race a shared TYPE object: a new op (l) concurrently mutates ONE shared "
+            "class -- setattr/delattr methods + class attributes, and reassigns __bases__ -- while "
+            "readers resolve+call those methods and run isinstance() on a shared instance. This "
+            "drives the type-version-tag / _PyType_Lookup method-cache / tp_mro-recompute "
+            "free-threading surface that op (d)'s per-INSTANCE __dict__ churn never reaches. Uses a "
+            "fresh generic class (not the target's), so it works across every target. Opt-in "
+            "(default off): type mutation raises more benign exceptions and can surface the type "
+            "machinery's own races as noise.",
+            default=False,
+        )
+        tsan_options.add_option(
             "--tsan-shared-objects-only",
             action="store_true",
             help="Restrict the stress region to racing the TARGET module's objects: drop the "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -1031,6 +1031,11 @@ class WritePythonCode(WriteCode):
         # builtin iterators (op h) and shared containers (ops f/i) that flood an extension hunt
         # with CPython-core races. See the ops-list / iterator-factory / worker gates below.
         objects_only = bool(getattr(self.options, "tsan_shared_objects_only", False))
+        # Opt-in: op (l), concurrent mutation of a shared TYPE object (setattr/delattr methods +
+        # __bases__ swap) while readers resolve+call them -- the type-version-tag / _PyType_Lookup
+        # method-cache / tp_mro-recompute surface op (d)'s per-instance __dict__ churn never reaches.
+        # Uses a fresh generic class (not the target's), emitted always but runtime-gated below.
+        mutate_types = bool(getattr(self.options, "tsan_mutate_types", False))
 
         # Slice C: build a richer, guarded set of shared-object FACTORIES (source_expr, label,
         # iterable) -- real target objects rather than only bare Class() instances. The same
@@ -1106,6 +1111,8 @@ class WritePythonCode(WriteCode):
             ops_list.append("i:read-while-mutate")
         if mutate_state:
             ops_list.append("j:prop-reassign")
+        if mutate_types:
+            ops_list.append("l:type-mutate")
         self.tsan_shared_kind = shared_kind
         self.tsan_manifest = {
             "kind": "tsan-provenance",
@@ -1132,6 +1139,9 @@ class WritePythonCode(WriteCode):
             # Opt-in concurrent-mutation ops: op (b) gets real args + curated mutators, and op (j)
             # (property reassignment) is added. Reflected in the ops list only when actually on.
             "mutate_state": mutate_state,
+            # Opt-in op (l): concurrent mutation of a shared TYPE (methods / __bases__) vs
+            # method-resolution readers -- the type-cache / version-tag / MRO race surface.
+            "mutate_types": mutate_types,
             "ops": ops_list,
             "workers_per_obj": workers_per_obj,
             "iters": iters,
@@ -1152,7 +1162,7 @@ class WritePythonCode(WriteCode):
                 len(builtin_iterators),
                 ext_iterators,
                 iter_off,
-                "a-j" if mutate_state else "a-i",
+                ("a-j" if mutate_state else "a-i") + ("+l" if mutate_types else ""),
                 " objonly" if objects_only else "",
                 workers_per_obj,
                 iters,
@@ -1215,6 +1225,28 @@ class WritePythonCode(WriteCode):
             0,
             "_tsan_call_args = "
             '["x", "fusil", 1, 2, 0, -1, 1.5, True, ["a", "b"], ("a",), {"a": 1}, b"x", None]',
+        )
+        # op (l) support (inert unless --tsan-mutate-types): a fresh GENERIC shared type + instance.
+        # Op (l) below mutates the CLASS (setattr/delattr methods, swap __bases__) while readers
+        # resolve+call them -- the type-version-tag / _PyType_Lookup method-cache / tp_mro-recompute
+        # race surface op (d)'s per-instance __dict__ churn never reaches. Generic (not the target's)
+        # so it works for every target and never corrupts the module under test.
+        self.write(0, "_MUTATE_TYPES = %r" % mutate_types)
+        self.write_block(
+            0,
+            """
+            class _TsanTypeBaseA:
+                _tsan_base_id = 0
+            class _TsanTypeBaseB:
+                _tsan_base_id = 1
+            class _TsanSharedType(_TsanTypeBaseA):
+                _tsan_cv = 0
+                def _tm0(self):
+                    return 0
+                def _tm1(self):
+                    return 1
+            _tsan_type_inst = _TsanSharedType()
+            """,
         )
         # Build the shared objects from the guarded factories (Slice C): a few real target
         # objects (module-level instances, class instances w/ & w/o args, plugin objects),
@@ -1569,6 +1601,33 @@ class WritePythonCode(WriteCode):
                                     setattr(_obj, _pn, getattr(_obj, _pn))
                                 if _role != 1:
                                     getattr(_obj, _pn, None)
+                        except Exception:
+                            pass
+                    # (l) shared-type mutation race: writers setattr/delattr methods + reassign
+                    # __bases__ on ONE shared CLASS while readers resolve+call them + isinstance()
+                    # a shared instance -- the type-version-tag / _PyType_Lookup method-cache /
+                    # tp_mro-recompute FT surface op (d)'s per-instance __dict__ churn never reaches.
+                    if _MUTATE_TYPES:
+                        try:
+                            if _role != 0:
+                                setattr(_TsanSharedType, "_tm%d" % (_i % 4),
+                                        lambda self, _v=_i: _v)
+                                _TsanSharedType._tsan_cv = _i
+                                if _i % 8 == 0:
+                                    try:
+                                        delattr(_TsanSharedType, "_tm%d" % (_i % 4))
+                                    except Exception:
+                                        pass
+                                if _i % 32 == 0:
+                                    _TsanSharedType.__bases__ = (
+                                        (_TsanTypeBaseB,) if (_i // 32) % 2
+                                        else (_TsanTypeBaseA,))
+                            if _role != 1:
+                                _tm = getattr(_tsan_type_inst, "_tm%d" % (_wid % 4), None)
+                                if callable(_tm):
+                                    _tm()
+                                getattr(_tsan_type_inst, "_tsan_cv", None)
+                                isinstance(_tsan_type_inst, _TsanSharedType)
                         except Exception:
                             pass
             """,

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -63,6 +63,7 @@ def _make_tsan_options(
     weird_subclasses=False,
     mutate_state=False,
     shared_objects_only=False,
+    mutate_types=False,
 ):
     o = MagicMock()
     o.tsan = True
@@ -89,6 +90,7 @@ def _make_tsan_options(
     # a truthy attribute and turn the machinery on in every test.
     o.tsan_mutate_state = mutate_state
     o.tsan_shared_objects_only = shared_objects_only  # same auto-vivify caveat
+    o.tsan_mutate_types = mutate_types  # same auto-vivify caveat (op l, opt-in)
     return o
 
 
@@ -409,6 +411,43 @@ class TestTSanGeneration(unittest.TestCase):
         # the worker consults the curated mutators (op b) and properties (op j)
         self.assertIn('_mut["mutators"]', src)
         self.assertIn('_mut["properties"]', src)
+
+    def test_mutate_types_off_by_default(self):
+        # --tsan-mutate-types is opt-in: op (l) never runs by default (the _MUTATE_TYPES runtime
+        # gate is False), so the manifest advertises neither the op nor the flag.
+        src = _generate_tsan()
+        self.assertIn("_MUTATE_TYPES = False", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertFalse(manifest["mutate_types"])
+        self.assertNotIn("l:type-mutate", manifest["ops"])
+        self.assertIn("ops=a-i", src)  # human provenance line unchanged when off
+
+    def test_mutate_types_op_emitted_when_enabled(self):
+        # With --tsan-mutate-types the worker gains op (l): concurrent mutation of a shared TYPE
+        # (setattr/delattr methods + __bases__ swap) vs method-resolution/isinstance readers.
+        src = _generate_tsan(mutate_types=True)
+        ast.parse(src)  # still valid Python
+        self.assertIn("_MUTATE_TYPES = True", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertTrue(manifest["mutate_types"])
+        self.assertIn("l:type-mutate", manifest["ops"])
+        self.assertIn("ops=a-i+l", src)  # human provenance line advertises op l
+        # the shared generic type + instance are emitted, and the worker mutates the CLASS while
+        # readers resolve methods / run isinstance on the shared instance.
+        self.assertIn("class _TsanSharedType(_TsanTypeBaseA):", src)
+        self.assertIn("_tsan_type_inst = _TsanSharedType()", src)
+        self.assertIn("setattr(_TsanSharedType,", src)  # method churn -> version-tag invalidation
+        self.assertIn("_TsanSharedType.__bases__ = (", src)  # MRO recompute race
+        self.assertIn("isinstance(_tsan_type_inst, _TsanSharedType)", src)  # reader-side resolution
+
+    def test_mutate_types_composes_with_mutate_state(self):
+        # Both opt-in mutation ops together: provenance advertises a-j+l and both ops are present.
+        src = _generate_tsan(mutate_state=True, mutate_types=True)
+        ast.parse(src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertIn("j:prop-reassign", manifest["ops"])
+        self.assertIn("l:type-mutate", manifest["ops"])
+        self.assertIn("ops=a-j+l", src)
 
     def test_shared_objects_only_off_by_default(self):
         # Default: the generic builtin iterators (op h) and shared-container ops (f/i) are present.


### PR DESCRIPTION
## What

Adds a new opt-in op to the `--tsan` concurrency-stress region, **op (l): shared-type mutation**, behind `--tsan-mutate-types` (default off).

## Why

The op-mix (a–j) is **object-state / container / iterator-centric**: op (d) churns a shared *instance*'s `__dict__`; ops f/i/h race shared containers and iterators. It never mutates a **type object**, so the type-system free-threading surface — `tp_version_tag` method-cache, `_PyType_Lookup`, `tp_mro` recomputation — is untouched. That's exactly the "per-object mutable C state, no critical section" shape the shared-iterator family kept yielding on (TSAN-0037/38/40/45/53/54/55), and it's where the magalu `--tsan` primary config had **converged** (fleet_tsan03–05 re-ingested = 0 genuinely-new bugs).

This reopens surface the current mix can't reach — without a new build (reuses `debug-ft-nojit-tsan`).

## What op (l) does

A fresh **generic** shared class `_TsanSharedType(_TsanTypeBaseA)` (a couple of methods, a class attribute, a swappable base) + one shared instance, emitted always but **inert** under the `_MUTATE_TYPES` runtime gate (same pattern as `_MUTATE_STATE`/op j). When enabled, the worker:

- **writers** (`_role != 0`): `setattr`/`delattr` methods on the *class* (version-tag invalidation via `type_modified`), reassign a class attribute, and periodically swap `__bases__` between two layout-compatible bases (`tp_mro` recompute + propagation);
- **readers** (`_role != 1`): resolve+call those methods on the shared instance and run `isinstance(inst, _TsanSharedType)` — the `_PyType_Lookup` method-cache read racing the writers' invalidations.

Generic (not the target's own class) → works for every target, never corrupts the module under test.

## Not generators

op (h) already **deliberately skips** generators/coroutines (`_TSAN_SKIP_ITER`) because a shared generator only reproduces the known concurrent-generator-resume crash (cpython#120321), so that surface is already covered/known. Type mutation is *not* in the mix or the skip list — genuinely new.

## Safety / compatibility

- **Default `--tsan` output is behaviourally unchanged** (gate `False`); non-`--tsan` output is entirely unaffected (the emitter is `--tsan`-gated).
- Manifest advertises the op (`mutate_types`, `l:type-mutate` in `ops`, human line `ops=…+l`).

## Testing

- `tests/python/test_tsan_generation.py`: `test_mutate_types_off_by_default`, `test_mutate_types_op_emitted_when_enabled`, `test_mutate_types_composes_with_mutate_state`.
- Runtime-smoke-tested on `debug-ft-nojit` (`PYTHON_GIL=0`): op (l) executes cleanly 3/3, no codegen bug.
- Full suite green (1198 tests); `ruff check` + `ruff format --check` clean.
- Doc: `doc/tsan-mode-plan.md` → "Phase 7 as-built".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d