### PR TITLE
sys-monitoring: contain the hostile callback so it can't self-terminate the script

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -1748,6 +1748,15 @@ class WritePythonCode(WriteCode):
 
             def _mon_run():
                 _mon_calls = [0]
+                # Global monitoring events (set_events) fire process-wide -- on the main thread's
+                # thread management, this region's own error handler, and the import + threading-
+                # shutdown machinery, none of which we wrap. A callback that raises/DISABLEs there
+                # escapes into that un-instrumented code and kills the whole script (exit 1) before
+                # the machinery is even stressed. So detonation is gated on this thread-local flag,
+                # set True ONLY while a worker is running an instrumented target inside a try/except
+                # (below); everywhere else the callback fires but returns None, harmlessly.
+                import threading as _mon_threading
+                _mon_active = _mon_threading.local()
                 # Pick a tool id, freeing it first in case a previous region left it registered.
                 _TID = 3
                 for _cand in (3, 4, 2, 1, 0, 5):
@@ -1783,8 +1792,18 @@ class WritePythonCode(WriteCode):
                 # the monitoring state while the C dispatcher is still mid-callback.
                 def _mon_cb(*_a):
                     _mon_calls[0] += 1
+                    # Detonate ONLY inside a controlled target call (see _mon_active above); a global
+                    # event firing on thread management / the error handler / interpreter shutdown
+                    # dispatches here too, and a raise there would escape un-instrumented code.
+                    if not getattr(_mon_active, "on", False):
+                        return None
                     _r = _mon_calls[0] % 11
                     if _r == 0:
+                        # Disarm BEFORE raising: setting _mon_active.on is itself a monitored op,
+                        # so a global event can dispatch here mid-disarm-store. Clearing the flag
+                        # first guarantees it can't be left stuck True -- otherwise a later global
+                        # event (in thread teardown / _delete) would bomb and kill the worker.
+                        _mon_active.on = False
                         raise ValueError("fusil monitoring callback bomb")
                     if _r == 1:
                         return _mon.DISABLE
@@ -1911,12 +1930,17 @@ class WritePythonCode(WriteCode):
                                 _mon.set_local_events(_TID, _fn.__code__, _lmask)
                             except BaseException:
                                 pass
-                        # (4) run instrumented code -> events fire -> hostile callbacks dispatch
-                        for _fn in _mon_targets:
-                            try:
-                                _fn(12) if _fn is _mon_target else _fn()
-                            except BaseException:
-                                pass
+                        # (4) run instrumented code -> events fire -> hostile callbacks dispatch.
+                        # Arm detonation only for this bounded, wrapped stretch (see _mon_active).
+                        _mon_active.on = True
+                        try:
+                            for _fn in _mon_targets:
+                                try:
+                                    _fn(12) if _fn is _mon_target else _fn()
+                                except BaseException:
+                                    pass
+                        finally:
+                            _mon_active.on = False
                         # (5) tear down this round (the callback may already have)
                         try:
                             _mon.set_events(_TID, 0)
@@ -1931,8 +1955,6 @@ class WritePythonCode(WriteCode):
                 # once. That is the PEP-669 (monitoring) x PEP-703 (free-threading) concurrent-
                 # monitoring surface the single-threaded sweep can't reach. Bounded rounds/threads so
                 # the per-line LINE/INSTRUCTION callbacks can't hang under the fleet timeout.
-                import threading as _mon_threading
-
                 _MON_NW = 6
                 _mon_barrier = _mon_threading.Barrier(_MON_NW)
 
@@ -1944,14 +1966,16 @@ class WritePythonCode(WriteCode):
                     for _round in range(100):
                         _mon_one_round(_round)
 
-                _mon_threads = [_mon_threading.Thread(target=_mon_worker) for _ in range(_MON_NW)]
-                for _t in _mon_threads:
-                    _t.start()
-                for _t in _mon_threads:
-                    _t.join()
-
-                # Final cleanup: clear all events and release both tool ids.
                 try:
+                    _mon_threads = [
+                        _mon_threading.Thread(target=_mon_worker) for _ in range(_MON_NW)
+                    ]
+                    for _t in _mon_threads:
+                        _t.start()
+                    for _t in _mon_threads:
+                        _t.join()
+
+                    # Final cleanup: clear all events and release both tool ids.
                     for _fn in _mon_targets:
                         for _tid in (_TID, _TID2):
                             if _tid < 0:
@@ -1968,8 +1992,16 @@ class WritePythonCode(WriteCode):
                             _mon.free_tool_id(_tid)
                         except BaseException:
                             pass
