### PR TITLE
new-uninit: ignore [NEW-UNINIT] progress markers in crash detection

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -966,6 +966,13 @@ class Fuzzer(Application):
             # these is the injected object's own exception text, never a target crash.
             r"fusil (bomb|iter bomb|superbomb|fileno bomb|hidden name|descriptor (get|set)"
             r"|stateful hash)",
+            # The --new-uninit region prints a progress marker per poked type,
+            # e.g. "[NEW-UNINIT] poking SystemError". The type name is arbitrary and
+            # routinely collides with a crash word ("SystemError" -> a 1.0 hit) or, worse,
+            # a kill word ("[NEW-UNINIT] poking MemoryError" -> the "MemoryError" kill word,
+            # which would drop the whole session and lose a genuine crash). These marker
+            # lines are our own output, never a target signal, so skip them before matching.
+            r"^\[NEW-UNINIT\] ",
         )
         for ignore_pattern in core_ignore_regexes + tuple(
             self.plugin_manager.get_stdout_ignore_regexes()

--- a/tests/test_file_watch.py
+++ b/tests/test_file_watch.py
@@ -126,6 +126,30 @@ class TestProcessLineScoring(unittest.TestCase):
         w = _watch(words={"error": 0.3}, kill_words={"MemoryError"})
         self.assertEqual(w.processLine(b"MemoryError: out of memory"), "KILL")
 
+    def test_new_uninit_marker_lines_ignored_but_real_still_scores(self):
+        # The --new-uninit region prints "[NEW-UNINIT] poking <TypeName>" per poked type.
+        # The type name collides with detection words: "SystemError" is a 1.0 hit word and
+        # "MemoryError" is a kill word. Without the ignore filter, "[NEW-UNINIT] poking
+        # MemoryError" would return KILL and drop a genuinely-crashing session. The core
+        # ignore regex (mirrored from fusil.python.Fuzzer) must skip every marker line.
+        w = _watch(words={"SystemError": 1.0}, kill_words={"MemoryError"})
+        w.ignoreRegex(r"^\[NEW-UNINIT\] ")
+        for line in (
+            b"[NEW-UNINIT] entering uninitialized-object region",
+            b"[NEW-UNINIT] discovered 115 candidate types",
+            b"[NEW-UNINIT] poking SystemError",  # collides with the SystemError hit word
+            b"[NEW-UNINIT] poking MemoryError",  # collides with the MemoryError kill word
+            b"[NEW-UNINIT] region complete",
+        ):
+            self.assertIsNone(w.processLine(line))
+        self.assertEqual(w.score, 0.0)
+        self.assertEqual(w.sent, [])
+        # Real signatures on their own lines are unaffected: SystemError still scores, and a
+        # genuine MemoryError still kills.
+        w.processLine(b"SystemError: null argument to internal routine")
+        self.assertEqual(w.score, 1.0)
+        self.assertEqual(w.processLine(b"MemoryError: out of memory"), "KILL")
+
     def test_cleanup_func_applied_before_matching(self):
         w = _watch(words={"boom": 1.0})
         w.cleanup_func = lambda line: line.replace(b"XXX", b"boom")


### PR DESCRIPTION
## Problem

The `--new-uninit` region prints one `[NEW-UNINIT] poking <TypeName>` progress marker per poked type. The type name is arbitrary and collides with `FileWatch`'s crash-detection words:

- `[NEW-UNINIT] poking SystemError` matches the `SystemError` 1.0 **hit** word → the session is mislabeled (e.g. a crash dir named `builtins-systemerror` when the real crash is an unrelated SEGV).
- `[NEW-UNINIT] poking MemoryError` matches the `MemoryError` **kill** word → `processLine` returns `KILL` and the whole session is dropped, **silently losing a genuine crash** found in that run (observed in a fleet: `session.log` shows `Ignoring session due to kill word: b'memoryerror'`).

Detection matches `\W`-bounded words over the merged stdout+stderr stream, so the marker's trailing type-name token is a real match even though the marker goes to stderr.

## Fix

Add `^\[NEW-UNINIT\] ` to the core stdout ignore regexes — the same `ignoreRegex` hook already used to skip the bomb-message family. `FileWatch` skips these own-output marker lines before word/kill matching. Real, differently-worded `SystemError`/`MemoryError` lines still score/kill exactly as before.

**Scoped to `--new-uninit` only:** the `[OOM]` markers are deliberately *not* blanket-ignored, because `[OOM] SystemError in <label>` (write_python_code.py) is an intentional detection signal. The other `[OOM]` label lines share the latent collision and are left for a separate audit.

## Test

Adds `test_new_uninit_marker_lines_ignored_but_real_still_scores` (mirrors the existing synthetic-SystemError test): asserts every marker line is ignored (including the `MemoryError` kill-word case), while a genuine `SystemError` still scores 1.0 and a genuine `MemoryError` still returns `KILL`.

Full suite green (1244 tests); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)