### PR TITLE
bombs: add reentrant-mutation family (mutate the container mid-C-op, not just raise)

### DIFF
--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -162,6 +162,125 @@ class FailingIterator:
         return self._i
 
 
+# --- Reentrant-mutation bombs: MUTATE the container mid-operation (not just raise) --------
+#
+# The exception bombs above make a protocol slot RAISE; these make it MUTATE the very
+# container the running C operation is iterating -- the reentrancy / use-after-free class.
+# When a C sequence/mapping routine borrows a container's internal storage (``ob_item`` array,
+# hash-table ``entries``) and then calls back into Python -- to compare (``__eq__``/``__lt__``),
+# hash (``__hash__``), or convert (``__index__``) an element -- clearing or resizing that
+# container from inside the callback frees/reallocates the borrowed pointer mid-loop. Core
+# CPython's own list/dict routines mostly re-check the size after each callback, but a great
+# deal of C-EXTENSION code (and less-trodden CPython C paths) caches the raw pointer once and
+# indexes it, so these objects are the protocol-slot analogue of an OOM injection aimed at the
+# reentrancy error path rather than the allocation-failure one. The mutation is DELAYED a few
+# calls (like the exception bombs) so a partially-consumed C loop is holding a live borrowed
+# pointer when it fires, rather than emptying the container before the loop starts.
+
+
+class _ClearParent:
+    """An element that clears the container holding it, from inside a comparison/hash/index
+    callback. Seeded into ``ReentrantClearList`` / ``ReentrantClearDict``; not used directly."""
+
+    def __init__(self, parent, max_delay=2):
+        self._parent = parent
+        self._calls = 0
+        self._delay = _bomb_random.randint(0, max_delay)
+
+    def _maybe_pull(self):
+        self._calls += 1
+        if self._calls > self._delay:
+            parent = self._parent
+            try:
+                parent.clear()
+            except Exception:
+                try:
+                    del parent[:]
+                except Exception:
+                    pass
+
+    def __eq__(self, other):
+        self._maybe_pull()
+        return False
+
+    def __lt__(self, other):
+        self._maybe_pull()
+        return True
+
+    def __gt__(self, other):
+        self._maybe_pull()
+        return False
+
+    def __hash__(self):
+        self._maybe_pull()
+        return 0
+
+    def __index__(self):
+        self._maybe_pull()
+        return 0
+
+    __int__ = __index__
+
+
+class ReentrantClearList(list):
+    """A pre-armed ``list``: it contains a self-clearing element, so any C op that compares,
+    hashes, or index-converts its items -- ``x in l`` / ``l.index(x)`` / ``l.sort()`` /
+    ``min(l)`` / ``max(l)`` / ``set(l)`` / ``bytes(l)``, or a C-extension routine iterating a
+    list argument -- can free the item array mid-loop (reentrant use-after-free)."""
+
+    def __init__(self):
+        super().__init__()
+        head = _bomb_random.randint(1, 4)
+        self.extend(range(head))
+        self.append(_ClearParent(self))
+        self.extend(range(head, head + _bomb_random.randint(2, 6)))
+
+
+class ReentrantClearDict(dict):
+    """A pre-armed ``dict``: a stored VALUE clears the dict from inside a comparison, so a C op
+    that compares the mapping's values -- ``d == other`` / dict richcompare, or a C-extension
+    routine walking a dict argument's values -- can free the entry table mid-walk."""
+
+    def __init__(self):
+        super().__init__()
+        for i in range(_bomb_random.randint(1, 3)):
+            self[i] = i
+        self["_fusil_pull"] = _ClearParent(self)
+        for i in range(_bomb_random.randint(1, 3)):
+            self["k%d" % i] = i
+
+
+class MutatingIterable:
+    """A hostile iterable whose ``__length_hint__`` lies (huge / zero / negative) and whose
+    iterator mutates its own backing store mid-iteration. C consumers that PRESIZE a buffer
+    from the hint and then fill it by iterating -- ``list()`` / ``tuple()`` / ``bytes()`` /
+    ``b"".join()`` / ``set()`` / ``[*it]`` / ``PySequence_Tuple`` / ``_PyList_Extend`` -- can
+    over-read or write past the presized buffer when the real yield count disagrees."""
+
+    def __init__(self):
+        self._data = list(range(_bomb_random.randint(4, 16)))
+        # A lie about the yield count: 0/1 (undersize -> grow path), -1 (negative -> the
+        # unguarded-negative presize/ValueError vector), and a large-but-not-guaranteed-OOM
+        # over-report (8 MB presize, not 8 TB -- a sprayed bomb must not just raise MemoryError).
+        self._hint = _bomb_random.choice([0, 1, -1, 1 << 16, 1 << 20])
+
+    def __length_hint__(self):
+        return self._hint
+
+    def __iter__(self):
+        data = self._data
+
+        def _gen():
+            for i, value in enumerate(list(data)):
+                if i == 1:
+                    data.clear()
+                elif i == 2:
+                    data.extend(range(1 << 10))
+                yield value
+
+        return _gen()
+
+
 # --- SuperBomb: every protocol slot is a landmine ----------------------------------------
 #
 # Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
