### PR TITLE
fleet: warn at preflight when SELinux would block systemd from exec'ing the fleet

### DIFF
--- a/fleet/README.md
+++ b/fleet/README.md
@@ -159,3 +159,44 @@ race that merely shares a frame with a gateway function). Prioritize the kept cr
 
 To see raw systemd state at any time: `systemctl status 'fusil@*'`,
 `journalctl -u fusil@3 -e`.
+
+## Troubleshooting
+
+### Every instance dies instantly with `status=203/EXEC` ("Permission denied")
+
+On **RHEL-family hosts** (Oracle Linux, RHEL, Fedora, Alma/Rocky) with SELinux **enforcing**,
+files under `/home` are labelled `user_home_t`, and systemd services (`init_t`) are **not
+permitted to execute them**. The journal looks like a missing `+x` bit:
+
+```
+fusil@1.service: Failed to locate executable /home/opc/projects/fusil/fleet/fleet-run: Permission denied
+fusil@1.service: Failed at step EXEC spawning .../fleet-run: Permission denied
+fusil@1.service: Main process exited, code=exited, status=203/EXEC
+```
+
+…but the real cause is an SELinux denial, visible only via `sudo ausearch -m avc -ts recent` or
+`setroubleshoot`. `chmod +x` will not help. `fleet check` now warns about this up front.
+
+Two things make it confusing: the error names the *executable* rather than SELinux, and the whole
+exec chain is affected — systemd runs `fleet-run`, which execs `RUNNER_PY`, which execs
+`TARGET_PYTHON`. **Relabelling only `fleet-run` just moves the denial to the next one.** A shim in
+`/usr/local/bin` doesn't help either: it still runs as `init_t` when it execs the home-dir script.
+
+Fixes, simplest first:
+
+```bash
+# 1. Dedicated fuzzing box: just stop enforcing. (A real, if small, security tradeoff --
+#    reasonable on a disposable instance whose job is running a fuzzer against hostile input.)
+sudo setenforce 0
+sudo sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config   # persist
+
+# 2. Keep enforcing: relabel the whole toolchain (re-run restorecon after every rebuild).
+sudo semanage fcontext -a -t bin_t "/path/to/fusil/fleet/fleet-run"
+sudo semanage fcontext -a -t bin_t "/path/to/venvs(/.*)?/bin(/.*)?"
+sudo restorecon -Rv /path/to/fusil/fleet /path/to/venvs /path/to/builds
+
+# 3. Cleanest long-term: keep the toolchain outside /home entirely (e.g. /opt).
+```
+
+The `audit2allow` recipe `setroubleshoot` prints works too, but grants `init_t` exec on home-dir
+files — about as broad as option 1, and harder to audit later.

--- a/fleet/fleet
+++ b/fleet/fleet
@@ -97,6 +97,44 @@ cmd_info(){  # the fleet banner: what this fleet is + where it lives
     echo "gil modes : ${GIL_MODES:-1}"
 }
 
