### PR TITLE
bombs: add lying-equality family (hashable + storable, but == / identity lie)

### DIFF
--- a/fusil/python/samples/bomb_objects.py
+++ b/fusil/python/samples/bomb_objects.py
@@ -358,6 +358,52 @@ class TypeFlipIterator:
         return {"str": "x", "none": None, "float": 1.5, "obj": object()}[self._flip]
 
 
+# --- Lying-equality bombs: hashable + storable, but == / identity lie -------------------------
+#
+# The stateful/lying bombs above lie about size/type; these lie about EQUALITY. They are cheap
+# to hash and store (a stable, colliding hash) so a C container accepts them as a key/member,
+# but their __eq__ then contradicts identity -- claiming equal to a value they are not, or giving
+# a different answer on each call. C code that assumes `a == b` implies interchangeability, caches
+# a slot after one comparison, or maintains its own hash table (a C-extension mapping) can probe
+# the wrong bucket, double-store, or read a stale entry. On core dict/set this desyncs values;
+# in a less-hardened C-extension container it can corrupt the table.
+
+
+class LyingEq:
+    """Hashes like the int ``1`` (a deliberate collision) and claims __eq__ equality with 1 and
+    every small int, and __index__/__int__ return 1 -- yet it is a distinct object that is not 1.
+    Used as a dict key / set member / sequence index it desyncs "equal-but-not-identical": stored
+    and found under hash(1), but not actually interchangeable with the ints it claims to equal."""
+
+    def __eq__(self, other):
+        return other == 1 or (isinstance(other, int) and -5 <= other <= 256)
+
+    def __hash__(self):
+        return hash(1)
+
+    def __index__(self):
+        return 1
+
+    __int__ = __index__
+
+
+class ShiftyEq:
+    """__eq__ flips its answer every few calls, so a single C routine that compares this object
+    more than once (insert-then-lookup in a hash table, a membership scan, a sort) sees the
+    equality relation change underneath it. __hash__ stays constant so it remains storable."""
+
+    def __init__(self):
+        self._calls = 0
+        self._period = _bomb_random.randint(2, 4)
+
+    def __eq__(self, other):
+        self._calls += 1
+        return (self._calls // self._period) % 2 == 0
+
+    def __hash__(self):
+        return 0
+
+
 # --- SuperBomb: every protocol slot is a landmine ----------------------------------------
 #
 # Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
@@ -638,6 +684,10 @@ BOMB_CLASS_NAMES = [
     "GrowingLen",
     "MutatingHash",
     "TypeFlipIterator",
+    # Lying-equality bombs: hashable + storable, but __eq__ / identity lie (claim equal to a
+    # value they are not, or flip the answer on each call) -- desyncs C hash tables.
+    "LyingEq",
+    "ShiftyEq",
 ]
 
 # Names the argument generator passes *as the class object itself* (not instantiated) -- the

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -799,6 +799,52 @@ class TypeFlipIterator:
         return {"str": "x", "none": None, "float": 1.5, "obj": object()}[self._flip]
 
 
+# --- Lying-equality bombs: hashable + storable, but == / identity lie -------------------------
+#
+# The stateful/lying bombs above lie about size/type; these lie about EQUALITY. They are cheap
+# to hash and store (a stable, colliding hash) so a C container accepts them as a key/member,
+# but their __eq__ then contradicts identity -- claiming equal to a value they are not, or giving
+# a different answer on each call. C code that assumes `a == b` implies interchangeability, caches
+# a slot after one comparison, or maintains its own hash table (a C-extension mapping) can probe
+# the wrong bucket, double-store, or read a stale entry. On core dict/set this desyncs values;
+# in a less-hardened C-extension container it can corrupt the table.
+
+
+class LyingEq:
+    """Hashes like the int ``1`` (a deliberate collision) and claims __eq__ equality with 1 and
+    every small int, and __index__/__int__ return 1 -- yet it is a distinct object that is not 1.
+    Used as a dict key / set member / sequence index it desyncs "equal-but-not-identical": stored
+    and found under hash(1), but not actually interchangeable with the ints it claims to equal."""
+
+    def __eq__(self, other):
+        return other == 1 or (isinstance(other, int) and -5 <= other <= 256)
+
+    def __hash__(self):
+        return hash(1)
+
+    def __index__(self):
+        return 1
+
+    __int__ = __index__
+
+
+class ShiftyEq:
+    """__eq__ flips its answer every few calls, so a single C routine that compares this object
+    more than once (insert-then-lookup in a hash table, a membership scan, a sort) sees the
+    equality relation change underneath it. __hash__ stays constant so it remains storable."""
+
+    def __init__(self):
+        self._calls = 0
+        self._period = _bomb_random.randint(2, 4)
+
+    def __eq__(self, other):
+        self._calls += 1
+        return (self._calls // self._period) % 2 == 0
+
+    def __hash__(self):
+        return 0
+
+
 # --- SuperBomb: every protocol slot is a landmine ----------------------------------------
 #
 # Spray-and-pray. A metaclass installs a raising method for a broad set of dunders; each one
@@ -1079,6 +1125,10 @@ BOMB_CLASS_NAMES = [
     "GrowingLen",
     "MutatingHash",
     "TypeFlipIterator",
+    # Lying-equality bombs: hashable + storable, but __eq__ / identity lie (claim equal to a
+    # value they are not, or flip the answer on each call) -- desyncs C hash tables.
+    "LyingEq",
+    "ShiftyEq",
 ]
 
 # Names the argument generator passes *as the class object itself* (not instantiated) -- the

--- a/tests/python/test_bomb_objects.py
+++ b/tests/python/test_bomb_objects.py
@@ -336,5 +336,37 @@ def _all_ints_then_str():
     yield "x"
 
 
+class TestLyingEqualityBombs(unittest.TestCase):
+    """The lying-equality family: hashable + storable, but __eq__ / identity contradict it."""
+
+    def test_lying_eq_collides_and_lies_equal(self):
+        le = B.LyingEq()
+        self.assertEqual(hash(le), hash(1))  # deliberate hash collision with 1
+        self.assertTrue(le == 1)  # claims equality with 1 ...
+        self.assertTrue(le == 256)  # ... and with small ints
+        self.assertFalse(le == 999)  # but not arbitrary ints
+        self.assertEqual(le.__index__(), 1)  # index/int report 1 ...
+        self.assertIsNot(le, 1)  # ... yet it is not 1 (equal-but-not-identical desync)
+
+    def test_lying_eq_is_storable_as_key(self):
+        # cheap stable hash -> a container accepts it as a key/member without error
+        d = {B.LyingEq(): "v"}
+        self.assertEqual(len(d), 1)
+        s = {B.LyingEq()}
+        self.assertEqual(len(s), 1)
+
+    def test_shifty_eq_flips_across_calls(self):
+        se = B.ShiftyEq()
+        se._period, se._calls = 2, 0
+        answers = [se == 0 for _ in range(8)]
+        self.assertGreater(len(set(answers)), 1)  # the equality answer changes underneath a caller
+        # hash stays constant so it remains storable while __eq__ lies
+        self.assertEqual(hash(se), hash(B.ShiftyEq()))
+
+    def test_lying_equality_bombs_registered(self):
+        for name in ("LyingEq", "ShiftyEq"):
+            self.assertIn(name, B.BOMB_CLASS_NAMES)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

A fourth bomb family in `fusil/python/samples/bomb_objects.py`. The stateful/lying bombs lie about *size/type*; these lie about **equality**.

They hash cheaply to a stable, **colliding** value so a C container accepts them as a key/member, but their `__eq__` then contradicts identity — claiming equal to a value they are not, or giving a different answer on each call. C code that assumes `a == b` implies interchangeability, caches a slot after one comparison, or maintains its own hash table (a C-extension mapping) can probe the wrong bucket, double-store, or read a stale entry. On core dict/set this desyncs values; in a less-hardened C-extension container it can corrupt the table.

## New bombs (self-contained, no-required-arg, arg-injectable via `BOMB_CLASS_NAMES`)

- **`LyingEq`** — hashes like the int `1` (deliberate collision), claims `__eq__` equality with `1` and every small int, and `__index__`/`__int__` return `1`, yet is a distinct object that **is not** `1` (equal-but-not-identical desync as a dict key / set member / sequence index).
- **`ShiftyEq`** — `__eq__` flips its answer every few calls, so a single C routine that compares it more than once (insert-then-lookup in a hash table, a membership scan, a sort) sees the equality relation change underneath it; `__hash__` stays constant so it remains storable.

They join the existing spray pool through `genBombObject` (no separate flag).

## Provenance

Idea harvested from studying lafleur's mutators (`_Impostor` / `_LyingInt` / `_Shifty`); implemented natively for fusil's argument-injection model.

## Testing

- `tests/python/test_bomb_objects.py::TestLyingEqualityBombs` — the hash-collision + lying-equality + storability mechanics and registry wiring.
- Golden snapshot regenerated (`bomb_objects.py` is embedded verbatim into every generated script).
- Full suite green (1220 tests); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d