@@ -432,6 +551,11 @@ BOMB_CLASS_NAMES = [
     "WrongTypeFile",
     "FilenoBomb",
     "DescriptorBomb",
+    # Reentrant-mutation bombs: MUTATE the container mid-C-operation (reentrancy / UAF class),
+    # rather than raising. Self-contained, built with no required args, arg-injectable like the rest.
+    "ReentrantClearList",
+    "ReentrantClearDict",
+    "MutatingIterable",
 ]
 
 # Names the argument generator passes *as the class object itself* (not instantiated) -- the

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -603,6 +603,125 @@ class FailingIterator:
         return self._i
 
 
+# --- Reentrant-mutation bombs: MUTATE the container mid-operation (not just raise) --------
+#
+# The exception bombs above make a protocol slot RAISE; these make it MUTATE the very
+# container the running C operation is iterating -- the reentrancy / use-after-free class.
+# When a C sequence/mapping routine borrows a container's internal storage (``ob_item`` array,
+# hash-table ``entries``) and then calls back into Python -- to compare (``__eq__``/``__lt__``),
+# hash (``__hash__``), or convert (``__index__``) an element -- clearing or resizing that
+# container from inside the callback frees/reallocates the borrowed pointer mid-loop. Core
+# CPython's own list/dict routines mostly re-check the size after each callback, but a great
+# deal of C-EXTENSION code (and less-trodden CPython C paths) caches the raw pointer once and
+# indexes it, so these objects are the protocol-slot analogue of an OOM injection aimed at the
+# reentrancy error path rather than the allocation-failure one. The mutation is DELAYED a few
+# calls (like the exception bombs) so a partially-consumed C loop is holding a live borrowed
+# pointer when it fires, rather than emptying the container before the loop starts.
+
+
+class _ClearParent:
+    """An element that clears the container holding it, from inside a comparison/hash/index
+    callback. Seeded into ``ReentrantClearList`` / ``ReentrantClearDict``; not used directly."""
+
+    def __init__(self, parent, max_delay=2):
+        self._parent = parent
+        self._calls = 0
+        self._delay = _bomb_random.randint(0, max_delay)
+
+    def _maybe_pull(self):
+        self._calls += 1
+        if self._calls > self._delay:
+            parent = self._parent
+            try:
+                parent.clear()
+            except Exception:
+                try:
+                    del parent[:]
+                except Exception:
+                    pass
+
+    def __eq__(self, other):
+        self._maybe_pull()
+        return False
+
+    def __lt__(self, other):
+        self._maybe_pull()
+        return True
+
+    def __gt__(self, other):
+        self._maybe_pull()
+        return False
+
+    def __hash__(self):
+        self._maybe_pull()
+        return 0
+
+    def __index__(self):
+        self._maybe_pull()
+        return 0
+
+    __int__ = __index__
+
+
+class ReentrantClearList(list):
+    """A pre-armed ``list``: it contains a self-clearing element, so any C op that compares,
+    hashes, or index-converts its items -- ``x in l`` / ``l.index(x)`` / ``l.sort()`` /
+    ``min(l)`` / ``max(l)`` / ``set(l)`` / ``bytes(l)``, or a C-extension routine iterating a
+    list argument -- can free the item array mid-loop (reentrant use-after-free)."""
+
+    def __init__(self):
+        super().__init__()
+        head = _bomb_random.randint(1, 4)
+        self.extend(range(head))
+        self.append(_ClearParent(self))
+        self.extend(range(head, head + _bomb_random.randint(2, 6)))
+
+
+class ReentrantClearDict(dict):
+    """A pre-armed ``dict``: a stored VALUE clears the dict from inside a comparison, so a C op
+    that compares the mapping's values -- ``d == other`` / dict richcompare, or a C-extension
+    routine walking a dict argument's values -- can free the entry table mid-walk."""
+
+    def __init__(self):
+        super().__init__()
+        for i in range(_bomb_random.randint(1, 3)):
+            self[i] = i
+        self["_fusil_pull"] = _ClearParent(self)
+        for i in range(_bomb_random.randint(1, 3)):
+            self["k%d" % i] = i
+
+
+class MutatingIterable:
+    """A hostile iterable whose ``__length_hint__`` lies (huge / zero / negative) and whose
+    iterator mutates its own backing store mid-iteration. C consumers that PRESIZE a buffer
+    from the hint and then fill it by iterating -- ``list()`` / ``tuple()`` / ``bytes()`` /
+    ``b"".join()`` / ``set()`` / ``[*it]`` / ``PySequence_Tuple`` / ``_PyList_Extend`` -- can
+    over-read or write past the presized buffer when the real yield count disagrees."""
+
+    def __init__(self):
+        self._data = list(range(_bomb_random.randint(4, 16)))
+        # A lie about the yield count: 0/1 (undersize -> grow path), -1 (negative -> the
+        # unguarded-negative presize/ValueError vector), and a large-but-not-guaranteed-OOM
+        # over-report (8 MB presize, not 8 TB -- a sprayed bomb must not just raise MemoryError).
+        self._hint = _bomb_random.choice([0, 1, -1, 1 << 16, 1 << 20])
+
+    def __length_hint__(self):
+        return self._hint
+
+    def __iter__(self):
+        data = self._data
+
+        def _gen():
+            for i, value in enumerate(list(data)):
+                if i == 1:
+                    data.clear()
+                elif i == 2:
+                    data.extend(range(1 << 10))
+                yield value
+
+        return _gen()
+
+
 # --- SuperBomb: every protocol slot is a landmine ----------------------------------------
 #
 # Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