-                except BaseException:
-                    pass
+                finally:
+                    # Defense-in-depth: whatever happened above (incl. a reentrant callback leaving
+                    # events set on some other id), guarantee NO tool has global events left on, so
+                    # interpreter shutdown / the rest of the script run clean instead of dispatching
+                    # a stray callback. Without this a leaked global event bombs threading._shutdown.
+                    for _tid in range(6):
+                        try:
+                            _mon.set_events(_tid, 0)
+                        except BaseException:
+                            pass
 
             if _mon is None:
                 print("[MONITORING] sys.monitoring unavailable (need CPython 3.12+); skipping",

--- a/tests/python/test_monitoring_generation.py
+++ b/tests/python/test_monitoring_generation.py
@@ -110,6 +110,31 @@ class TestMonitoringGeneration(unittest.TestCase):
         src = _generate(sys_monitoring=True)
         self.assertIn("_local_evs[_mon_calls[0] % len(_local_evs)]", src)
 
+    def test_callback_detonation_is_gated_and_contained(self):
+        # The hostile callback fires on GLOBAL monitoring events, which dispatch process-wide --
+        # including on thread management, the region's own error handler, and interpreter shutdown.
+        # A raise/DISABLE there would escape un-instrumented code and kill the whole script (the
+        # exit-1-every-session bug). Detonation must be gated behind a thread-local flag armed ONLY
+        # around the wrapped target run, and the raise branch must disarm BEFORE raising so an
+        # interrupted disarm-store can't leave the flag stuck True (which would bomb thread teardown).
+        src = _generate(sys_monitoring=True)
+        self.assertIn("_mon_active = _mon_threading.local()", src)
+        self.assertIn('if not getattr(_mon_active, "on", False):', src)
+        # armed only around the target run, disarmed in a finally
+        self.assertIn("_mon_active.on = True", src)
+        self.assertIn("_mon_active.on = False", src)
+        # disarm-before-raise: the flag is cleared on the line immediately before the raise
+        self.assertIn(
+            '_mon_active.on = False\n            raise ValueError("fusil monitoring callback bomb")',
+            src,
+        )
+
+    def test_all_tool_ids_force_cleared_on_exit(self):
+        # Defense-in-depth: whatever a reentrant callback left set, no tool may keep GLOBAL events
+        # enabled past the region, or a stray event bombs threading._shutdown at interpreter exit.
+        src = _generate(sys_monitoring=True)
+        self.assertIn("for _tid in range(6):", src)
+
     def test_composes_with_tsan(self):
         # `--tsan --sys-monitoring` must emit the (threaded) MONITORING region -- run under the full
         # --tsan environment -- NOT the tsan concurrency-stress region. --sys-monitoring wins.


### PR DESCRIPTION
## Problem

Every session in the ASan sys-monitoring fleet (**fleet_20**) self-terminated with **exit 1** before the monitoring machinery was stressed at all. Observed at `fusil-sysmon_fleet_20/inst-04/python-2/shutil-exitcode1/stdout`:

```
[MONITORING] entering sys.monitoring hostile-callback region
...
  File ".../source.py", line 1585, in _mon_run
  File ".../threading.py", line 699, in __init__
  File ".../source.py", line 1436, in _mon_cb
ValueError: fusil monitoring callback bomb
...
Exception ignored on threading shutdown:
```

**Root cause.** `_write_monitoring_region` enables monitoring events **globally** (`set_events`), which dispatch the hostile callback **process-wide** — not just on the instrumented targets. The callback raises `ValueError` on every 11th dispatch, so the bomb detonated in un-instrumented, un-wrapped code:

- the main thread's `Thread(...)`/`.start()` machinery,
- the region's own error-handler `print` (→ import → traceback colorize),
- interpreter shutdown (`threading._shutdown`).

The first escaped bomb during thread startup propagated to `<module>` → exit 1. So the region **never actually ran its rounds** — it was pure fuzzer self-noise (a clean Python `ValueError`, not a crash), and the fleet was ~100% false positives.

## Fix

- **Gate detonation behind a thread-local flag** (`_mon_active.on`) armed **only** around the bounded, `try/except`-wrapped target run in step (4). Everywhere else the callback still fires (fully exercising the global-event dispatch machinery) but returns `None` harmlessly — nothing escapes into thread management, the error handler, imports, or shutdown.
- **Disarm before raising.** Setting the flag is itself a monitored op, so a global event can dispatch mid-disarm-store; clearing the flag *first* guarantees it can't be left stuck `True` (which would otherwise bomb thread teardown / `_delete` and kill the worker).
- **`finally` force-clears events for every tool id (0–5)** so a reentrant callback leaving events set can't bomb interpreter shutdown.

Global-event coverage is **fully preserved** (~49k contained dispatches/run).

## Verification

- `debug-ft-nojit` and `debug-ft-nojit-asan`: full 100-round region now **completes at exit 0 with zero escaped bombs / thread deaths / ASan reports** across many runs (was exit 1 every time).
- Instrumented count: **49,219** contained callback dispatches in one run — hostility preserved.
- Full suite green (`python -m unittest discover -s tests`, 1243 tests); `ruff check` + `ruff format --check` clean.
- New tests lock in the containment invariants (gate present, disarm-before-raise, all-tool-id force-clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)