### PR TITLE
tsan: feed TSan only its parseable suppression lines (fix "failed to parse suppressions")

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -869,7 +869,31 @@ class Fuzzer(Application):
             halt = "0" if self.options.tsan_no_halt else "1"
             tsan_opts = ["halt_on_error=%s" % halt, "symbolize=1", "exitcode=66", "history_size=4"]
             if self.options.tsan_suppressions:
-                tsan_opts.append("suppressions=%s" % self.options.tsan_suppressions)
+                # TSan's parser rejects the WHOLE file if any line is not `type:pattern`, but a
+                # fusil suppressions file mixes TSan-native rules with post-hoc-only signature
+                # regexes (which the --tsan-dedup-catalog deduper reads from the ORIGINAL file).
+                # Hand TSan only its parseable subset, written to a run-local file; if there is no
+                # TSan-native rule, hand it no suppressions file at all (post-hoc still prunes).
+                import os
+
+                from fusil.python.tsan_dedup import tsan_native_suppressions
+
+                with open(self.options.tsan_suppressions) as _sfh:
+                    _native = tsan_native_suppressions(_sfh.read())
+                if _native:
+                    _native_path = os.path.join(
+                        project.directory.directory, "tsan_suppressions_native.txt"
+                    )
+                    with open(_native_path, "w") as _sfh:
+                        _sfh.write(_native)
+                    tsan_opts.append("suppressions=%s" % _native_path)
+                else:
+                    self.warning(
+                        "TSan: --tsan-suppressions %s has no TSan-native (race:/called_from_lib:/"
+                        "...) rules; its signature-regex rules are applied post-hoc by "
+                        "--tsan-dedup-catalog only, not fed to TSAN_OPTIONS (which would reject them)."
+                        % self.options.tsan_suppressions
+                    )
             process.env.set("TSAN_OPTIONS", ":".join(tsan_opts))
             process.env.set("PYTHON_GIL", "0")
             # Clear DEBUGINFOD_URLS so llvm-symbolizer resolves frames from the target's own (full)

--- a/fusil/python/tsan_dedup.py
+++ b/fusil/python/tsan_dedup.py
@@ -510,6 +510,35 @@ class Suppressor:
         return False
 
 
+# TSan's OWN suppression parser (TSAN_OPTIONS=suppressions=) rejects the WHOLE file with "failed
+# to parse suppressions" if any non-comment line is not `type:pattern` for a supported type. fusil
+# suppressions files also carry signature-regex lines (`file:func | file:func`, `^A | A$`,
+# `libc\.so`) that ONLY the post-hoc Suppressor above understands -- handing those to TSan is what
+# breaks it. This keeps just the TSan-native subset for TSAN_OPTIONS; the post-hoc deduper keeps
+# reading the ORIGINAL, full file (via Suppressor.from_file).
+_TSAN_NATIVE_SUPP = re.compile(
+    r"^\s*(?:race|race_top|mutex|thread|signal|called_from_lib|deadlock)\s*:"
+)
+
+
+def tsan_native_suppressions(text):
+    """Return the text of only the lines TSan itself can parse -- its supported ``type:pattern``
+    rules plus comments and blank lines -- from a fusil suppressions file that mixes those with
+    post-hoc-only signature regexes. Returns ``""`` when the file has NO TSan-native rule at all,
+    signalling the caller to hand TSan no suppressions file (the signature-regex rules are still
+    applied post-hoc by ``--tsan-dedup-catalog``)."""
+    kept = []
+    has_rule = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if _TSAN_NATIVE_SUPP.match(line):
+            kept.append(line)
+            has_rule = True
+        elif not stripped or stripped.startswith("#"):
+            kept.append(line)
+    return ("\n".join(kept) + "\n") if has_rule else ""
+
+
 # ---- bounded stdout reader (shared contract with oom_dedup) ----
 _STDOUT_HEAD = int(os.environ.get("TSAN_STDOUT_HEAD", 256 * 1024))
 _STDOUT_TAIL = int(os.environ.get("TSAN_STDOUT_TAIL", 1024 * 1024))

