### PR TITLE
keep the message when repr() of a caught exception fails

### DIFF
--- a/fusil/python/write_python_code.py
+++ b/fusil/python/write_python_code.py
@@ -664,7 +664,24 @@ class WritePythonCode(WriteCode):
                 self.write(0, "try:")
                 self.write(1, "errmsg = repr(err)")
                 self.write(0, "except Exception as e_repr:")
-                self.write(1, "errmsg = f'Error during repr: {e_repr.__class__.__name__}'")
+                with self.indented():
+                    # Keep the repr-failure's MESSAGE, not just its class. PyPy surfaces an
+                    # escaped RPython-level exception as
+                    #   SystemError: unexpected internal exception (please report a bug):
+                    #                <OutOfRange object ...>
+                    # and that text is the only thing identifying WHICH internal exception
+                    # leaked. Recording the class alone turns every such hit into an
+                    # anonymous "SystemError" that cannot be told apart from any other -- a
+                    # real triage loss, seen on a _pyio session. str() can raise too, so it
+                    # is guarded in turn.
+                    self.write(0, "try:")
+                    self.write(1, "_repr_detail = str(e_repr)")
+                    self.write(0, "except Exception:")
+                    self.write(1, "_repr_detail = '<unprintable>'")
+                    self.write(
+                        0,
+                        "errmsg = f'Error during repr: {e_repr.__class__.__name__}: {_repr_detail}'",
+                    )
                 self.write(0, "errmsg = errmsg.encode('ASCII', 'replace').decode('ASCII')")
                 self.write(0, "if verbose:")
                 self.write_print_to_stderr(

--- a/tests/python/golden/fakemod_seed1234.py
+++ b/tests/python/golden/fakemod_seed1234.py
@@ -1367,7 +1367,11 @@ def callMethod(prefix, obj_to_call, method_name, *arguments, verbose=True):
         try:
             errmsg = repr(err)
         except Exception as e_repr:
-            errmsg = f'Error during repr: {e_repr.__class__.__name__}'
+            try:
+                _repr_detail = str(e_repr)
+            except Exception:
+                _repr_detail = '<unprintable>'
+            errmsg = f'Error during repr: {e_repr.__class__.__name__}: {_repr_detail}'
         errmsg = errmsg.encode('ASCII', 'replace').decode('ASCII')
         if verbose:
             print(f"[{prefix}] {func_display_name} => EXCEPTION: {err.__class__.__name__}: {errmsg}", file=stderr)

--- a/tests/python/test_write_python_code.py
+++ b/tests/python/test_write_python_code.py
@@ -623,3 +623,47 @@ class TestFaulthandlerPrelude(unittest.TestCase):
         header = self._header(no_faulthandler=True)
         self.assertNotIn("_fusil_faulthandler", header)
         self.assertIn("from gc import collect", header)
+
+
+class TestReprFailureKeepsDetail(unittest.TestCase):
+    """When repr(err) itself raises, keep the failure's MESSAGE, not just its class.
+
+    PyPy reports an escaped RPython-level exception as
+        SystemError: unexpected internal exception (please report a bug): <OutOfRange object>
+    and that text is the ONLY thing identifying which internal exception leaked. Recording
+    just the class turns every such hit into an indistinguishable "SystemError" -- which is
+    exactly what happened to a _pyio session that could then not be told apart from any other
+    SystemError.
+    """
+
+    def _emitted(self):
+        source_agent = MagicMock()
+        source_agent.options = make_test_options(no_numpy=True, no_tstrings=True)
+        module = ModuleType("reprmod")
+        module.fn = lambda *a: a
+        writer = WritePythonCode(
+            parent_python_source=source_agent,
+            filename="out.py",
+            module=module,
+            module_name="reprmod",
+            threads=False,
+            _async=False,
+        )
+        writer.output = StringIO()
+        writer._write_helper_call_functions()
+        return writer.output.getvalue()
+
+    def test_repr_failure_records_the_message(self):
+        emitted = self._emitted()
+        self.assertIn("_repr_detail", emitted)
+        self.assertIn("{e_repr.__class__.__name__}: {_repr_detail}", emitted)
+
+    def test_str_of_the_repr_failure_is_itself_guarded(self):
+        # str() can raise for the same reason repr() did.
+        emitted = self._emitted()
+        detail_at = emitted.index("_repr_detail = str(e_repr)")
+        self.assertIn("try:", emitted[:detail_at])
+        self.assertIn("'<unprintable>'", emitted[detail_at:])
+
+    def test_emitted_handler_is_valid_python(self):
+        ast.parse(self._emitted())


### PR DESCRIPTION
Found while triaging a PyPy fleet: a crash dir I could not identify, purely because of this
fallback.

## The gap

When `repr(err)` itself raises, the harness records only the class of the repr failure:

```python
except Exception as e_repr:
    errmsg = f'Error during repr: {e_repr.__class__.__name__}'
```

That message is sometimes the *only* identifying information available. PyPy surfaces an
escaped RPython-level exception as:

```
SystemError: unexpected internal exception (please report a bug): <OutOfRange object at 0x...>
```

The bracketed name is **which** internal exception leaked. Dropping it collapses every such
hit into an indistinguishable `SystemError`.

That is not hypothetical: a `_pyio` session logged exactly `EXCEPTION: ValueError: Error
during repr: SystemError` and remains unattributable. Meanwhile a sibling `zipfile` session,
whose repr *succeeded*, named `<OutOfRange object>` — enough to localize it to
`pypy_module_struct.c:_unpack` and reduce it to a five-line reproducer.

`str()` can raise for the same reason `repr()` did, so it is guarded in turn and falls back
to `'<unprintable>'`.

## Tests

Three, in `tests/python/test_write_python_code.py`: the message is included, the `str()` call
is itself guarded, and the emitted handler still parses. Full suite green (1270); ruff clean;
golden regenerated for the intentional output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)