@@ -873,6 +992,11 @@ BOMB_CLASS_NAMES = [
     "WrongTypeFile",
     "FilenoBomb",
     "DescriptorBomb",
+    # Reentrant-mutation bombs: MUTATE the container mid-C-operation (reentrancy / UAF class),
+    # rather than raising. Self-contained, built with no required args, arg-injectable like the rest.
+    "ReentrantClearList",
+    "ReentrantClearDict",
+    "MutatingIterable",
 ]
 
 # Names the argument generator passes *as the class object itself* (not instantiated) -- the

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -213,5 +213,76 @@ class TestGeneratorWiring(unittest.TestCase):
         self.assertTrue(saw_instance and saw_type)
 
 
+class TestReentrantMutationBombs(unittest.TestCase):
+    """The reentrant-mutation family MUTATES the container mid-callback (reentrancy / UAF
+    class) rather than raising -- distinct from the exception bombs above."""
+
+    def test_clear_parent_clears_container_on_compare_callback(self):
+        # delay 0 -> the first comparison callback clears the container holding the element.
+        lst = [1, 2, 3]
+        cp = B._ClearParent(lst, max_delay=0)
+        lst.append(cp)
+        self.assertEqual(len(lst), 4)
+        _ = cp == 99  # a compare callback (what a C compare loop invokes)
+        self.assertEqual(len(lst), 0)  # parent cleared from inside the dunder
+
+    def test_clear_parent_respects_delay(self):
+        lst = [1]
+        cp = B._ClearParent(lst)
+        cp._delay, cp._calls = 2, 0
+        lst.append(cp)
+        hash(cp)  # call 1
+        hash(cp)  # call 2
+        self.assertGreater(len(lst), 0)  # not yet
+        hash(cp)  # call 3 > delay 2 -> clears
+        self.assertEqual(len(lst), 0)
+
+    def test_clear_parent_fires_from_multiple_slots(self):
+        for trigger in (
+            lambda c: c == 1,
+            lambda c: c < 1,
+            lambda c: hash(c),
+            lambda c: c.__index__(),
+        ):
+            lst = [0, 1]
+            cp = B._ClearParent(lst, max_delay=0)
+            lst.append(cp)
+            trigger(cp)
+            self.assertEqual(len(lst), 0)
+
+    def test_reentrant_list_is_prearmed_and_benign_until_compared(self):
+        rl = B.ReentrantClearList()
+        self.assertIsInstance(rl, list)
+        self.assertGreater(len(rl), 0)
+        # repr / len must NOT trigger the clear (no compare/hash/index of the seeded element)
+        _ = repr(rl)
+        _ = len(rl)
+        self.assertGreater(len(rl), 0)
+        # exactly one seeded self-clearing element
+        self.assertEqual(sum(isinstance(x, B._ClearParent) for x in rl), 1)
+
+    def test_reentrant_dict_is_prearmed_dict(self):
+        rd = B.ReentrantClearDict()
+        self.assertIsInstance(rd, dict)
+        self.assertIn("_fusil_pull", rd)
+        self.assertIsInstance(rd["_fusil_pull"], B._ClearParent)
+
+    def test_mutating_iterable_lies_about_length(self):
+        # __length_hint__ draws from a set that includes negative and large values (presize
+        # crash vectors), while iteration yields a different, real count.
+        hints = {B.MutatingIterable().__length_hint__() for _ in range(200)}
+        self.assertTrue(any(h < 0 for h in hints))  # negative hint present
+        self.assertTrue(any(h >= (1 << 16) for h in hints))  # large over-report present
+        self.assertTrue(all(h <= (1 << 20) for h in hints))  # but never a guaranteed-OOM presize
+        # materializing works regardless of the (lying) hint and yields the real, different count
+        mi = B.MutatingIterable()
+        mi._hint = 1 << 20  # exercise the large-presize path deterministically
+        self.assertIsInstance(list(mi), list)
+
+    def test_reentrant_bombs_registered(self):
+        for name in ("ReentrantClearList", "ReentrantClearDict", "MutatingIterable"):
+            self.assertIn(name, B.BOMB_CLASS_NAMES)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds a new bomb family to `fusil/python/samples/bomb_objects.py`: **reentrant-mutation bombs** that *mutate* the container a running C routine is iterating, rather than *raising* from a protocol slot.

