### PR TITLE
tsan: eliminate partial-read misclassification (reap before keep-policy + parser backstop)

### DIFF
--- a/fusil/process/create.py
+++ b/fusil/process/create.py
@@ -419,6 +419,30 @@ class CreateProcess(ProjectAgent):
                 self._terminate()
                 sleep(0.500)
 
+    def on_session_stop(self):
+        """Reap the child on the session stop -- BEFORE the keep-policy reads its stdout.
+
+        A watcher can score a session to a stop while the child is still RUNNING -- most
+        importantly a TSan ``WARNING: ThreadSanitizer: data race`` under halt_on_error=0
+        (``--tsan-no-halt``), where the child keeps executing (and printing more reports) after
+        the first race trips the stdout watcher. ``SessionDirectory`` is a ``SessionAgent``, so
+        its ``deinit`` -> ``checkKeepDirectory`` (which runs the in-loop dedupe keep-policy)
+        fires AHEAD of this ``ProjectAgent``'s own ``deinit`` -> ``terminate()``: the keep-policy
+        then reads a HALF-WRITTEN stdout and mis-keys the truncated report (a single-stanza race
+        fabricated into a bogus ``A | A`` self-race). Terminating here, on the stop, runs the
+        grace-drain (``--crash-drain-ms``) so the child finishes its in-flight report and is
+        reaped + flushed before the keep-policy reads.
+
+        Gated to ``--tsan``: it is the mode where a crash-scored stop routinely leaves the child
+        alive (halt_on_error=0). Elsewhere the crash self-terminates the child, so terminate()
+        here is the same no-op reap it already does at ``deinit`` time; ``deinit`` remains the
+        backstop for both (terminate() is idempotent once the child is reaped).
+        """
+        if not getattr(self.options, "tsan", False):
+            return
+        if self.process is not None:
+            self.terminate()
+
     def deinit(self):
         if self.process:
             self.terminate()

--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -745,6 +745,15 @@ class Fuzzer(Application):
         target_cmd = [self.options.python, "-u", "<source.py>"]
         if self.options.tsan:
             target_cmd = ["setarch", "-R"] + target_cmd
+            # Under --tsan the child keeps running (and printing) after the first race trips the
+            # stdout watcher (halt_on_error=0). CreateProcess.on_session_stop terminates it on the
+            # stop -- ahead of the SessionAgent keep-policy that reads stdout -- so it needs a
+            # grace-drain: without one, terminate() SIGKILLs immediately and the kept report is
+            # truncated mid-stanza (a partial single-stanza race then mis-keys as a self-race).
+            # Default it here; an explicit --crash-drain-ms wins (0 was only ever the sensible
+            # default for non-tsan targets, where the crash self-terminates the child).
+            if not self.options.crash_drain_ms:
+                self.options.crash_drain_ms = 5000
         process = PythonProcess(
             project,
             self.options,

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -316,10 +316,17 @@ def _parse_race(text, source_roots=None):
         else:
             i += 1
     if len(stanzas) < 2:
-        # A malformed / single-stanza report: still try to key on whatever we have.
+        # A single-stanza report is INCOMPLETE: TSan always emits >=2 accesses for a data race,
+        # so a lone stanza means the 2nd was lost -- either an unmatched access header (a parser
+        # gap) or, under halt_on_error=0, the report was read mid-flush while the child was still
+        # writing it. Key the one site we DO have against "?" rather than DUPLICATING it into a
+        # symmetric "A | A": a fabricated self-race is indistinguishable from a genuine two-thread
+        # self-race, so it pollutes the catalog and invents spurious "NEW"s (seen live in
+        # fusil-tsan_fleet_17: partial reads mislabeled _Py_TYPE_impl|_Py_TYPE_impl etc.). "? | A"
+        # instead preserves the one site we saw and honestly marks the report as partial.
         if not stanzas:
             return None
-        stanzas.append(stanzas[0])
+        stanzas.append([])
     sites = [_top_site(fr, source_roots) for fr in stanzas[:2]]
     if all(s is None for s in sites):
         return None

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -82,6 +82,22 @@ REPORT_PUBLIC_THREAD_API = "\n".join(
     ]
 )
 
