### PR TITLE
sys-monitoring: compose with --tsan (run threaded monitoring region under TSan)

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -769,6 +769,17 @@ class WritePythonCode(WriteCode):
         """Writes the core fuzzing loops for functions, classes, and objects."""
         self._write_fuzzing_logic_preamble()
 
+        # --sys-monitoring mode: stress the sys.monitoring (PEP 669) instrumentation / event-
+        # dispatch C machinery with HOSTILE callbacks (raise / DISABLE / junk / re-entrant
+        # set_events / register_callback / free_tool_id from inside a callback), now from several
+        # barrier-released threads. Checked BEFORE --tsan so `--tsan --sys-monitoring` COMPOSES:
+        # the monitoring region runs under the full --tsan environment (TSan build, TSAN_OPTIONS,
+        # setarch -R, unlimited RLIMIT_AS, PYTHON_GIL=0), so its concurrent monitoring-state
+        # mutation is reported as data races -- the PEP 669 x PEP 703 surface. Self-contained.
+        if getattr(self.options, "sys_monitoring", False):
+            self._write_monitoring_region()
+            return
+
         # TSan / --concurrency-stress mode: skip the single-threaded function/class/object sweeps
         # and emit only the concurrency-stress region -- it instantiates its own shared objects and
         # hammers them from many threads, which is the whole point (and keeps the script small).
@@ -782,13 +793,6 @@ class WritePythonCode(WriteCode):
         # re-validating can segfault an alternative interpreter (the RustPython re.Match seam).
         if getattr(self.options, "new_uninit", False):
             self._write_new_uninit_region()
-            return
-
-        # --sys-monitoring mode: stress the sys.monitoring (PEP 669) instrumentation / event-
-        # dispatch C machinery with HOSTILE callbacks (raise / DISABLE / junk / re-entrant
-        # set_events / register_callback / free_tool_id from inside a callback). Self-contained.
-        if getattr(self.options, "sys_monitoring", False):
-            self._write_monitoring_region()
             return
 
         self._write_function_fuzzing_loop()

--- a/tests/python/test_monitoring_generation.py
+++ b/tests/python/test_monitoring_generation.py
@@ -110,6 +110,14 @@ class TestMonitoringGeneration(unittest.TestCase):
         src = _generate(sys_monitoring=True)
         self.assertIn("_local_evs[_mon_calls[0] % len(_local_evs)]", src)
 
+    def test_composes_with_tsan(self):
+        # `--tsan --sys-monitoring` must emit the (threaded) MONITORING region -- run under the full
+        # --tsan environment -- NOT the tsan concurrency-stress region. --sys-monitoring wins.
+        src = _generate(sys_monitoring=True, tsan=True)
+        self.assertIn("# --- sys.monitoring hostile-callback region (--sys-monitoring) ---", src)
+        self.assertIn("def _mon_worker():", src)
+        self.assertNotIn("TSan concurrency-stress region", src)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_tsan_generation.py
+++ b/tests/python/test_tsan_generation.py
@@ -68,6 +68,12 @@ def _make_tsan_options(
 ):
     o = MagicMock()
     o.tsan = True
+    # Other generation MODES must be explicitly False: a bare MagicMock auto-vivifies a truthy
+    # attribute, and _write_main_fuzzing_logic checks --sys-monitoring BEFORE --tsan (they compose),
+    # so an unset o.sys_monitoring would hijack every tsan test into the monitoring region.
+    o.sys_monitoring = False
+    o.new_uninit = False
+    o.concurrency_stress = False
     o.tsan_threads = threads
     o.tsan_iterations = iterations
     o.tsan_shared_objects = shared_objects


### PR DESCRIPTION
Enables `--tsan --sys-monitoring` so the (now threaded, PR #251) monitoring region runs under the **full TSan environment** — for finding concurrent-monitoring **data races**, not just crashes.

## Problem

`--tsan` and `--sys-monitoring` were mutually exclusive: `_write_main_fuzzing_logic` emitted the tsan stress region and `return`ed *before* the `--sys-monitoring` check. And running `--sys-monitoring` **alone** on a TSan build doesn't help — without the `--tsan` flag, `setupProject` leaves `RLIMIT_AS` finite, so TSan's shadow-memory re-exec fails and it runs **degraded** (detects nothing).

## Fix

Check `--sys-monitoring` **before** the `--tsan`/`--concurrency-stress` region. Now `--tsan --sys-monitoring` emits the threaded monitoring region under the full `--tsan` env that `setupProject` already sets up (TSan build verified, `TSAN_OPTIONS`, `setarch -R`, unlimited `RLIMIT_AS`, `PYTHON_GIL=0`, `--tsan-dedup-catalog`). The concurrent monitoring-state mutation across the 6 worker threads is then reported as data races. `--tsan` alone and `--sys-monitoring` alone are unchanged.

## Test-harness fix (MagicMock auto-vivify)

`_make_tsan_options` builds a bare `MagicMock`, so `o.sys_monitoring` auto-vivified to a **truthy** Mock — and now that it's checked first, it hijacked every tsan-generation test into the monitoring region. Set `sys_monitoring`/`new_uninit`/`concurrency_stress = False` explicitly (matching the existing auto-vivify guard for the opt-in tsan ops). This is a test-only issue: production options come from optparse with real `False` defaults.

## Test plan
- New `test_composes_with_tsan`: `--tsan --sys-monitoring` emits the monitoring region, not the tsan stress region.
- `tests.python.test_tsan_generation` + `test_monitoring_generation` — 40 pass; full suite **1241 pass**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BXgZLbi637orTFRSvzL3d