### PR TITLE
tsan_dedup: key foreign-library races on the library, not the CPython boundary

### DIFF
--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -19,6 +19,15 @@ across builds, so the signature is function-level; the exact lines are kept for 
 The catalog snapshot (``known_races.tsv``, produced by the sibling cpython-tsan-findings
 catalog) maps each known signature to a race id. Matching is exact on the signature.
 
+If a stanza's innermost real frame is in a FOREIGN system library (``libc.so.6`` /
+``libcrypto.so.3`` / ..., a curated allowlist -- NOT a target ``--tsan-source-root`` ``.so`` or a
+``*.cpython-*.so`` extension), the race happened inside that library and the CPython frame below is
+just the call boundary, so the site keys on the library (``libcrypto.so.3:?`` /
+``libc.so.6:tzset_internal``) instead of collapsing onto a real CPython function (tp_new_wrapper /
+cfunction_vectorcall_NOARGS) -- which used to mint a false signature that needed a per-pairing
+suppression each. A single ``libc.so`` / ``libcrypto.so`` suppression now covers the whole class.
+CPython (and source-root extension) signatures are byte-for-byte unchanged.
+
 ``parse_report`` optionally takes ``source_roots`` (Slice D): a list of ``--tsan-source-root``
 directories. A frame that is NOT CPython source but whose file lives under one of those roots is
 normalised to its path relative to the root (``/build/cereggii/src/atomic_dict.c`` ->
@@ -60,6 +69,11 @@ ACCESS = re.compile(
 # func or the location may be "<null>" (interceptors / non-CPython .so frames); those simply
 # don't yield a CPython source and are skipped by the source match below.
 FRAME = re.compile(r"^\s*#\d+\s+(\S+)\s+(.+?)\s+\(")
+# The module a frame lives in: the `(module+0xoffset)` tail (NOT the trailing `(BuildId: ...)`,
+# which has no `+0x`). Used to tell a FOREIGN-library frame (libcrypto.so.3 / libc.so.6) from the
+# `python` interpreter or a CPython extension (`*.cpython-*.so`). TSan attributes intercepted libc
+# calls (memcpy/free/...) to the `python` module, so the module -- not the func -- is the signal.
+FRAME_MODULE = re.compile(r"\(([^()]+?)\+0x[0-9a-fA-F]+\)")
 # The CPython-source-relative part of a frame location (handles the build dir's leading `./`).
 CPY_SRC = re.compile(
     r"(?:^|/)((?:Objects|Python|Modules|Include|Parser|Programs)/[\w./+-]+\.(?:c|h)):(\d+)"
@@ -194,16 +208,96 @@ def _is_plumbing(func):
     return func in PLUMBING_SKIP or bool(_STACKREF.fullmatch(func))
 
 
+# A FOREIGN SYSTEM library: a race whose innermost real frame is here (libcrypto.so.3, libc.so.6,
+# ...) happened INSIDE that library -- the CPython frame below it is just the call boundary -- so
+# keying on the CPython frame mints a false signature (tp_new_wrapper / cfunction_vectorcall_NOARGS)
+# that collides with real CPython functions and needs a per-pairing suppression. Key on the foreign
+# library instead. This is a CURATED allowlist of system libs that are NEVER a fuzzing target, on
+# purpose: a bare `\.so$` would also swallow a TARGET C extension (a `--tsan-source-root` .so such
+# as `cereggii.so`, or any `*.cpython-*.so`), whose races ARE findings -- those must still resolve
+# via the source-root / CPython path, not be relabeled "foreign". An uncatalogued foreign lib just
+# falls back to today's CPython-boundary collapse (needs a suppression), which is no worse than before.
+_FOREIGN_MODULE = re.compile(
+    r"(?:^|/)(?:lib(?:c|m|crypto|ssl|z|lzma|bz2|pthread|dl|rt|util|resolv|nsl|gcc_s|stdc\+\+|ffi)"
+    r"|ld-linux[\w.-]*)\.so(?:\.\d+)*$"
+)
+# libc/foreign memory + string interceptors: dispatch-like (the real foreign function is one frame
+# down), so prefer a non-interceptor foreign frame for the site when one is present.
+_MEM_INTERCEPTORS = frozenset(
+    {
+        "memcpy",
+        "memmove",
+        "memset",
+        "memcmp",
+        "memchr",
+        "bcmp",
+        "bcopy",
+        "bzero",
+        "malloc",
+        "calloc",
+        "realloc",
+        "free",
+        "reallocarray",
+        "posix_memalign",
+        "aligned_alloc",
+        "strdup",
+        "strndup",
+        "strlen",
+        "strnlen",
+        "strcmp",
+        "strncmp",
+        "strcpy",
+        "strncpy",
+        "strcat",
+        "strncat",
+        "strchr",
+        "strrchr",
+    }
+)
+
+
+def _is_foreign_module(module):
+    """True if ``module`` is a foreign shared library (not the interpreter, not a CPython ext)."""
+    return bool(module) and ".cpython-" not in module and bool(_FOREIGN_MODULE.search(module))
+
+
+def _foreign_site(foreign):
+    """Pick a (module, func, None) site from foreign frames (innermost first): prefer the innermost
+    NON-interceptor foreign func (e.g. `tzset_internal`), else the innermost named interceptor (e.g.
+    `strdup`/`memcmp`), else the module alone (func `?`, when every foreign frame is `<null>` -- the
+    common OpenSSL-internal case)."""
+    for module, func in foreign:
+        if func != "<null>" and func not in _MEM_INTERCEPTORS:
+            return (module, func, None)
+    for module, func in foreign:
+        if func != "<null>":
+            return (module, func, None)
+    return (foreign[0][0], "?", None)
+
+
 def _top_site(frames, source_roots=None):
-    """Given a stanza's frames (innermost first) as (func, location), return the top real
+    """Given a stanza's frames (innermost first) as (func, location, module), return the top real
     racing site (file, func, line): the innermost resolved frame whose func isn't plumbing.
-    Falls back to the innermost resolved frame if all are plumbing; None if none resolve.
-    ``source_roots`` (Slice D) additionally resolves extension frames under those roots."""
+
+    FOREIGN-library first: if any foreign-library frame (libcrypto.so.3 / libc.so.6 / ...) sits at
+    or above the innermost resolved CPython/ext site, the race happened inside that library, so key
+    on it (``(module, func, None)``) rather than collapsing to the CPython call boundary. Otherwise
+    unchanged: innermost resolved non-plumbing frame, falling back to the innermost resolved frame;
+    None if none resolve. ``source_roots`` (Slice D) additionally resolves extension frames under
+    those roots. Frames may be 2-tuples (legacy callers / tests) -- treated as having no module."""
     real = []
-    for func, location in frames:
+    foreign = []  # (module, func) for foreign frames seen BEFORE any resolved CPython/ext site
+    for frame in frames:
+        func, location = frame[0], frame[1]
+        module = frame[2] if len(frame) > 2 else None
         site = _frame_site(func, location, source_roots)
         if site is not None:
             real.append(site)
+            continue
+        if not real and _is_foreign_module(module):
+            foreign.append((module, func))
+    if foreign:
+        return _foreign_site(foreign)  # foreign frame(s) innermost -> foreign-library race
     if not real:
         return None
     for site in real:
@@ -276,7 +370,8 @@ def _parse_segv(text, m, source_roots=None):
             continue
         fm = FRAME.match(line)
         if fm:
-            frames.append((fm.group(1), fm.group(2)))
+            mm = FRAME_MODULE.search(line)
+            frames.append((fm.group(1), fm.group(2), mm.group(1) if mm else None))
         elif frames:
             break  # crash stack ended
     site = _top_site(frames, source_roots)
@@ -301,7 +396,8 @@ def _parse_race(text, source_roots=None):
             while i < n:
                 fm = FRAME.match(lines[i])
                 if fm:
-                    frames.append((fm.group(1), fm.group(2)))
+                    mm = FRAME_MODULE.search(lines[i])
+                    frames.append((fm.group(1), fm.group(2), mm.group(1) if mm else None))
                     i += 1
                     continue
                 # stanza ends at the first non-frame line (blank / next header)

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -98,6 +98,49 @@ REPORT_TRUNCATED_SINGLE_STANZA = "\n".join(
     ]
 )
 
+# A FOREIGN-LIBRARY race: the actual racing accesses are INSIDE a system library (here OpenSSL's
+# libcrypto), unsymbolized (`<null>`); TSan attributes the memcmp/memcpy INTERCEPTORS to the
+# `python` module, and the only CPython frame is the call boundary (tp_new_wrapper). Keying on
+# tp_new_wrapper collapses distinct libcrypto races onto a real CPython function and needs a
+# per-pairing suppression -- so key on the foreign library instead.
+REPORT_FOREIGN_OPENSSL = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=1)",
+        "  Read of size 8 at 0x7f00 by thread T1:",
+        "    #0 memcmp <null> (python+0x10c) (BuildId: aa)",
+        "    #1 <null> <null> (libcrypto.so.3+0x250b01) (BuildId: bb)",
+        "    #2 tp_new_wrapper /b/./Objects/typeobject.c:10485:11 (python+0x400) (BuildId: aa)",
+        "",
+        "  Previous write of size 8 at 0x7f00 by thread T2:",
+        "    #0 memcpy <null> (python+0xfa) (BuildId: aa)",
+        "    #1 <null> <null> (libcrypto.so.3+0x250916) (BuildId: bb)",
+        "    #2 tp_new_wrapper /b/./Objects/typeobject.c:10485:11 (python+0x400) (BuildId: aa)",
+        "",
+        "SUMMARY: ThreadSanitizer: data race in tp_new_wrapper",
+    ]
+)
+
+# Foreign glibc race: concurrent time.tzset() -> glibc tzset_internal free()/strdup()s the
+# process-global TZ buffers. free/malloc interceptors are in `python`; the real racer is in
+# libc.so.6 (tzset_internal / strdup, whose `time/tzset.c` / `string/strdup.c` sources are NOT
+# CPython dirs so they don't resolve). Prefer the innermost NON-interceptor foreign func.
+REPORT_FOREIGN_TZSET = "\n".join(
+    [
+        "WARNING: ThreadSanitizer: data race (pid=2)",
+        "  Write of size 8 at 0x7f00 by thread T1:",
+        "    #0 free <null> (python+0xfe) (BuildId: aa)",
+        "    #1 tzset_internal time/tzset.c:401:3 (libc.so.6+0xe90e5) (BuildId: cc)",
+        "    #2 cfunction_vectorcall_NOARGS /b/Objects/methodobject.c:508:24 (python+0x370) (BuildId: aa)",
+        "",
+        "  Previous write of size 8 at 0x7f00 by thread T2:",
+        "    #0 malloc <null> (python+0xfd) (BuildId: aa)",
+        "    #1 strdup string/strdup.c:42:15 (libc.so.6+0xbbc) (BuildId: cc)",
+        "    #2 cfunction_vectorcall_NOARGS /b/Objects/methodobject.c:508:24 (python+0x370) (BuildId: aa)",
+        "",
+        "SUMMARY: ThreadSanitizer: data race in tzset_internal",
+    ]
+)
+
 # TSan lowercases the whole SECOND access line, including the `atomic` qualifier: "Previous
 # atomic write". The reader-vs-atomic-writer shape is the single most common race class in the
 # catalog, so failing to match this header dropped the 2nd stanza and (via the len<2 fallback)