## Why

fusil's existing exception bombs make a dunder **raise** — the OOM-injection analogue for the unguarded-`PyErr_Clear` / swallowed-error bug class. This adds the complementary **reentrancy / use-after-free** class, which fusil didn't cover.

When a C sequence/mapping routine borrows a container's internal storage (`ob_item` array, hash-table `entries`) and then calls back into Python — to compare (`__eq__`/`__lt__`), hash (`__hash__`), or index-convert (`__index__`) an element — clearing or resizing that container **from inside the callback** frees/reallocates the borrowed pointer mid-loop. Core CPython's own list/dict routines mostly re-check the size after each callback, but a great deal of **C-extension code (fusil's primary target)** and less-trodden CPython C paths cache the raw pointer once and index it — exactly the unguarded-reentrancy paths this exercises.

## New bombs (self-contained, no-required-arg, arg-injectable via `BOMB_CLASS_NAMES`)

- **`_ClearParent`** — an element whose compare/hash/index callback clears its parent container, **delayed** a few calls (like the exception bombs) so a partially-consumed C loop is holding a live borrowed pointer when it fires.
- **`ReentrantClearList` / `ReentrantClearDict`** — pre-armed `list`/`dict` subclasses seeded with a self-clearing element/value; benign under `repr`/`len`, arm on the first compare/hash op (`x in l`, `l.index`, `min`/`max`, `set(l)`, `bytes(l)`, `d == other`, or a C-ext walking the argument).
- **`MutatingIterable`** — `__length_hint__` lies (`0`/`1`/`-1`/large — the negative + over-report presize vectors) and the iterator mutates its own backing store mid-iteration, for C consumers that presize a buffer from the hint then fill by iterating (`PySequence_Tuple`/`_PyList_Extend`/`bytes`/`join`/…). Capped below a guaranteed-OOM presize so a *sprayed* bomb doesn't just raise `MemoryError`.

They join the existing spray pool through `genBombObject` (no separate flag) — armed like every other bomb, firing only when a target C op touches the relevant protocol.

## Provenance

Idea harvested from studying lafleur's mutators (`RugPuller` / `RefcountEscapeHatch`); implemented natively for fusil's argument-injection model (not ported code).

## Testing

- `tests/python/test_bomb_objects.py::TestReentrantMutationBombs` — mechanism (clear-on-compare-callback fires, respects delay, fires from multiple slots), benign-until-compared, pre-armed structure, `__length_hint__` lies, registry wiring.
- Golden snapshot regenerated (`bomb_objects.py` is embedded verbatim into every generated script).
- Full suite green (1205 tests); `ruff check` + `ruff format --check` clean over the CI scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d