+check_selinux(){  # RHEL-family footgun: SELinux blocks systemd from exec'ing out of $HOME
+    # On Oracle Linux / RHEL / Fedora with SELinux enforcing, files under /home get the label
+    # user_home_t, and systemd services (init_t) are NOT permitted to execute them. Every
+    # instance then dies instantly with `status=203/EXEC` and "Permission denied" -- which
+    # looks exactly like a missing +x bit, so the real cause (an SELinux AVC denial) is only
+    # visible in the journal. Warn here instead, since preflight otherwise passes happily.
+    #
+    # WARNING, not a failure: a site-local policy module may legitimately allow this, and we
+    # must not refuse to start a fleet that would actually work.
+    command -v getenforce >/dev/null 2>&1 || return 0
+    [ "$(getenforce 2>/dev/null)" = "Enforcing" ] || return 0
+    command -v ls >/dev/null 2>&1 || return 0
+    local bad="" p label
+    # The WHOLE exec chain matters: systemd execs fleet-run, which execs RUNNER_PY, which
+    # execs TARGET_PYTHON. Relabelling only the first just moves the denial to the next one.
+    for p in "$HERE/fleet-run" "$RUNNER_PY" "$TARGET_PYTHON"; do
+        [ -e "$p" ] || continue
+        label="$(ls -Zd "$p" 2>/dev/null | awk '{print $1}')"
+        case "$label" in
+            *user_home_t*|*admin_home_t*) bad="$bad    $p  [$label]
+" ;;
+        esac
+    done
+    [ -n "$bad" ] || return 0
+    echo "  WARNING: SELinux is Enforcing and these are labelled *home_t, which systemd"
+    echo "  (init_t) may NOT execute. Each instance would die at 203/EXEC 'Permission denied':"
+    printf '%s' "$bad"
+    echo "    Note: a +x bit is NOT the problem, and relabelling only fleet-run is not enough --"
+    echo "    the whole chain (fleet-run -> RUNNER_PY -> TARGET_PYTHON) must be executable by systemd."
+    echo "    Confirm: sudo ausearch -m avc -ts recent"
+    echo "    Fix (dedicated fuzzing box, simplest): sudo setenforce 0"
+    echo "      persist: sudo sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config"
+    echo "    Or keep enforcing and relabel the toolchain, e.g.:"
+    echo "      sudo semanage fcontext -a -t bin_t '$HERE/fleet-run'"
+    echo "      sudo restorecon -Rv '$HERE' \"\$(dirname \"\$(dirname '$RUNNER_PY')\")\""
+    echo "      (repeat for TARGET_PYTHON's build tree; re-run restorecon after each rebuild)"
+}
+
 cmd_check(){  # validate fleet.conf before we start anything (catches the #1 footgun:
               # wrong paths / a non-venv python that can't import fusil under systemd)
     local ok=1 repo
@@ -144,6 +182,8 @@ cmd_check(){  # validate fleet.conf before we start anything (catches the #1 foo
                      echo "    -> use a free-threaded runner python, or remove $g from GIL_MODES"; ok=0; }
         done
     fi
+    # Advisory only (never sets ok=0) -- see check_selinux.
+    check_selinux
     [ "$ok" = 1 ] || die "preflight failed -- fix fleet.conf (see above), then retry"
     echo "preflight OK: runner imports fusil+ptrace; paths exist"
 }


### PR DESCRIPTION
## Problem

On RHEL-family hosts (Oracle Linux, RHEL, Fedora, Alma/Rocky) with SELinux **enforcing**, files under `/home` are labelled `user_home_t`, and systemd services (`init_t`) are **not permitted to execute them**. Every fleet instance dies instantly:

```
fusil@1.service: Failed to locate executable /home/opc/projects/fusil/fleet/fleet-run: Permission denied
fusil@1.service: Failed at step EXEC spawning .../fleet-run: Permission denied
fusil@1.service: Main process exited, code=exited, status=203/EXEC
```

Two things make this expensive to diagnose:

1. The message names the *executable* and says "Permission denied", so it reads exactly like a missing `+x` bit. It isn't — `fleet up` already `chmod +x`es `fleet-run` (fleet:153). The real cause is an SELinux AVC denial, visible only via `sudo ausearch -m avc -ts recent` or `setroubleshoot`.
2. `fleet check` validated every path and exec bit, reported **preflight OK**, and then the whole fleet started doomed — with the only evidence in the journal.

## Fix

`check_selinux()` runs as part of preflight. When `getenforce` reports `Enforcing`, it reads the SELinux label of the **entire exec chain** — systemd runs `fleet-run`, which execs `RUNNER_PY`, which execs `TARGET_PYTHON` — and for any labelled `*home_t` prints the offending paths plus concrete fixes.

It calls out the two things that cost the most time:
- a `+x` bit is **not** the problem;
- relabelling only `fleet-run` is **not enough**, since the denial just moves to the next link. (A shim in `/usr/local/bin` doesn't help either: it still runs as `init_t` when it execs the home-dir script.)

**Advisory only — it never fails preflight.** A site-local policy module may legitimately allow this, and refusing to start a fleet that would actually work is worse than a spurious warning. It no-ops entirely where `getenforce` is absent or not `Enforcing`.

Also adds a Troubleshooting section to `fleet/README.md` documenting the failure mode and the three fixes (permissive / relabel / move out of `/home`), including why the `audit2allow` recipe `setroubleshoot` suggests isn't recommended.

## Verification

| case | result |
|---|---|
| no `getenforce` (Debian/Ubuntu) | silent no-op |
| `getenforce` → `Permissive` | silent no-op |
| `Enforcing` + `/home` labels (simulated) | warns with exact paths + labels |
| a `bin_t`-labelled `TARGET_PYTHON` in that run | correctly **excluded** from the report |

`bash -n` clean; full suite green (1244 tests); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)