### PR TITLE
blacklist _testmultiphase.call_state_registration_func (raises SystemError by design)

### DIFF
--- a/fusil/python/blacklists.py
+++ b/fusil/python/blacklists.py
@@ -183,6 +183,14 @@ BLACKLIST = {
         # EVERY __pypy__ session as a crash. Manufactured signal, never a target bug.
         "_internal_crash",
     },
+    # _testmultiphase.call_state_registration_func() exists to PROVE the error path: it calls
+    # PyState_AddModule/PyState_RemoveModule on a multi-phase-init module, which is defined to
+    # raise SystemError -- a 1.0 crash word. Identical on CPython and on PyPy's cpyext
+    # (verified both), so it is a guaranteed false positive on any interpreter; it kept 11
+    # dirs in one PyPy fleet. Only this function is blacklisted, not the module: the rest of
+    # _testmultiphase (foo/Example/Str) is real multi-phase-init surface worth fuzzing, and on
+    # PyPy it exercises the cpyext C-API emulation layer.
+    "_testmultiphase": {"call_state_registration_func"},
     "_socket": SOCKET,
     "socket": SOCKET,
     "posix": POSIX,

--- a/tests/python/test_blacklists.py
+++ b/tests/python/test_blacklists.py
@@ -35,6 +35,15 @@ class TestContainerShapes(unittest.TestCase):
 class TestKnownEntriesPresent(unittest.TestCase):
     """Pin a few high-value entries so accidental deletion is caught."""
 
+    def test_testmultiphase_state_func_blacklisted_but_module_is_not(self):
+        # It raises SystemError by design (PyState_AddModule on a module with slots) on every
+        # interpreter. Blacklist the one function, not the module -- the rest is real
+        # multi-phase-init/cpyext surface.
+        self.assertIn("call_state_registration_func", bl.BLACKLIST["_testmultiphase"])
+        self.assertNotIn("_testmultiphase", bl.MODULE_BLACKLIST)
+        for keep in ("foo", "Example", "Str"):
+            self.assertNotIn(keep, bl.BLACKLIST["_testmultiphase"])
+
     def test_default_int_handler_blacklisted(self):
         # It raises KeyboardInterrupt, a BaseException, which escapes the generated script's
         # `except Exception` handlers and kills the session outright (the #192 class).


### PR DESCRIPTION
Third noise source from the PyPy stdlib fleet triage (after #259).

`_testmultiphase.call_state_registration_func()` exists to **prove the error path**: it calls
`PyState_AddModule` / `PyState_RemoveModule` on a multi-phase-init module, which is *defined*
to raise `SystemError` — a **1.0 crash word**.

Verified identical on both interpreters:

```
CPython 3.14:  call_state_registration_func(1) -> SystemError: PyState_AddModule called on module with slots
               call_state_registration_func(2) -> SystemError: PyState_RemoveModule called on module with slots
PyPy 7.3.23:   same, via cpyext
```

So it's a guaranteed false positive anywhere, not a PyPy quirk. It kept **11 dirs** in one
fleet.

## Why the function and not the module

`_testcapi` / `_testinternalcapi` / `_testlimitedcapi` are blacklisted wholesale, but
`_testmultiphase` shouldn't be: `foo`, `Example` and `Str` are real multi-phase-init surface
worth fuzzing, and on PyPy the whole module runs through **cpyext**, the C-API emulation
layer — the most interesting target that interpreter has. Measured over the fleet, only
`call_state_registration_func` produces the SystemError; `foo` (387 calls), `Example` (216)
and `Str` (200) were all clean.

The test pins both halves: the function is blacklisted, the module is not, and the three
useful names stay fuzzable.

Full suite green (1255); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)