### PR TITLE
bombs: add stateful/lying dunder family (slot succeeds but returns an inconsistent answer)

### DIFF
--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -281,6 +281,83 @@ class MutatingIterable:
         return _gen()
 
 
+# --- Stateful / lying bombs: the protocol slot SUCCEEDS but returns an INCONSISTENT answer ---
+#
+# The exception bombs raise; the reentrant bombs mutate a container. These lie *quietly*: a slot
+# returns a value that is internally inconsistent across calls (or with a sibling slot), so C
+# code that reads it once to size/plan and then trusts it -- preallocating a buffer from __len__,
+# storing under a cached __hash__, specializing on the first element's type -- writes past the
+# buffer, lands in the wrong hash bucket, or trips a type fast-path. The lie is DELAYED (like the
+# other bombs) so the C routine has already committed to the first answer when it changes.
+
+
+class GrowingLen:
+    """__len__ under-reports on its first read (small presize) then reports a much larger size,
+    while __getitem__ / __iter__ yield up to the larger count. C code that presizes a buffer from
+    the first __len__ and then fills by index/iteration can write past it (the __len__-lies-small
+    buffer-preallocation class; complements LyingLen, which only over-reports)."""
+
+    def __init__(self):
+        self._calls = 0
+        self._small = _bomb_random.choice([0, 1, 2])
+        self._big = _bomb_random.choice([64, 256, 4096])
+
+    def __len__(self):
+        self._calls += 1
+        return self._small if self._calls <= 1 else self._big
+
+    def __getitem__(self, index):
+        if not isinstance(index, int) or index >= self._big or index < 0:
+            raise IndexError(index)
+        return index
+
+    def __iter__(self):
+        return iter(range(self._big))
+
+
+class MutatingHash:
+    """__hash__ is constant for a few calls -- long enough to be stored as a dict/set key -- then
+    starts returning different values, violating hash-constancy while the object is a live key.
+    A C hash table that cached the original hash now finds the key in the wrong bucket (lookup
+    miss / KeyError, or a corrupted probe sequence in a less-hardened C-extension mapping)."""
+
+    def __init__(self):
+        self._calls = 0
+        self._delay = _bomb_random.randint(1, 3)
+
+    def __hash__(self):
+        self._calls += 1
+        if self._calls <= self._delay:
+            return 0
+        return _bomb_random.randrange(1 << 60)
+
+    def __eq__(self, other):
+        return self is other
+
+
+class TypeFlipIterator:
+    """Yields a consistent type (ints) for a few items, then flips to an incompatible type
+    (str / None / float / a bare object) mid-stream, feeding C reducers that may specialize on
+    the first element's type -- max() / min() / sum() / sorted() / bytes() / b"".join() / heapq --
+    a wrong type after the fast-path has committed."""
+
+    def __init__(self):
+        self._i = 0
+        self._n = _bomb_random.randint(2, 8)
+        self._flip = _bomb_random.choice(["str", "none", "float", "obj"])
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._i += 1
+        if self._i > self._n + 4:
+            raise StopIteration
+        if self._i <= self._n:
+            return self._i  # a consistent run of ints
+        return {"str": "x", "none": None, "float": 1.5, "obj": object()}[self._flip]
+
+
 # --- SuperBomb: every protocol slot is a landmine ----------------------------------------
 #
 # Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
@@ -556,6 +633,11 @@ BOMB_CLASS_NAMES = [
     "ReentrantClearList",
     "ReentrantClearDict",
     "MutatingIterable",
+    # Stateful / lying bombs: a slot SUCCEEDS but returns an inconsistent answer across calls
+    # (__len__ grows, __hash__ changes while keyed, iterator flips element type mid-stream).
+    "GrowingLen",
+    "MutatingHash",
+    "TypeFlipIterator",
 ]
 
 # Names the argument generator passes *as the class object itself* (not instantiated) -- the

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -722,6 +722,83 @@ class MutatingIterable:
         return _gen()
 
 
