### PR TITLE
stop scoring the fuzzer's own noise as target crashes

### DIFF
--- a/fusil/python/__init__.py
+++ b/fusil/python/__init__.py
@@ -964,8 +964,13 @@ class Fuzzer(Application):
         core_ignore_regexes = (
             # The whole bomb-message family from fusil/python/samples/bomb_objects.py: any of
             # these is the injected object's own exception text, never a target crash.
+            # Keep this in sync with the raise sites: bomb_objects.py and the
+            # write_python_code.py monitoring-callback bomb. `instancecheck` (the metaclass
+            # bomb) is raised as SystemError -- a 1.0 word -- so a missing alternative here
+            # is not a cosmetic gap, it manufactures crashes: 7 such sessions were kept in a
+            # single PyPy fleet.
             r"fusil (bomb|iter bomb|superbomb|fileno bomb|hidden name|descriptor (get|set)"
-            r"|stateful hash)",
+            r"|stateful hash|instancecheck|junk return|monitoring callback bomb)",
             # The --new-uninit region prints a progress marker per poked type,
             # e.g. "[NEW-UNINIT] poking SystemError". The type name is arbitrary and
             # routinely collides with a crash word ("SystemError" -> a 1.0 hit) or, worse,

--- a/fusil/python/blacklists.py
+++ b/fusil/python/blacklists.py
@@ -143,8 +143,13 @@ BLACKLIST = {
     # Sleep
     "time": {"sleep", "pthread_getcpuclockid"},
     "select": {"epoll", "poll", "select"},
-    "signal": {"pause", "alarm", "setitimer", "pthread_kill"},
+    "signal": {"default_int_handler", "pause", "alarm", "setitimer", "pthread_kill"},
     "_signal": {
+        # Raises KeyboardInterrupt -- a BaseException, so it blows straight through the
+        # generated script's `except Exception` handlers and kills the session (the fusil
+        # #192 class). Called directly as a fuzz target it tagged 16 dirs `-sigint` in one
+        # PyPy fleet, and it also hit the rustpython fleets; it exists on every interpreter.
+        "default_int_handler",
         "pause",
         "alarm",
         "setitimer",

--- a/tests/python/test_blacklists.py
+++ b/tests/python/test_blacklists.py
@@ -35,6 +35,12 @@ class TestContainerShapes(unittest.TestCase):
 class TestKnownEntriesPresent(unittest.TestCase):
     """Pin a few high-value entries so accidental deletion is caught."""
 
+    def test_default_int_handler_blacklisted(self):
+        # It raises KeyboardInterrupt, a BaseException, which escapes the generated script's
+        # `except Exception` handlers and kills the session outright (the #192 class).
+        for module in ("signal", "_signal"):
+            self.assertIn("default_int_handler", bl.BLACKLIST[module], module)
+
     def test_pypy_self_harming_helpers_blacklisted(self):
         # These attack the fuzzer or the host, not the target. attach_gdb was caught live on
         # a PyPy 3.11 fleet: it runs gdb inside the session and gdb's banner scores on the

--- a/tests/test_file_watch.py
+++ b/tests/test_file_watch.py
@@ -245,3 +245,45 @@ class TestFileReading(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestBombSignaturesAreIgnored(unittest.TestCase):
+    """Every "fusil ..." exception the bomb objects raise must be ignored, not scored.
+
+    These are the harness's OWN hostile objects proving the target propagates exceptions --
+    never a target crash. Several are raised as SystemError, which is a 1.0 word, so a
+    signature missing from the ignore regex does not merely add noise: it manufactures
+    crashes. `instancecheck` (added with the metaclass bomb) was missing and kept 7 sessions
+    in a single PyPy fleet.
+    """
+
+    def test_ignore_regex_covers_every_raised_bomb_signature(self):
+        import pathlib
+        import re
+
+        root = pathlib.Path(__file__).resolve().parent.parent
+        # The alternation fusil/python/__init__.py installs, kept as one source of truth.
+        pattern = re.compile(
+            r"fusil (bomb|iter bomb|superbomb|fileno bomb|hidden name|descriptor (get|set)"
+            r"|stateful hash|instancecheck|junk return|monitoring callback bomb)"
+        )
+        sources = [
+            root / "fusil" / "python" / "samples" / "bomb_objects.py",
+            root / "fusil" / "python" / "write_python_code.py",
+        ]
+        raised = set()
+        for path in sources:
+            for line in path.read_text().splitlines():
+                if "raise " not in line and "return " not in line:
+                    continue
+                for match in re.findall(r'"(fusil [^"%]+)', line):
+                    raised.add(match.strip())
+        self.assertTrue(raised, "found no bomb signatures to check -- did the raise sites move?")
+        uncovered = sorted(sig for sig in raised if not pattern.search(sig))
+        self.assertEqual(
+            uncovered,
+            [],
+            "these bomb signatures are raised but not in the ignore regex in "
+            "fusil/python/__init__.py, so they will be scored as target crashes: "
+            + ", ".join(uncovered),
+        )


### PR DESCRIPTION
Two independent false-positive sources, both measured on a PyPy 3.11 stdlib fleet
(`fusil-pypy311_fleet_02`, 255 kept dirs). Together they account for **23 of 255 (9%)** —
every one a session the fuzzer killed itself.

## 1. Three bomb signatures missing from the stdout ignore regex

The regex has been extended once per bomb family, but three raise sites were added later
without it:

| signature | raised at | covered? |
|---|---|---|
| `fusil instancecheck` | `bomb_objects.py:685` (metaclass bomb) | ❌ |
| `fusil monitoring callback bomb` | `write_python_code.py:1807` | ❌ |
| `fusil junk return` | `write_python_code.py:1811` | ❌ |

`instancecheck` is raised as **SystemError — a 1.0 word**, so this isn't a cosmetic gap: it
manufactures crashes. 7 sessions kept in that one fleet.

`test_ignore_regex_covers_every_raised_bomb_signature` scrapes the raise sites and fails on
any signature the regex misses, so the next bomb family can't repeat this. Verified: with the
three alternatives removed it reports exactly those three.

## 2. `default_int_handler` kills the session

`signal.default_int_handler` / `_signal.default_int_handler` raise `KeyboardInterrupt` — a
`BaseException`, so it blows straight through the generated script's `except Exception`
handlers and takes the session with it. That's the #192 class.

Called directly as a fuzz target it tagged **16 dirs `-sigint`** in this fleet, and the
rustpython fleets show the same pattern. It exists on every interpreter, so this is not
PyPy-specific. Its neighbours (`pause`/`alarm`/`setitimer`/`pthread_kill`) were already
blacklisted for exactly this reason — this one was just missed.

Full suite green (1254); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)