### PR TITLE
blacklist the __pypy__ helpers that attack the fuzzer instead of the target

### DIFF
--- a/fusil/python/blacklists.py
+++ b/fusil/python/blacklists.py
@@ -153,6 +153,31 @@ BLACKLIST = {
         "sigwaitinfo",
         "sigtimedwait",
     },
+    # PyPy interpreter internals (__pypy__) that attack the fuzzer or the host rather than
+    # the target -- the "generated code kills its own session" class (see fusil #192).
+    # Everything else in __pypy__ is deliberately left fuzzable: it is PyPy-only surface with
+    # no CPython counterpart, which is the whole point of fuzzing PyPy.
+    "__pypy__": {
+        # Spawns an interp-level gdb *inside the session*. Observed live: gdb's own banner
+        # ("For bug reporting instructions...") lands in the captured stdout and scores on
+        # the "bug" word, so the session is kept as a crash that never happened.
+        "attach_gdb",
+        # "Executes a script of Python code in a given remote Python process." A fuzzer-chosen
+        # pid means arbitrary code injection into any process on the box -- including sibling
+        # fleet instances and the fuzzer itself.
+        "remote_exec",
+        # Installs a process-global hook invoked on every code-object creation; handing it one
+        # of fusil's bomb objects makes the rest of the session detonate on unrelated code.
+        "set_code_callback",
+        # Blocks: calls PyOS_InputHook() / stops under the reverse debugger.
+        "pyos_inputhook",
+        "revdb_stop",
+        # Documented as "for testing purposes, raise an interpreter-level ValueError.
+        # Should turn into a SystemError automatically" -- a deliberate self-test helper.
+        # "SystemError" is a 1.0 crash word, so with --test-private this alone tagged
+        # EVERY __pypy__ session as a crash. Manufactured signal, never a target bug.
+        "_internal_crash",
+    },
     "_socket": SOCKET,
     "socket": SOCKET,
     "posix": POSIX,

--- a/tests/python/test_blacklists.py
+++ b/tests/python/test_blacklists.py
@@ -35,6 +35,21 @@ class TestContainerShapes(unittest.TestCase):
 class TestKnownEntriesPresent(unittest.TestCase):
     """Pin a few high-value entries so accidental deletion is caught."""
 
+    def test_pypy_self_harming_helpers_blacklisted(self):
+        # These attack the fuzzer or the host, not the target. attach_gdb was caught live on
+        # a PyPy 3.11 fleet: it runs gdb inside the session and gdb's banner scores on the
+        # "bug" word, manufacturing a crash. remote_exec injects code into an arbitrary pid.
+        self.assertLessEqual(
+            {"attach_gdb", "remote_exec", "set_code_callback", "_internal_crash"},
+            bl.BLACKLIST["__pypy__"],
+        )
+
+    def test_pypy_blacklist_stays_narrow(self):
+        # __pypy__ is PyPy-only surface with no CPython counterpart -- the reason to fuzz PyPy
+        # at all. Only the self-harming helpers belong here, never the interesting internals.
+        for keep in ("newdict", "strategy", "internal_repr", "intop", "move_to_end"):
+            self.assertNotIn(keep, bl.BLACKLIST["__pypy__"])
+
     def test_sys_trace_hooks_blacklisted(self):
         self.assertEqual(
             bl.BLACKLIST["sys"] & {"settrace", "setprofile"}, {"settrace", "setprofile"}


### PR DESCRIPTION
Follow-up to #256, caught while validating the first PyPy 3.11 fleet config.

Five members of `__pypy__` are debug/test plumbing rather than fuzzable surface, and each
manufactures a crash that never happened:

| member | what it does | why it must go |
|---|---|---|
| `attach_gdb` | "Run an interp-level gdb" | runs gdb **inside the session**; its banner (`For bug reporting instructions...`) hits the `bug` word. Observed live as `__pypy__-bug-systemerror`. |
| `_internal_crash` | "for testing purposes, raise an interpreter-level ValueError. Should turn into a SystemError automatically" | `SystemError` is a **1.0** crash word — with `--test-private` this alone tagged **4 of 4** `__pypy__` sessions as crashes |
| `remote_exec` | "Executes a script of Python code in a given remote Python process" | fuzzer-chosen pid ⇒ arbitrary code injection into any process on the box, incl. sibling fleet instances and the fuzzer itself |
| `set_code_callback` | process-global hook on every code-object creation | hand it a fusil bomb object and the rest of the session detonates on unrelated code |
| `pyos_inputhook`, `revdb_stop` | `PyOS_InputHook()` / reverse-debugger stop | block |

This is the "generated code kills its own session" class from #192, plus one genuine host
hazard (`remote_exec`).

**Deliberately narrow.** `__pypy__` is PyPy-only surface with no CPython counterpart —
the reason to fuzz PyPy at all — so `newdict` / `strategy` / `internal_repr` / `intop` /
`move_to_end` and the rest stay fuzzable. `test_pypy_blacklist_stays_narrow` pins that
direction so a future edit can't quietly blanket the module.

## Verification

PyPy 3.11.15 / 7.3.23, `--test-private --functions-number 60`:

- before: **4/4** sessions tagged `__pypy__-systemerror`
- after: **5/5** clean, zero calls to any blacklisted member, 3.3k–4.9k lines of real
  fuzzing per session

Full suite green (1249 tests); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)