+# --- Stateful / lying bombs: the protocol slot SUCCEEDS but returns an INCONSISTENT answer ---
+#
+# The exception bombs raise; the reentrant bombs mutate a container. These lie *quietly*: a slot
+# returns a value that is internally inconsistent across calls (or with a sibling slot), so C
+# code that reads it once to size/plan and then trusts it -- preallocating a buffer from __len__,
+# storing under a cached __hash__, specializing on the first element's type -- writes past the
+# buffer, lands in the wrong hash bucket, or trips a type fast-path. The lie is DELAYED (like the
+# other bombs) so the C routine has already committed to the first answer when it changes.
+
+
+class GrowingLen:
+    """__len__ under-reports on its first read (small presize) then reports a much larger size,
+    while __getitem__ / __iter__ yield up to the larger count. C code that presizes a buffer from
+    the first __len__ and then fills by index/iteration can write past it (the __len__-lies-small
+    buffer-preallocation class; complements LyingLen, which only over-reports)."""
+
+    def __init__(self):
+        self._calls = 0
+        self._small = _bomb_random.choice([0, 1, 2])
+        self._big = _bomb_random.choice([64, 256, 4096])
+
+    def __len__(self):
+        self._calls += 1
+        return self._small if self._calls <= 1 else self._big
+
+    def __getitem__(self, index):
+        if not isinstance(index, int) or index >= self._big or index < 0:
+            raise IndexError(index)
+        return index
+
+    def __iter__(self):
+        return iter(range(self._big))
+
+
+class MutatingHash:
+    """__hash__ is constant for a few calls -- long enough to be stored as a dict/set key -- then
+    starts returning different values, violating hash-constancy while the object is a live key.
+    A C hash table that cached the original hash now finds the key in the wrong bucket (lookup
+    miss / KeyError, or a corrupted probe sequence in a less-hardened C-extension mapping)."""
+
+    def __init__(self):
+        self._calls = 0
+        self._delay = _bomb_random.randint(1, 3)
+
+    def __hash__(self):
+        self._calls += 1
+        if self._calls <= self._delay:
+            return 0
+        return _bomb_random.randrange(1 << 60)
+
+    def __eq__(self, other):
+        return self is other
+
+
+class TypeFlipIterator:
+    """Yields a consistent type (ints) for a few items, then flips to an incompatible type
+    (str / None / float / a bare object) mid-stream, feeding C reducers that may specialize on
+    the first element's type -- max() / min() / sum() / sorted() / bytes() / b"".join() / heapq --
+    a wrong type after the fast-path has committed."""
+
+    def __init__(self):
+        self._i = 0
+        self._n = _bomb_random.randint(2, 8)
+        self._flip = _bomb_random.choice(["str", "none", "float", "obj"])
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._i += 1
+        if self._i > self._n + 4:
+            raise StopIteration
+        if self._i <= self._n:
+            return self._i  # a consistent run of ints
+        return {"str": "x", "none": None, "float": 1.5, "obj": object()}[self._flip]
+
+
 # --- SuperBomb: every protocol slot is a landmine ----------------------------------------
 #
 # Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
@@ -997,6 +1074,11 @@ BOMB_CLASS_NAMES = [
     "ReentrantClearList",
     "ReentrantClearDict",
     "MutatingIterable",
+    # Stateful / lying bombs: a slot SUCCEEDS but returns an inconsistent answer across calls
+    # (__len__ grows, __hash__ changes while keyed, iterator flips element type mid-stream).
+    "GrowingLen",
+    "MutatingHash",
+    "TypeFlipIterator",
 ]
 
 # Names the argument generator passes *as the class object itself* (not instantiated) -- the

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -284,5 +284,57 @@ class TestReentrantMutationBombs(unittest.TestCase):
             self.assertIn(name, B.BOMB_CLASS_NAMES)
 
 