+# A TRUNCATED report: the WARNING + first access stanza are present, but the report was read
+# mid-flush (halt_on_error=0, child still writing) so the SECOND stanza never arrived. A data race
+# always has >=2 accesses, so a lone stanza is incomplete -- it must NOT be duplicated into a
+# fabricated "A | A" self-race (which masquerades as a real two-thread self-race). Seen live in
+# fusil-tsan_fleet_17 (partial reads -> _Py_TYPE_impl|_Py_TYPE_impl, PyMem_RawMalloc|PyMem_RawMalloc).
+REPORT_TRUNCATED_SINGLE_STANZA = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=7)",
+        "  Read of size 8 at 0x7f00 by thread T11:",
+        "    #0 _Py_TYPE_impl /b/./Include/object.h:270:12 (python+0x1) (BuildId: aa)",
+        "    #1 _PyEval_EvalFrameDefault /b/Python/ceval.c:1000:3 (python+0x2) (BuildId: aa)",
+        "    #2 method_vectorcall /b/./Objects/classobject.c:55:12 (python+0x3) (BuildId: aa)",
+        # ...file ends here, mid-flush: no "Previous write" stanza, no SUMMARY.
+    ]
+)
+
 # TSan lowercases the whole SECOND access line, including the `atomic` qualifier: "Previous
 # atomic write". The reader-vs-atomic-writer shape is the single most common race class in the
 # catalog, so failing to match this header dropped the 2nd stanza and (via the len<2 fallback)
@@ -241,6 +257,16 @@ class TestParse(unittest.TestCase):
             " | Modules/_threadmodule.c:rlock_repr",
         )
         self.assertFalse(r["framework"])