@@ -266,6 +309,29 @@ class TestParse(unittest.TestCase):
         self.assertNotEqual(
             r["signature"],
             "Include/object.h:_Py_TYPE_impl | Include/object.h:_Py_TYPE_impl",
+        )
+
+    def test_foreign_openssl_race_keys_on_library_not_boundary(self):
+        # libcrypto-internal race must NOT collapse to the CPython call boundary (tp_new_wrapper);
+        # it keys on the foreign library. func is `<null>` (unsymbolized) -> module + "?".
+        r = tsan_dedup.parse_report(REPORT_FOREIGN_OPENSSL)
+        self.assertEqual(r["signature"], "libcrypto.so.3:? | libcrypto.so.3:?")
+        self.assertNotIn("tp_new_wrapper", r["signature"])
+        self.assertFalse(r["framework"])
+
+    def test_foreign_tzset_race_prefers_noninterceptor_libc_func(self):
+        # Prefer the real libc function (tzset_internal) over the memory interceptor (strdup).
+        r = tsan_dedup.parse_report(REPORT_FOREIGN_TZSET)
+        self.assertEqual(r["signature"], "libc.so.6:strdup | libc.so.6:tzset_internal")
+        self.assertNotIn("cfunction_vectorcall_NOARGS", r["signature"])
+
+    def test_python_module_interceptor_does_not_trigger_foreign(self):
+        # REPORT_TWO_SITES' write stanza has `#0 memset <null> (python+0x1)` -- a `python`-module
+        # interceptor, NOT a foreign lib -- so it is skipped to reach list_append, unchanged.
+        r = tsan_dedup.parse_report(REPORT_TWO_SITES)
+        self.assertEqual(
+            r["signature"],
+            "Objects/listobject.c:list_append | Objects/listobject.c:list_extend",
         )
 
     def test_access_header_variants_match(self):


