### PR TITLE
--tsan: add op (m) shared-callable mutation (--tsan-mutate-callables)

### DIFF
--- a/doc/tsan-mode-plan.md
+++ b/doc/tsan-mode-plan.md
@@ -657,6 +657,33 @@ under test. The manifest advertises it (`mutate_types`, `l:type-mutate` in `ops`
 Distinct from generators (op h skip above → cpython#120321): type mutation is *not* already
 covered by the mix or the skip list, so it opens genuinely new surface.
 
+## Phase 8 as-built: shared-callable mutation (`--tsan-mutate-callables`, op m)
+
+**Motivation.** The op-mix still never mutated a **function** object — the `func_code` /
+`func_version` / `__defaults__` / `__kwdefaults__` / closure-cell surface was untouched. Function
+attribute setters `Py_XSETREF` the old value with **no critical section**, so two threads assigning
+one shared function's attribute both decref the old value → a concurrent **double-free** (the
+`func_set_qualname` class of cpython#153297).
+
+**op (m)** (opt-in, `--tsan-mutate-callables`, `store_true`, default off; `tsan_options`). A fresh
+**generic** shared closure `_tsan_shared_fn` (1 free var → a real cell) + a pool of
+`__code__`-swap-compatible code objects (each a 1-freevar closure, so `func_set_code`'s
+freevar-count check passes) are emitted always (inert under `_MUTATE_CALLABLES`, like op l/j). When
+on, the worker:
+- **writers** (`_role != 0`) swap `__defaults__` / `__kwdefaults__`, stomp the closure cell's
+  `cell_contents`, and periodically swap `__code__` from the pool;
+- **readers** (`_role != 1`) **call** the shared function (which reads `func_code`/defaults/cell).
+
+Generic (not the target's), so it works for every target. Manifest advertises it (`mutate_callables`,
+`m:callable-mutate`, human line `ops=…+m`); default runs unchanged. Tests: `test_tsan_generation.py`
+(`test_mutate_callables_off_by_default` / `_op_emitted_when_enabled` /
+`_composes_with_types_and_state`). **Immediately effective:** on `debug-ft-nojit` (no sanitizer) the
+`__defaults__` and `__code__` swaps abort 3/3 with `_Py_NegativeRefcount` (double-free of the
+replaced tuple / code object). Prior art: cpython#153297 / PR #153335 harden `__name__` /
+`__qualname__` / `__code__` — but **not** `__defaults__` / `__kwdefaults__`, which op (m) surfaces as
+uncovered siblings of the same setter race. (`cell_contents` stomping did **not** crash — that path
+is already FT-safe.)
+
 ## 10. Testing
 
 - **Golden emitter tests:** the stress region is deterministic given a seed → add a golden

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -563,6 +563,19 @@ class Fuzzer(Application):
             default=False,
         )
         tsan_options.add_option(
+            "--tsan-mutate-callables",
+            action="store_true",
+            help="Also race a shared FUNCTION object: a new op (m) concurrently swaps a shared "
+            "closure's __code__ / __defaults__ and stomps its cell's cell_contents while readers "
+            "CALL it -- races on func->func_code / func_version, the __defaults__ tuple, and the "
+            "closure cell's ob_ref (the cell-refcount race no other op reaches). Uses a fresh "
+            "generic closure (not the target's), so it works across every target. Opt-in "
+            "(default off): callable mutation raises more benign exceptions (arg-count mismatches "
+            "after a __code__/__defaults__ swap) and can surface the function machinery's own "
+            "races as noise.",
+            default=False,
+        )
+        tsan_options.add_option(
             "--tsan-shared-objects-only",
             action="store_true",
             help="Restrict the stress region to racing the TARGET module's objects: drop the "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -1036,6 +1036,11 @@ class WritePythonCode(WriteCode):
         # method-cache / tp_mro-recompute surface op (d)'s per-instance __dict__ churn never reaches.
         # Uses a fresh generic class (not the target's), emitted always but runtime-gated below.
         mutate_types = bool(getattr(self.options, "tsan_mutate_types", False))
+        # Opt-in: op (m), concurrent mutation of a shared FUNCTION object (swap __code__ /
+        # __defaults__, stomp the closure cell's cell_contents) while readers CALL it -- the
+        # func_code / func_version / __defaults__ / closure-cell-refcount surface no other op
+        # reaches. Uses a fresh generic closure (not the target's), emitted always, gated below.
+        mutate_callables = bool(getattr(self.options, "tsan_mutate_callables", False))
 
         # Slice C: build a richer, guarded set of shared-object FACTORIES (source_expr, label,
         # iterable) -- real target objects rather than only bare Class() instances. The same
@@ -1113,6 +1118,8 @@ class WritePythonCode(WriteCode):
             ops_list.append("j:prop-reassign")
         if mutate_types:
             ops_list.append("l:type-mutate")
+        if mutate_callables:
+            ops_list.append("m:callable-mutate")
         self.tsan_shared_kind = shared_kind
         self.tsan_manifest = {
             "kind": "tsan-provenance",
@@ -1142,6 +1149,9 @@ class WritePythonCode(WriteCode):
             # Opt-in op (l): concurrent mutation of a shared TYPE (methods / __bases__) vs
             # method-resolution readers -- the type-cache / version-tag / MRO race surface.
             "mutate_types": mutate_types,
+            # Opt-in op (m): concurrent mutation of a shared FUNCTION (__code__ / __defaults__ /
+            # cell_contents) vs callers -- the func_code / func_version / closure-cell surface.
+            "mutate_callables": mutate_callables,
             "ops": ops_list,
             "workers_per_obj": workers_per_obj,
             "iters": iters,
@@ -1162,7 +1172,9 @@ class WritePythonCode(WriteCode):
                 len(builtin_iterators),
                 ext_iterators,
                 iter_off,
-                ("a-j" if mutate_state else "a-i") + ("+l" if mutate_types else ""),
+                ("a-j" if mutate_state else "a-i")
+                + ("+l" if mutate_types else "")
+                + ("+m" if mutate_callables else ""),
                 " objonly" if objects_only else "",
                 workers_per_obj,
                 iters,
@@ -1246,6 +1258,28 @@ class WritePythonCode(WriteCode):
                 def _tm1(self):
                     return 1
             _tsan_type_inst = _TsanSharedType()
+            """,
+        )
+        # op (m) support (inert unless --tsan-mutate-callables): a fresh GENERIC shared CLOSURE
+        # (1 free var -> a real cell to stomp) + a pool of __code__-swap-compatible code objects
+        # (each a 1-freevar closure, so func_set_code's freevar-count check passes). Op (m) below
+        # swaps __code__/__defaults__ and stomps the cell's cell_contents while readers CALL it.
+        self.write(0, "_MUTATE_CALLABLES = %r" % mutate_callables)
+        self.write_block(
+            0,
+            """
+            def _tsan_make_closure(_seed=0):
+                _closed = _seed
+                def _fn(_a=0, _b=0):
+                    return _closed + _a + _b
+                return _fn
+            def _tsan_alt_closure():
+                _closed = 0
+                def _fn(_a, _b, _c):  # different arity, still 1 freevar -> __code__-swap-compatible
+                    return _closed
+                return _fn
+            _tsan_shared_fn = _tsan_make_closure()
+            _tsan_code_pool = [_tsan_shared_fn.__code__, _tsan_alt_closure().__code__]
             """,
         )
         # Build the shared objects from the guarded factories (Slice C): a few real target
@@ -1628,6 +1662,34 @@ class WritePythonCode(WriteCode):
                                     _tm()
                                 getattr(_tsan_type_inst, "_tsan_cv", None)
                                 isinstance(_tsan_type_inst, _TsanSharedType)
+                        except Exception:
+                            pass
+                    # (m) shared-callable mutation race: writers swap __code__ / __defaults__ /
+                    # __kwdefaults__ and stomp the closure cell's cell_contents on ONE shared
+                    # function while readers CALL it -- races on func->func_code / func_version,
+                    # the __defaults__/__kwdefaults__ containers (their setters Py_XSETREF the old
+                    # value with no critical section -> concurrent double-free; the func_set_qualname
+                    # class of cpython#153297, whose fix PR #153335 covers __name__/__qualname__/
+                    # __code__ but NOT __defaults__/__kwdefaults__), and the closure cell's ob_ref.
+                    if _MUTATE_CALLABLES:
+                        try:
+                            if _role != 0:
+                                _tsan_shared_fn.__defaults__ = (_i, _i) if _i % 2 else ()
+                                _tsan_shared_fn.__kwdefaults__ = {"_z": _i} if _i % 3 else None
+                                _tsan_cells = _tsan_shared_fn.__closure__
+                                if _tsan_cells:
+                                    _tsan_cells[0].cell_contents = _i
+                                if _i % 16 == 0:
+                                    try:
+                                        _tsan_shared_fn.__code__ = _tsan_code_pool[
+                                            (_i // 16) % len(_tsan_code_pool)]
+                                    except Exception:
+                                        pass
+                            if _role != 1:
+                                try:
+                                    _tsan_shared_fn()
+                                except Exception:
+                                    pass
                         except Exception:
                             pass
             """,

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -64,6 +64,7 @@ def _make_tsan_options(
     mutate_state=False,
     shared_objects_only=False,
     mutate_types=False,
+    mutate_callables=False,
 ):
     o = MagicMock()
     o.tsan = True
@@ -91,6 +92,7 @@ def _make_tsan_options(
     o.tsan_mutate_state = mutate_state
     o.tsan_shared_objects_only = shared_objects_only  # same auto-vivify caveat
     o.tsan_mutate_types = mutate_types  # same auto-vivify caveat (op l, opt-in)
+    o.tsan_mutate_callables = mutate_callables  # same auto-vivify caveat (op m, opt-in)
     return o
 
 
@@ -448,6 +450,46 @@ class TestTSanGeneration(unittest.TestCase):
         self.assertIn("j:prop-reassign", manifest["ops"])
         self.assertIn("l:type-mutate", manifest["ops"])
         self.assertIn("ops=a-j+l", src)
+
+    def test_mutate_callables_off_by_default(self):
+        # --tsan-mutate-callables is opt-in: op (m) never runs by default.
+        src = _generate_tsan()
+        self.assertIn("_MUTATE_CALLABLES = False", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertFalse(manifest["mutate_callables"])
+        self.assertNotIn("m:callable-mutate", manifest["ops"])
+        self.assertIn("ops=a-i", src)  # human provenance line unchanged when off
+
+    def test_mutate_callables_op_emitted_when_enabled(self):
+        # With --tsan-mutate-callables the worker gains op (m): concurrent mutation of a shared
+        # FUNCTION (__code__ / __defaults__ / cell_contents) vs caller readers.
+        src = _generate_tsan(mutate_callables=True)
+        ast.parse(src)  # still valid Python
+        self.assertIn("_MUTATE_CALLABLES = True", src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertTrue(manifest["mutate_callables"])
+        self.assertIn("m:callable-mutate", manifest["ops"])
+        self.assertIn("ops=a-i+m", src)  # human provenance line advertises op m
+        # the shared closure + swap-compatible code pool are emitted, and the worker mutates the
+        # callable (defaults / code swap / cell stomp) while readers call it.
+        self.assertIn("_tsan_shared_fn = _tsan_make_closure()", src)
+        self.assertIn("_tsan_code_pool = [", src)
+        self.assertIn("_tsan_shared_fn.__defaults__ =", src)  # defaults-tuple race
+        self.assertIn(
+            "_tsan_shared_fn.__kwdefaults__ =", src
+        )  # kwdefaults race (uncovered sibling)
+        self.assertIn(".cell_contents = _i", src)  # closure-cell refcount race
+        self.assertIn("_tsan_shared_fn.__code__ = _tsan_code_pool[", src)  # func_code swap
+        self.assertIn("_tsan_shared_fn()", src)  # reader-side call
+
+    def test_mutate_callables_composes_with_types_and_state(self):
+        # All three opt-in mutation ops together: provenance advertises a-j+l+m.
+        src = _generate_tsan(mutate_state=True, mutate_types=True, mutate_callables=True)
+        ast.parse(src)
+        manifest = _extract_tsan_manifest(src)
+        self.assertIn("l:type-mutate", manifest["ops"])
+        self.assertIn("m:callable-mutate", manifest["ops"])
+        self.assertIn("ops=a-j+l+m", src)
 
     def test_shared_objects_only_off_by_default(self):
         # Default: the generic builtin iterators (op h) and shared-container ops (f/i) are present.


### PR DESCRIPTION
## What

Adds **op (m): shared-callable mutation** to the `--tsan` stress region, behind `--tsan-mutate-callables` (opt-in, default off) — the op-l sibling for **function objects**.

## Why

The op-mix (a–l) never mutated a **function**, so the `func_code` / `func_version` / `__defaults__` / `__kwdefaults__` / closure-cell surface was untouched. Function attribute setters `Py_XSETREF` the old value with **no critical section**, so two threads assigning one shared function's attribute both decref the old value → a concurrent **double-free** (the `func_set_qualname` class of cpython#153297).

## What op (m) does

A fresh **generic** shared closure `_tsan_shared_fn` (1 free var → a real cell) + a pool of `__code__`-swap-compatible code objects (each a 1-freevar closure so `func_set_code`'s freevar-count check passes), emitted always but inert under the `_MUTATE_CALLABLES` runtime gate (same pattern as op l/j). When enabled:

- **writers** (`_role != 0`): swap `__defaults__` / `__kwdefaults__`, stomp the closure cell's `cell_contents`, and periodically swap `__code__` from the pool;
- **readers** (`_role != 1`): **call** the shared function (which reads `func_code`/defaults/cell).

Generic (not the target's own function) → works for every target.

## Immediately effective + a live finding

On `debug-ft-nojit` (**no sanitizer needed**) the `__defaults__` and `__code__` swaps abort **3/3** with `_Py_NegativeRefcount` — a double-free of the replaced tuple / code object.

**Prior art:** cpython#153297 / PR #153335 harden `__name__` / `__qualname__` / `__code__` — but **not** `__defaults__` / `__kwdefaults__`, which op (m) surfaces as **uncovered siblings** of the same setter race (identical `Py_XSETREF`-without-critical-section pattern). (`cell_contents` stomping did **not** crash — that path is already FT-safe.)

## Safety / compatibility

- **Default `--tsan` output is behaviourally unchanged** (runtime `_MUTATE_CALLABLES` gate); non-`--tsan` output untouched (op-m is emitted only in `_write_tsan_stress_region`; the non-tsan golden is unaffected).
- Manifest advertises the op (`mutate_callables`, `m:callable-mutate`, human line `ops=…+m`).

## Testing

- `tests/python/test_tsan_generation.py`: `test_mutate_callables_off_by_default`, `test_mutate_callables_op_emitted_when_enabled`, `test_mutate_callables_composes_with_types_and_state`.
- Runtime-verified on `debug-ft-nojit` (`PYTHON_GIL=0`): the emitted op aborts 3/3 on the `__defaults__` double-free.
- Full suite green (1208 tests); `ruff check` + `ruff format --check` clean over the CI scope.
- Doc: `doc/tsan-mode-plan.md` → "Phase 8 as-built".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d