+
+    def test_truncated_single_stanza_keys_partial_not_self_pair(self):
+        # A report cut off after the first stanza (mid-flush read) must key as "? | <site>",
+        # NEVER duplicate the lone site into a fabricated "A | A" self-race.
+        r = tsan_dedup.parse_report(REPORT_TRUNCATED_SINGLE_STANZA)
+        self.assertEqual(r["signature"], "? | Include/object.h:_Py_TYPE_impl")
+        self.assertNotEqual(
+            r["signature"],
+            "Include/object.h:_Py_TYPE_impl | Include/object.h:_Py_TYPE_impl",
+        )
 
     def test_access_header_variants_match(self):
         for header in (

--- a/tests/test_process_create.py
+++ b/tests/test_process_create.py
@@ -731,6 +731,38 @@ class TestLive(unittest.TestCase):
         self.assertIn(("session_rename", ("timeout",)), agent.sent)
 
 
+# =================================================================== on_session_stop (reap)
+@unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")
+class TestOnSessionStop(unittest.TestCase):
+    """Under --tsan the child keeps running after the first race trips the stdout watcher, so
+    it must be reaped on the stop -- ahead of the SessionAgent keep-policy that reads stdout --
+    or the keep-policy reads a half-written report. on_session_stop terminates it for --tsan."""
+
+    def test_tsan_running_child_is_terminated_on_stop(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(tsan=True))
+        agent.process = _FakePopen(poll_status=None)  # still running
+        agent._terminated = False
+        agent.terminate = lambda: setattr(agent, "_terminated", True)
+        agent.on_session_stop()
+        self.assertTrue(agent._terminated)
+
+    def test_non_tsan_does_not_terminate_on_stop(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(tsan=False))
+        agent.process = _FakePopen(poll_status=None)
+        agent._terminated = False
+        agent.terminate = lambda: setattr(agent, "_terminated", True)
+        agent.on_session_stop()
+        self.assertFalse(agent._terminated)  # unchanged: terminate() stays at deinit time
+
+    def test_tsan_no_child_is_noop(self):
+        agent, _ = _make(arguments=["python"], name="p", options=_options(tsan=True))
+        agent.process = None
+        agent._terminated = False
+        agent.terminate = lambda: setattr(agent, "_terminated", True)
+        agent.on_session_stop()
+        self.assertFalse(agent._terminated)
+
+
 # =========================================================================== terminate
 @unittest.skipUnless(HAVE_CREATE, "fusil runtime stack (python-ptrace) not importable")
 class TestTerminate(unittest.TestCase):


### PR DESCRIPTION
Eliminates the truncated-TSan-report misclassification seen in `fusil-tsan_fleet_17`, in two parts: **(1) fix the root cause** — the keep-policy reading stdout while the child is still writing — and **(2) harden the parser** for any residual truncation.

## Root cause

`WatchStdout` watches the child's **growing** stdout file. Under `--tsan-no-halt` (`halt_on_error=0`) the first `WARNING: ThreadSanitizer: data race` scores the session to a stop **while the child keeps running and printing more reports**. `SessionDirectory` is a `SessionAgent`, so its `deinit → checkKeepDirectory` (the in-loop dedupe keep-policy that reads stdout) runs at `destroySession`'s `self.session.deactivate()` — **before** the project agents deactivate, i.e. before `CreateProcess.terminate()` reaps the child. The keep-policy therefore read a **half-written** report.

Concretely, 3 dirs in fleet_17 were classified on partial reads (recorded signature ≠ the complete on-disk report):

| dir | recorded (partial) | truth (full report) |
|---|---|---|
| `profiling_sampling_heatmap_collector` | `_Py_TYPE_impl \| _Py_TYPE_impl` | `_mi_memcpy \| _Py_TYPE_impl` |
| `tracemalloc` | `PyMem_RawMalloc \| PyMem_RawMalloc` | `PyMem_RawMalloc \| PyMem_SetAllocator` |
| `asyncio_queues` | stale `SEGV addr=? pc=?` | (gone on full re-parse) |

## Part 1 — eliminate partial reads at the source (`create.py`, `__init__.py`)

`CreateProcess.on_session_stop` now terminates the child **on the stop** (gated to `--tsan`), so it's reaped + flushed before the `SessionAgent` keep-policy runs. `terminate()`'s existing grace-drain lets the child finish its in-flight report first; `--tsan` defaults `--crash-drain-ms` to 5000 (the child finishes its bounded 4×200 op-mix and exits 66 well within that — an explicit `--crash-drain-ms` wins). `deinit()` stays the backstop; `terminate()` is idempotent once the child is reaped, and non-`--tsan` modes are unchanged (their crash self-terminates the child, so the stop already comes after exit).

## Part 2 — parser backstop (`tsan_dedup.py`)

For the residual case where even the drain is overrun (SIGKILL of a slow/hung child mid-report), `_parse_race` no longer **duplicates** a lone stanza into a fabricated `A | A` self-race (indistinguishable from a genuine two-thread self-race like `descr_get_qualname | descr_get_qualname`). A single-stanza report now keys `? | <site>` — preserving the one site and honestly marking it partial. Validated against the real `profiling…heatmap` file: a simulated mid-flush read yields `? | _Py_TYPE_impl` instead of the fabricated self-race.

## Cross-repo contract

`parse_report`'s signature format is imported by `cpython-tsan-findings/scripts/ingest.py`. Part 2 only changes output for **incomplete** reports (previously a fabricated pair) — real catalog signatures are unchanged.

## Test plan
- `python -m unittest tests.test_process_create` — incl. new `TestOnSessionStop` (3 tests)
- `python -m unittest tests.python.test_tsan_dedup` — 47 pass, incl. `test_truncated_single_stanza_keys_partial_not_self_pair`
- `tests.test_session_lifecycle tests.test_process_watch tests.test_process_stdout tests.test_file_watch tests.python.test_tsan_generation` all green
- `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d