+class TestStatefulLyingBombs(unittest.TestCase):
+    """The stateful/lying family: a slot succeeds but returns an inconsistent answer across
+    calls (grows / changes / flips type), rather than raising or mutating a container."""
+
+    def test_growing_len_underreports_then_grows(self):
+        gl = B.GrowingLen()
+        first = len(gl)
+        second = len(gl)
+        self.assertGreater(second, first)  # first read small (presize), then grows
+        # __getitem__ / __iter__ yield up to the grown count (past a buffer sized from `first`)
+        self.assertEqual(len(list(iter(gl))), second)
+        self.assertEqual(gl[0], 0)
+        with self.assertRaises(IndexError):
+            gl[second]
+
+    def test_mutating_hash_stable_then_changes(self):
+        mh = B.MutatingHash()
+        mh._delay, mh._calls = 2, 0
+        h1 = hash(mh)  # call 1
+        h2 = hash(mh)  # call 2 -- still stable, so it can be stored as a key
+        self.assertEqual(h1, h2)
+        # after the delay the hash starts changing (violating hash-constancy while keyed)
+        later = {hash(mh) for _ in range(20)}
+        self.assertTrue(any(h != h1 for h in later))
+        # equal only to itself, so a dict lookup with a changed hash misses its own key
+        self.assertTrue(mh == mh)
+        self.assertFalse(mh == B.MutatingHash())
+
+    def test_type_flip_iterator_flips_off_first_type(self):
+        # a consistent run of ints, then an incompatible type mid-stream
+        seen = set()
+        for _ in range(50):
+            kinds = [type(v).__name__ for v in B.TypeFlipIterator()]
+            self.assertEqual(kinds[0], "int")  # starts consistent
+            seen.update(kinds)
+        self.assertTrue(seen - {"int"})  # at least one non-int flip type appears
+        # feeding a C reducer a run of ints then a str raises (caught by the harness), not hangs
+        with self.assertRaises(TypeError):
+            max(_all_ints_then_str())
+
+    def test_stateful_lying_bombs_registered(self):
+        for name in ("GrowingLen", "MutatingHash", "TypeFlipIterator"):
+            self.assertIn(name, B.BOMB_CLASS_NAMES)
+
+
+def _all_ints_then_str():
+    # a deterministic type-flip stream for the reducer assertion above
+    yield 1
+    yield 2
+    yield "x"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

A third bomb family in `fusil/python/samples/bomb_objects.py`, complementing:
- the **exception bombs** (a slot *raises*), and
- the **reentrant bombs** (a slot *mutates* its container).

These **lie quietly**: a protocol slot *succeeds* but returns a value that is inconsistent across calls (or with a sibling slot), so C code that reads it once to size/plan and then trusts it writes past a buffer, lands in the wrong hash bucket, or trips a type fast-path. The lie is **delayed** (like the other bombs) so the C routine has already committed to the first answer when it changes.

## New bombs (self-contained, no-required-arg, arg-injectable via `BOMB_CLASS_NAMES`)

- **`GrowingLen`** — `__len__` under-reports on its first read (small presize) then reports a much larger size, while `__getitem__`/`__iter__` yield up to the larger count. C code that presizes a buffer from the first `__len__` and fills by index/iteration can write past it. (Complements `LyingLen`, which only *over*-reports.)
- **`MutatingHash`** — `__hash__` is constant for a few calls (long enough to be stored as a dict/set key) then returns different values, violating hash-constancy while the object is a live key — wrong-bucket lookup / corrupted probe sequence in a less-hardened C-extension mapping.
- **`TypeFlipIterator`** — yields a consistent run of ints then flips to an incompatible type (`str`/`None`/`float`/`object`) mid-stream, feeding C reducers that may specialize on the first element's type (`max`/`min`/`sum`/`sorted`/`bytes`/`join`/`heapq`).

They join the existing spray pool through `genBombObject` (no separate flag) — armed like every other bomb, firing only when a target C op reads the relevant slot.

## Provenance

Idea harvested from studying lafleur's mutators (`StatefulLen`/`UnstableHash`/`StatefulIter`, `IncompatibleTypeIterator`); implemented natively for fusil's argument-injection model.

## Testing

- `tests/python/test_bomb_objects.py::TestStatefulLyingBombs` — the grow/change/flip mechanics + registry wiring.
- Golden snapshot regenerated (`bomb_objects.py` is embedded verbatim into every generated script).
- Full suite green (1215 tests); `ruff check` + `ruff format --check` clean over the CI scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d