### PR DESCRIPTION
## Problem

`parse_report` picks each race stanza's *innermost CPython frame* as the site. When the actual racing access is inside a **foreign system library** (OpenSSL's libcrypto, glibc), TSan attributes the intercepted libc call (`memcpy`/`free`/...) to the `python` module and leaves the real racer unsymbolized in the `.so`, so the deduper collapses the race onto the nearest CPython frame — the *call boundary*. That mints **false signatures that collide with real CPython functions**:

- `tp_new_wrapper | tp_new_wrapper` — actually a libcrypto-internal ASN1 race (concurrent `_ssl` object construction; dup of cpython#150191)
- `cfunction_vectorcall_NOARGS | cfunction_vectorcall_NOARGS` — actually glibc `tzset_internal` (concurrent `time.tzset()`)
- `_multiprocessing_SemLock_impl | _Py_Dealloc` — actually glibc `__sem_mappings` tsearch/tdelete (TSAN-0003)
- several locale (`localeconv`/`setlocale`) faces

Each needed its own anchored suppression, and every new foreign-frame permutation needs another.

## Fix

`_top_site` now detects when a **foreign-system-library** frame sits at/above the innermost resolved CPython/ext site, and keys on the library instead: `(module, innermost-non-interceptor-func)` → e.g. `libc.so.6:tzset_internal`, `libcrypto.so.3:?` (when all foreign frames are `<null>`). TSan attributes intercepted libc calls to `python`, so the signal is the frame's **module**, not its func — a new `FRAME_MODULE` regex extracts it.

A single `libc\.so` / `libcrypto\.so` catalog suppression then covers the whole foreign class and pre-empts future permutations.

**FOREIGN is a curated allowlist** of system libs (`libc`/`libcrypto`/`libssl`/`libm`/`libpthread`/`ld-linux`/...), deliberately **not** a bare `.so$`: a *target* C extension — a `--tsan-source-root` `.so` like `cereggii.so`, or any `*.cpython-*.so` — must still resolve via the source-root / CPython path, because its races are findings. Verified: `cereggii.so`, `libhdf5.so.310`, `_socket.cpython-...so` are **not** foreign.

## Contract / safety

`parse_report`'s signature format is a cross-repo contract (`cpython-tsan-findings/scripts/ingest.py` imports this module). Only **foreign-collapse** signatures change; **CPython and source-root signatures are byte-for-byte unchanged**. Measured over `fusil-tsan_fleet_17` with the sibling catalog's broad `libc/libcrypto/libssl` rules (added in lockstep): cataloged=221, suppressed=121, **STILL-NEW=15, foreign leaks = NONE**, no known race regressed.

## Test plan
- `python -m unittest tests.python.test_tsan_dedup` — 50 pass (47 prior + 3 new: OpenSSL keys on libcrypto, tzset prefers `tzset_internal` over `strdup`, `python`-module interceptor does *not* trigger foreign)
- The 4 `TestSourceRoots` tests still pass (curated allowlist excludes `cereggii.so`)
- `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d