--- a/tests/python/test_tsan_dedup.py
+++ b/tests/python/test_tsan_dedup.py
@@ -6,6 +6,7 @@ Mirrors test_oom_dedup.
 """
 
 import os
+import re
 import tempfile
 import unittest
 
@@ -622,6 +623,47 @@ class TestReadStdout(unittest.TestCase):
         with os.fdopen(fd, "w") as fh:
             fh.write(REPORT_TWO_SITES)
         self.assertIn("data race", tsan_dedup.read_crash_stdout(path))
+
+
+class TestTsanNativeSuppressions(unittest.TestCase):
+    """tsan_native_suppressions() extracts only the lines TSan's own parser accepts, so a fusil
+    suppressions file (which mixes TSan-native rules with post-hoc-only signature regexes) can be
+    fed to TSAN_OPTIONS without the 'failed to parse suppressions' error."""
+
+    def _rule_lines(self, text):
+        return [ln for ln in text.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+
+    def test_signature_regex_lines_are_dropped(self):
+        src = (
+            "# comment\n"
+            "Modules/_localemodule.c:locale_decode_monetary\n"
+            "libc\\.so\n"
+            "^Objects/typeobject.c:tp_new_wrapper | Objects/typeobject.c:tp_new_wrapper$\n"
+            "called_from_lib:libcrypto.so\n"
+        )
+        out = tsan_dedup.tsan_native_suppressions(src)
+        self.assertEqual(self._rule_lines(out), ["called_from_lib:libcrypto.so"])
+        self.assertIn("# comment", out)  # comments kept
+
+    def test_all_native_file_is_kept_verbatim_rules(self):
+        src = "race:count_repr\nrace_top:foo\ncalled_from_lib:libssl.so\ndeadlock:bar\n"
+        out = tsan_dedup.tsan_native_suppressions(src)
+        self.assertEqual(
+            self._rule_lines(out),
+            ["race:count_repr", "race_top:foo", "called_from_lib:libssl.so", "deadlock:bar"],
+        )
+
+    def test_no_native_rule_returns_empty(self):
+        # a purely post-hoc (signature-regex) file -> "" so the caller hands TSan no file at all
+        src = "# only signature regexes\nlibc\\.so\nModules/foo.c:bar | Modules/foo.c:baz\n"
+        self.assertEqual(tsan_dedup.tsan_native_suppressions(src), "")
+
+    def test_output_is_tsan_parseable(self):
+        src = "libc\\.so\nrace:foo\ncalled_from_lib:libcrypto.so\n"
+        out = tsan_dedup.tsan_native_suppressions(src)
+        valid = re.compile(r"^(race|race_top|mutex|thread|signal|called_from_lib|deadlock):\S")
+        for ln in self._rule_lines(out):
+            self.assertRegex(ln.strip(), valid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Fleet 18 failed **every session** with:

```
ThreadSanitizer: failed to parse suppressions.
Supported suppression types are:
- race
- race_top
- mutex
- thread
- signal
- called_from_lib
- deadlock
```

A `--tsan-suppressions` file is fed to **both** the in-loop post-hoc deduper **and**, verbatim, to the target's `TSAN_OPTIONS=suppressions=` (`__init__.py:872`). The framework-noise file (`cpython-tsan-findings/catalog/suppressions.txt`) is written in fusil's **post-hoc format** — signature regexes (`file:func | file:func`, `^A | A$`, `libc\.so`) that the `Suppressor` matches against the parsed race *signature*. TSan's own parser rejects the **whole file** if any non-comment line is not `type:pattern`, so every session aborts.

Some of those rules (the anchored `^A | A$` OpenSSL/tzset forms, the structseq self-pair) are **inherently post-hoc-only** and can't be expressed in TSan format, so the file genuinely can't be made all-TSan.

## Fix

`tsan_dedup.tsan_native_suppressions()` extracts just the TSan-native subset (its supported `type:pattern` rules + comments/blanks). `setupProject` writes that to a run-local file (`<run>/tsan_suppressions_native.txt`) and points `TSAN_OPTIONS` at it. If the file has **no** native rule, TSan is given no suppressions file at all (with a logged warning) — the signature-regex rules are still applied **post-hoc** by `--tsan-dedup-catalog`, which keeps reading the original full file.

- Byte-for-byte unchanged for a gateway-style all-`race:` file (it passes through whole).
- The paired catalog change adds `called_from_lib:libcrypto.so` / `libssl.so` (TSan-native, SSL-only so it can't over-suppress) so TSan drops OpenSSL-internal races at the source; glibc stays post-hoc-only (`libc.so` is too ubiquitous for `called_from_lib`).

## Test plan
- `tests.python.test_tsan_dedup` — new `TestTsanNativeSuppressions` (signature-regex lines dropped, native lines kept, empty→"" , output is TSan-parseable); 54 pass.
- Full suite **1238 pass**; `ruff check` + `ruff format --check` clean.
- Verified against the real `suppressions.txt`: filter returns the 2 `called_from_lib` rules (TSan-parseable), and the post-hoc `Suppressor` still prunes a `libc.so.6` foreign race from the original file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d