### PR TITLE
replay.py: an empty env value emitted a SyntaxError, breaking every replay script

### DIFF
--- a/fusil/process/replay_python.py
+++ b/fusil/process/replay_python.py
@@ -66,6 +66,12 @@ def formatPath(value, cwd, cwd_bytes):
         value = ""
     elif value:
         result.append(formatValue(value))
+    if not result:
+        # Nothing matched and nothing was left over, i.e. the value is empty. Joining an
+        # empty list yields "", which emits `"KEY": ,` -- a SyntaxError that makes the whole
+        # replay script unusable. fusil sets DEBUGINFOD_URLS="" in every target child, so
+        # without this every crash dir in every run got an unparseable replay.py.
+        return formatValue(value)
     return " + ".join(result)
 
 

--- a/tests/test_replay_python.py
+++ b/tests/test_replay_python.py
@@ -54,6 +54,16 @@ class TestFormatPath(unittest.TestCase):
             "b'a' + cwd_bytes + b'b'",
         )
 
+    def test_empty_str_is_a_valid_expression(self):
+        # An empty value used to make formatPath return "" -- joining an empty result list --
+        # which the env-dict emitter turned into `"KEY": ,`, a SyntaxError. fusil sets
+        # DEBUGINFOD_URLS="" in EVERY target child, so this is the common case, and it made
+        # every replay.py in every run unparseable.
+        self.assertEqual(formatPath("", "/work", b"/work"), "''")
+
+    def test_empty_bytes_is_a_valid_expression(self):
+        self.assertEqual(formatPath(b"", "/work", b"/work"), "b''")
+
     def test_no_match_returns_plain_value(self):
         self.assertEqual(formatPath("nothing", "<path>", b"<path>"), repr("nothing"))
 
@@ -214,6 +224,18 @@ class TestGlobalVariables(unittest.TestCase):
     def test_env_dict_rendered(self):
         out = self._emit(arguments=["prog"], env={"KEY": "value"})
         self.assertIn('"KEY":', out)
+
+    def test_env_dict_with_empty_value_is_parseable(self):
+        # The existing validity test's fixture env has no empty values, so it could not catch
+        # the `"KEY": ,` regression. Assert on the emitted dict directly.
+        out = self._emit(arguments=["prog"], env={"DEBUGINFOD_URLS": "", "OTHER": "x"})
+        self.assertIn("\"DEBUGINFOD_URLS\": '',", out)
+        # Exec just the env block (globalVariables also emits chdir()/limits lines).
+        block = out[out.index("env = {") : out.index("}", out.index("env = {")) + 1]
+        namespace = {"cwd": "/work"}
+        exec(compile(block, "replay.py", "exec"), namespace)
+        self.assertEqual(namespace["env"]["DEBUGINFOD_URLS"], "")
+        self.assertEqual(namespace["env"]["OTHER"], "x")
 
     def test_need_cwd_bytes_when_argument_contains_cwd(self):
         # A bytes argument containing the cwd triggers the cwd_bytes helper line.


### PR DESCRIPTION
Found while triaging a PyPy fleet — I went to run a crash dir's `replay.py` and it wouldn't parse.

## The bug

`formatPath()` builds its result by appending pieces and then joins them. For an **empty
value** nothing is ever appended, so it returns `""` and the env-dict emitter writes:

```python
env = {
    "DEBUGINFOD_URLS": ,
}
```

`SyntaxError`.

## Why it matters more than it looks

fusil sets `DEBUGINFOD_URLS=""` in **every** target child (the llvm-symbolizer workaround,
`fusil/python/__init__.py:791`), so the empty value is the common case, not an edge case.

Measured across the existing runs under `/home/fusil/runs`: **60 of 60** sampled `replay.py`
files fail to parse — apsw, OOM, TSan, PyPy alike.

`replay.py` is the primary triage artifact — the thing a human runs to reproduce a kept crash
outside the fuzzer. The failure is silent: the crash dir looks complete, and nothing surfaces
until someone actually tries to replay it, possibly long after the run.

## Tests

The existing `test_generated_script_is_valid_python` could not catch this — its fixture env
has no empty values. Added three tests to `tests/test_replay_python.py` (kept alongside the
existing 34, not replacing them), verified to fail without the fix:

- `test_empty_str_is_a_valid_expression` / `test_empty_bytes_is_a_valid_expression`
- `test_env_dict_with_empty_value_is_parseable` — execs the emitted env block

Verified end-to-end on a fresh PyPy crash dir: `replay.py` now parses and `replay.py --help`
runs. Full suite green (1252); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)