### PR TITLE
--sys-monitoring: add PEP 669 hostile-callback fuzzing mode

### DIFF
--- a/doc/python-fuzzer.md
+++ b/doc/python-fuzzer.md
@@ -147,6 +147,23 @@ optionally prunes the ~96%-duplicate crashes as they happen.
 Full details: [`oom-fuzzing.md`](oom-fuzzing.md), [`oom-sequences.md`](oom-sequences.md),
 [`oom-dedup-plan.md`](oom-dedup-plan.md).
 
+## sys.monitoring hostile-callback fuzzing — `--sys-monitoring`
+
+Stresses the PEP 669 (`sys.monitoring`) instrumentation / event-dispatch C machinery — a complex
+state machine that is lightly fuzzed. `WritePythonCode._write_monitoring_region` emits a
+self-contained region (the whole session's logic, like `--new-uninit`): it acquires a monitoring
+tool id, registers a **hostile callback** for a rotating subset of events, instruments a generic
+loop plus the target module's own functions, and runs them so events fire. The callback mostly
+returns normally but every few calls detonates — it raises, returns the `DISABLE` sentinel or
+junk, or **re-entrantly mutates the monitoring state** (`set_events` / `register_callback` /
+`free_tool_id` / `restart_events`) from *inside* the dispatcher. A **second tool** statically
+instruments the same code so multi-tool dispatch (the most fragile area) is exercised too. The
+run is bounded (small targets, few rounds) so per-line/per-instruction events can't hang, and
+every step is guarded so one bad slot never stops the sweep; the tool ids are released at the end.
+Opt-in (`store_true`, default off; in the "generic hostile modes" group). On current CPython this
+runs clean (no immediate find), but it is an armed probe of an under-fuzzed surface. Tests:
+`test_monitoring_generation.py`.
+
 ## JIT fuzzing — moved to lafleur
 
 fusil no longer fuzzes the Tier-2 JIT. The `fusil/python/jit/` subsystem and the `--jit-*`
@@ -191,6 +208,7 @@ PYTHONPATH=$PWD python fuzzers/fusil-python-threaded --unsafe [options]
 #   --only-generate          write source.py without executing it
 #   --deep-dive              recursively fuzz method return values (off by default)
 #   --oom-fuzz / --oom-seq   OOM (allocation-failure) injection
+#   --sys-monitoring         PEP 669 sys.monitoring hostile-callback stress mode
 #   --oom-dedup-catalog F    in-loop crash dedup/labeling vs a known-sites snapshot
 #   --no-memory-limit        don't apply RLIMIT_AS (implied for ASan targets)
 ```

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -624,6 +624,18 @@ class Fuzzer(Application):
             default=False,
         )
         altinterp_options.add_option(
+            "--sys-monitoring",
+            help="Emit the sys.monitoring (PEP 669) hostile-callback region: acquire a tool id, "
+            "register HOSTILE callbacks (that raise, return the DISABLE sentinel or junk, and "
+            "re-entrantly mutate the monitoring state -- set_events / register_callback / "
+            "free_tool_id -- from INSIDE a callback) for a rotating subset of events, instrument "
+            "generic + target-module code, then run it so the events fire mid-hostile-callback. "
+            "Stresses the instrumentation / event-dispatch C machinery, a fragile and lightly "
+            "fuzzed surface. Default: False",
+            action="store_true",
+            default=False,
+        )
+        altinterp_options.add_option(
             "--rustpython-dedup-catalog",
             help="Path to a known_panics.tsv snapshot (from the rustpython-findings catalog). "
             "In-loop dedupe: each crash is reduced to its panic-site signature "

--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -784,6 +784,13 @@ class WritePythonCode(WriteCode):
             self._write_new_uninit_region()
             return
 
+        # --sys-monitoring mode: stress the sys.monitoring (PEP 669) instrumentation / event-
+        # dispatch C machinery with HOSTILE callbacks (raise / DISABLE / junk / re-entrant
+        # set_events / register_callback / free_tool_id from inside a callback). Self-contained.
+        if getattr(self.options, "sys_monitoring", False):
+            self._write_monitoring_region()
+            return
+
         self._write_function_fuzzing_loop()
         self.emptyLine()
 
@@ -1709,6 +1716,237 @@ class WritePythonCode(WriteCode):
             """,
         )
         self.write_print_to_stderr(0, '"[TSAN] concurrency-stress region complete"')
+        self.emptyLine()
+
+    def _write_monitoring_region(self) -> None:
+        """Emit the --sys-monitoring PEP-669 hostile-callback region.
+
+        Acquire a monitoring tool id, register HOSTILE callbacks (that raise, return the DISABLE
+        sentinel or junk, and re-entrantly mutate the monitoring state -- set_events /
+        register_callback / free_tool_id / restart_events -- from INSIDE a callback) for a
+        rotating subset of events, instrument a generic function plus the target module's own
+        functions, and run them so the events fire mid-hostile-callback. Stresses the
+        instrumentation / event-dispatch C machinery (a fragile, lightly-fuzzed surface).
+        Everything is wrapped so one bad slot never stops the sweep; the run is bounded (small
+        targets, few rounds) so the per-line/per-instruction events can't hang.
+        """
+        self.emptyLine()
+        self.write(0, "# --- sys.monitoring hostile-callback region (--sys-monitoring) ---")
+        self.write(0, "import sys as _mon_sys")
+        self.write(0, "_MON_UNSAFE = frozenset(%r)" % (tuple(sorted(TSAN_UNSAFE_CALLS)),))
+        self.write_print_to_stderr(
+            0, '"[MONITORING] entering sys.monitoring hostile-callback region"'
+        )
+        self.write_block(
+            0,
+            """
+            _mon = getattr(_mon_sys, "monitoring", None)
+
+            def _mon_run():
+                _mon_calls = [0]
+                # Pick a tool id, freeing it first in case a previous region left it registered.
+                _TID = 3
+                for _cand in (3, 4, 2, 1, 0, 5):
+                    try:
+                        try:
+                            _mon.free_tool_id(_cand)
+                        except BaseException:
+                            pass
+                        _mon.use_tool_id(_cand, "fusil")
+                        _TID = _cand
+                        break
+                    except BaseException:
+                        continue
+
+                _EV = _mon.events
+
+                def _evbit(_name):
+                    return getattr(_EV, _name, 0)
+
+                # Events that may be set GLOBALLY (set_events); LINE/INSTRUCTION/BRANCH*/JUMP are
+                # local-only and raise if set globally -- that validation path is itself a target,
+                # so they still go through set_local_events (guarded) below.
+                _GLOBAL_NAMES = ("PY_START", "PY_RESUME", "PY_RETURN", "PY_YIELD", "CALL",
+                                 "RAISE", "EXCEPTION_HANDLED", "PY_UNWIND", "PY_THROW",
+                                 "STOP_ITERATION", "RERAISE", "C_RETURN", "C_RAISE")
+                _LOCAL_NAMES = _GLOBAL_NAMES + ("LINE", "INSTRUCTION", "JUMP", "BRANCH",
+                                                "BRANCH_LEFT", "BRANCH_RIGHT")
+                _global_evs = [(_n, _evbit(_n)) for _n in _GLOBAL_NAMES if _evbit(_n)]
+                _local_evs = [(_n, _evbit(_n)) for _n in _LOCAL_NAMES if _evbit(_n)]
+
+                # The hostile callback: mostly returns None (event fires normally), but every few
+                # calls it detonates -- raise, DISABLE, junk return, or a RE-ENTRANT mutation of
+                # the monitoring state while the C dispatcher is still mid-callback.
+                def _mon_cb(*_a):
+                    _mon_calls[0] += 1
+                    _r = _mon_calls[0] % 11
+                    if _r == 0:
+                        raise ValueError("fusil monitoring callback bomb")
+                    if _r == 1:
+                        return _mon.DISABLE
+                    if _r == 2:
+                        return "fusil junk return"
+                    if _r == 3:
+                        try:
+                            _mon.set_events(_TID, 0)
+                        except BaseException:
+                            pass
+                    elif _r == 4:
+                        try:
+                            _mon.register_callback(_TID, _evbit("LINE"), _mon_cb)
+                        except BaseException:
+                            pass
+                    elif _r == 5:
+                        # very hostile: drop + re-acquire the tool id from inside dispatch
+                        try:
+                            _mon.free_tool_id(_TID)
+                            _mon.use_tool_id(_TID, "fusil")
+                        except BaseException:
+                            pass
+                    elif _r == 6:
+                        try:
+                            _mon.restart_events()
+                        except BaseException:
+                            pass
+                    return None
+
+                # Instrumented targets: a generic loop that raises/handles (fires PY_START/RETURN/
+                # RAISE/EXCEPTION_HANDLED/LINE/...), plus the target module's own functions (real
+                # C-calling code -> CALL/C_RETURN/C_RAISE events).
+                def _mon_target(_n):
+                    _s = 0
+                    for _i in range(_n):
+                        _s += _i
+                        if _i % 4 == 0:
+                            try:
+                                raise ValueError(_i)
+                            except ValueError:
+                                pass
+                    return _s
+
+                _mon_targets = [_mon_target]
+                for _name in list(dir(fuzz_target_module)):
+                    if _name.startswith("_") or _name in _MON_UNSAFE:
+                        continue
+                    try:
+                        _obj = getattr(fuzz_target_module, _name)
+                    except BaseException:
+                        continue
+                    if callable(_obj) and hasattr(_obj, "__code__"):
+                        _mon_targets.append(_obj)
+                    if len(_mon_targets) >= 8:
+                        break
+
+                # A SECOND tool statically instrumenting the same code: multi-tool dispatch (two
+                # tools' callbacks + DISABLE state on one location) is the most fragile monitoring
+                # area, exercised here while tool _TID churns its events/callbacks below.
+                _TID2 = -1
+                for _cand in (4, 2, 1, 0, 5):
+                    if _cand == _TID:
+                        continue
+                    try:
+                        try:
+                            _mon.free_tool_id(_cand)
+                        except BaseException:
+                            pass
+                        _mon.use_tool_id(_cand, "fusil2")
+                        _TID2 = _cand
+                        break
+                    except BaseException:
+                        continue
+                if _TID2 >= 0:
+                    _gmask2 = 0
+                    for _n, _bit in _global_evs:
+                        _gmask2 |= _bit
+                    for _n, _bit in _local_evs:
+                        try:
+                            _mon.register_callback(_TID2, _bit, _mon_cb)
+                        except BaseException:
+                            pass
+                    try:
+                        _mon.set_events(_TID2, _gmask2)
+                    except BaseException:
+                        pass
+                    for _fn in _mon_targets:
+                        try:
+                            _mon.set_local_events(_TID2, _fn.__code__, _gmask2)
+                        except BaseException:
+                            pass
+
+                for _round in range(200):
+                    try:
+                        # (1) register the hostile callback for a rotating event subset
+                        for _n, _bit in _local_evs:
+                            if (_round + len(_n)) % 3:
+                                try:
+                                    _mon.register_callback(_TID, _bit, _mon_cb)
+                                except BaseException:
+                                    pass
+                        # (2) set a rotating GLOBAL event mask
+                        _gmask = 0
+                        for _n, _bit in _global_evs:
+                            if (_round + _bit) % 2:
+                                _gmask |= _bit
+                        try:
+                            _mon.set_events(_TID, _gmask)
+                        except BaseException:
+                            pass
+                        # (3) set LOCAL events (incl. LINE/INSTRUCTION) on each target's code
+                        _lmask = 0
+                        for _n, _bit in _local_evs:
+                            if (_round + _bit) % 3 == 0:
+                                _lmask |= _bit
+                        for _fn in _mon_targets:
+                            try:
+                                _mon.set_local_events(_TID, _fn.__code__, _lmask)
+                            except BaseException:
+                                pass
+                        # (4) run instrumented code -> events fire -> hostile callbacks dispatch
+                        for _fn in _mon_targets:
+                            try:
+                                _fn(12) if _fn is _mon_target else _fn()
+                            except BaseException:
+                                pass
+                        # (5) tear down this round (the callback may already have)
+                        try:
+                            _mon.set_events(_TID, 0)
+                        except BaseException:
+                            pass
+                    except BaseException:
+                        pass
+
+                # Final cleanup: clear all events and release both tool ids.
+                try:
+                    for _fn in _mon_targets:
+                        for _tid in (_TID, _TID2):
+                            if _tid < 0:
+                                continue
+                            try:
+                                _mon.set_local_events(_tid, _fn.__code__, 0)
+                            except BaseException:
+                                pass
+                    for _tid in (_TID, _TID2):
+                        if _tid < 0:
+                            continue
+                        try:
+                            _mon.set_events(_tid, 0)
+                            _mon.free_tool_id(_tid)
+                        except BaseException:
+                            pass
+                except BaseException:
+                    pass
+
+            if _mon is None:
+                print("[MONITORING] sys.monitoring unavailable (need CPython 3.12+); skipping",
+                      file=stderr)
+            else:
+                try:
+                    _mon_run()
+                except BaseException as _mon_e:
+                    print("[MONITORING] region error: %r" % (_mon_e,), file=stderr)
+            """,
+        )
+        self.write_print_to_stderr(0, '"[MONITORING] sys.monitoring region complete"')
         self.emptyLine()
 
     def _write_function_fuzzing_loop(self) -> None:

--- a/tests/python/test_monitoring_generation.py
+++ b/tests/python/test_monitoring_generation.py
@@ -1,0 +1,98 @@
+"""Tests for the --sys-monitoring (PEP 669) hostile-callback region code generation.
+
+Pure generation tests (no target execution): build an options object with --sys-monitoring on,
+generate a script, and assert the emitted region is present, valid Python, and self-contained
+(guards sys.monitoring, acquires + releases tool ids, registers hostile callbacks, sets global +
+local events, and runs instrumented targets) -- and that none of it appears when the mode is off.
+Mirrors test_tsan_generation / test_oom_fuzz.
+"""
+
+import ast
+import os
+import sys
+import tempfile
+import unittest
+from types import ModuleType
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, "..", ".."))  # repo root -> import fusil.*
+sys.path.insert(0, os.path.join(SCRIPT_DIR, ".."))  # tests/ -> import python._test_options
+
+from unittest.mock import MagicMock
+
+from python._test_options import make_test_options
+
+from fusil.python.write_python_code import WritePythonCode
+
+
+def _module():
+    mod = ModuleType("monmod")
+
+    def helper(*a):
+        return a
+
+    mod.helper = helper
+    return mod
+
+
+def _generate(**overrides):
+    o = make_test_options(no_numpy=True, no_tstrings=True, **overrides)
+    parent = MagicMock()
+    parent.options = o
+    parent.filenames = ["/bin/sh"]
+    fd, path = tempfile.mkstemp(suffix="_mon_test.py")
+    os.close(fd)
+    try:
+        writer = WritePythonCode(
+            parent, path, _module(), "monmod", threads=False, _async=False, plugin_manager=None
+        )
+        writer.generate_fuzzing_script()
+        with open(path) as fp:
+            return fp.read()
+    finally:
+        os.unlink(path)
+
+
+class TestMonitoringGeneration(unittest.TestCase):
+    def test_off_by_default(self):
+        src = _generate()
+        self.assertNotIn("sys.monitoring hostile-callback region", src)
+        self.assertNotIn("_mon_run", src)
+
+    def test_region_emitted_when_enabled(self):
+        src = _generate(sys_monitoring=True)
+        ast.parse(src)  # valid Python
+        self.assertIn("# --- sys.monitoring hostile-callback region (--sys-monitoring) ---", src)
+        self.assertIn("import sys as _mon_sys", src)
+        # guarded against interpreters without sys.monitoring
+        self.assertIn('_mon = getattr(_mon_sys, "monitoring", None)', src)
+        self.assertIn("if _mon is None:", src)
+        self.assertIn("def _mon_run():", src)
+        self.assertIn("[MONITORING] sys.monitoring region complete", src)
+
+    def test_hostile_callback_and_lifecycle_emitted(self):
+        src = _generate(sys_monitoring=True)
+        # tool-id lifecycle
+        self.assertIn("_mon.use_tool_id(", src)
+        self.assertIn("_mon.free_tool_id(", src)
+        # hostile callback: raise / DISABLE / junk / re-entrant state mutation from inside dispatch
+        self.assertIn("def _mon_cb(", src)
+        self.assertIn("raise ValueError(", src)
+        self.assertIn("return _mon.DISABLE", src)
+        self.assertIn("_mon.register_callback(", src)
+        self.assertIn("_mon.restart_events()", src)
+        # events are set globally + locally on instrumented target code
+        self.assertIn("_mon.set_events(", src)
+        self.assertIn("_mon.set_local_events(", src)
+        # the second tool (multi-tool dispatch is the fragile area)
+        self.assertIn("_TID2", src)
+        self.assertIn('_mon.use_tool_id(_cand, "fusil2")', src)
+
+    def test_targets_include_generic_and_module_functions(self):
+        src = _generate(sys_monitoring=True)
+        self.assertIn("def _mon_target(", src)  # generic instrumented loop
+        self.assertIn("for _name in list(dir(fuzz_target_module)):", src)  # module's own functions
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_oom_fuzz.py
+++ b/tests/python/test_oom_fuzz.py
@@ -50,6 +50,7 @@ def _make_options(oom_fuzz, oom_verbose=False):
     # Alt-interpreter generic modes OFF too (same MagicMock-is-truthy divert hazard as tsan).
     o.concurrency_stress = False
     o.new_uninit = False
+    o.sys_monitoring = False  # opt-in mode; a bare MagicMock attr would divert generation
     o.test_private = False
     o.no_numpy = True
     o.no_tstrings = True


### PR DESCRIPTION
## What

A new self-contained fuzzing **mode** (like `--new-uninit`) that stresses the `sys.monitoring` (PEP 669) instrumentation / event-dispatch C machinery — a complex, lightly-fuzzed state machine.

## How

`WritePythonCode._write_monitoring_region` emits the whole session's logic (gated in `_write_main_fuzzing_logic`, returns early):

- acquire a monitoring **tool id**;
- register a **hostile callback** for a rotating subset of events — the callback mostly returns normally but every few calls **detonates**: raises, returns the `DISABLE` sentinel or junk, or **re-entrantly mutates the monitoring state** (`set_events` / `register_callback` / `free_tool_id` / `restart_events`) from *inside* the dispatcher;
- instrument a generic loop **plus the target module's own functions**, and run them so events fire;
- a **second tool** statically instruments the same code so **multi-tool dispatch** (the most fragile area) is exercised too;
- the run is bounded (small targets, few rounds) so per-line/per-instruction events can't hang; every step is guarded; both tool ids are released at the end.

## Status

Opt-in (`--sys-monitoring`, `store_true`, default off; "generic hostile modes" group). On current CPython 3.16.0a0 debug/ASan builds this **runs clean (no immediate find)** — but unlike a provably-hardened surface, `sys.monitoring` is a complex, historically-buggy state machine, so this is an **armed probe** with latent value across builds/versions/alt-interpreters and future regressions.

## Compatibility

- Default output unchanged (opt-in mode, `make_test_options`-based tests get the real `sys_monitoring=False` default; the non-tsan golden is unaffected).
- `test_oom_fuzz`'s `_make_options` (a bare MagicMock) gains `sys_monitoring=False` — the same opt-in-mode auto-vivify guard the other harnesses use (a MagicMock attr is truthy and would otherwise divert generation).

## Testing

- `tests/python/test_monitoring_generation.py` — region emitted / off-by-default, hostile-callback + tool lifecycle, generic + module-function targets.
- Runtime-verified on release + debug + ASan builds (runs clean, no hang, restores monitoring state).
- Full suite green (1216 tests); `ruff check` + `ruff format --check` clean.
- Doc: `doc/python-fuzzer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d